### PR TITLE
 feat(#25) Implemented loader version extractor

### DIFF
--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/LoaderVersionExtractor.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/LoaderVersionExtractor.java
@@ -20,13 +20,11 @@ import static java.lang.Thread.currentThread;
  */
 public class LoaderVersionExtractor {
 
-    private static final Logger logger = Logger.getLogger(LoaderVersionExtractor.class.getName());
-
     public static final MavenLibrary LIBRARY_SUREFIRE_BOOTER =
         new MavenLibrary("org.apache.maven.surefire", "surefire-booter");
     public static final MavenLibrary LIBRARY_JUNIT = new MavenLibrary("junit", "junit");
     public static final MavenLibrary LIBRARY_TEST_NG = new MavenLibrary("org.testng", "testng");
-
+    private static final Logger logger = Logger.getLogger(LoaderVersionExtractor.class.getName());
     private static Map<ClassLoader, Map<MavenLibrary, String>> loaderWithLibraryVersions = new HashMap<>();
     private static List<MavenLibrary> initLibraries = new ArrayList<>();
 
@@ -50,10 +48,13 @@ public class LoaderVersionExtractor {
 
     /**
      * In the given classloader finds manifest file on a path matching the given groupId and artifactId;
-     * when it the file is matched, then it retrieves and returns a version.
+     * when the file is matched, then it retrieves and returns a version.
      *
-     * @param mavenLibrary Maven library to find
-     * @param loader The classloader the library should be in
+     * @param mavenLibrary
+     *     Maven library to find
+     * @param loader
+     *     The classloader the library should be in
+     *
      * @return Version retrieved from the matched path
      */
     public static String getVersionFromClassLoader(MavenLibrary mavenLibrary, ClassLoader loader) {
@@ -81,7 +82,9 @@ public class LoaderVersionExtractor {
                 String manifestURL = manifests.nextElement().toString();
 
                 Optional<MavenLibrary> matched =
-                    librariesToFind.parallelStream().filter(library -> manifestURL.matches(library.getRegex())).findFirst();
+                    librariesToFind.parallelStream()
+                        .filter(library -> manifestURL.matches(library.getRegex()))
+                        .findFirst();
 
                 if (matched.isPresent()) {
                     MavenLibrary matchedLibrary = matched.get();

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/LoaderVersionExtractor.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/LoaderVersionExtractor.java
@@ -1,0 +1,154 @@
+package org.arquillian.smart.testing.surefire.provider;
+
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+
+import static java.lang.Thread.currentThread;
+
+/**
+ * Loads library versions from given classloader.
+ */
+public class LoaderVersionExtractor {
+
+    private static final Logger logger = Logger.getLogger(LoaderVersionExtractor.class.getName());
+
+    public static final MavenLibrary LIBRARY_SUREFIRE_BOOTER =
+        new MavenLibrary("org.apache.maven.surefire", "surefire-booter");
+    public static final MavenLibrary LIBRARY_JUNIT = new MavenLibrary("junit", "junit");
+    public static final MavenLibrary LIBRARY_TEST_NG = new MavenLibrary("org.testng", "testng");
+
+    private static Map<ClassLoader, Map<MavenLibrary, String>> loaderWithLibraryVersions = new HashMap<>();
+    private static List<MavenLibrary> initLibraries = new ArrayList<>();
+
+    static {
+        initLibraries.add(LIBRARY_SUREFIRE_BOOTER);
+        initLibraries.add(LIBRARY_JUNIT);
+        initLibraries.add(LIBRARY_TEST_NG);
+    }
+
+    public static String getSurefireBooterVersion() {
+        return getVersionFromClassLoader(LIBRARY_SUREFIRE_BOOTER, currentThread().getContextClassLoader());
+    }
+
+    public static String getJunitVersion() {
+        return getVersionFromClassLoader(LIBRARY_JUNIT, currentThread().getContextClassLoader());
+    }
+
+    public static String getTestNgVersion() {
+        return getVersionFromClassLoader(LIBRARY_TEST_NG, currentThread().getContextClassLoader());
+    }
+
+    /**
+     * In the given classloader finds manifest file on a path matching the given groupId and artifactId;
+     * when it the file is matched, then it retrieves and returns a version.
+     *
+     * @param mavenLibrary Maven library to find
+     * @param loader The classloader the library should be in
+     * @return Version retrieved from the matched path
+     */
+    public static String getVersionFromClassLoader(MavenLibrary mavenLibrary, ClassLoader loader) {
+        if (loaderWithLibraryVersions.get(loader) != null) {
+            if (!initLibraries.contains(mavenLibrary)) {
+                List<MavenLibrary> wrappedLibrary = Arrays.asList(new MavenLibrary[] {mavenLibrary});
+                Map<MavenLibrary, String> implTitleWithVersion = getTitleWithVersion(wrappedLibrary, loader);
+                loaderWithLibraryVersions.put(loader, implTitleWithVersion);
+            }
+        } else {
+            Map<MavenLibrary, String> implTitleWithVersion = getTitleWithVersion(initLibraries, loader);
+            loaderWithLibraryVersions.put(loader, implTitleWithVersion);
+        }
+
+        return loaderWithLibraryVersions.get(loader).get(mavenLibrary);
+    }
+
+    private static Map<MavenLibrary, String> getTitleWithVersion(List<MavenLibrary> libraries, ClassLoader classLoader) {
+        Map<MavenLibrary, String> implTitleWithVersion = new HashMap<>();
+        ArrayList<MavenLibrary> librariesToFind = new ArrayList<>(libraries);
+        try {
+            Enumeration<URL> manifests = classLoader.getResources("META-INF/MANIFEST.MF");
+
+            while (manifests.hasMoreElements()) {
+                String manifestURL = manifests.nextElement().toString();
+
+                Optional<MavenLibrary> matched =
+                    librariesToFind.parallelStream().filter(library -> manifestURL.matches(library.getRegex())).findFirst();
+
+                if (matched.isPresent()) {
+                    MavenLibrary matchedLibrary = matched.get();
+                    String startWithVersion = manifestURL.replaceAll(matchedLibrary.getLeadingRegex(), "");
+                    String version = startWithVersion.substring(0, startWithVersion.indexOf(File.separator));
+                    implTitleWithVersion.put(matchedLibrary, version);
+                    librariesToFind.remove(matchedLibrary);
+                }
+            }
+        } catch (Exception e) {
+            logger.log(Level.WARNING,
+                "Exception {0} occurred while resolving manifest files",
+                e.getMessage());
+        }
+
+        return implTitleWithVersion;
+    }
+
+    static class MavenLibrary {
+        private final String groupId;
+        private final String artifactId;
+
+        MavenLibrary(String groupId, String artifactId) {
+
+            this.groupId = groupId;
+            this.artifactId = artifactId;
+        }
+
+        String getRegex() {
+            return Pattern.compile(getLeadingString()
+                + ".*"
+                + File.separator
+                + artifactId
+                + "-.*\\.jar.*").pattern();
+        }
+
+        String getLeadingRegex() {
+            return Pattern.compile(getLeadingString()).pattern();
+        }
+
+        private String getLeadingString() {
+            return ".*"
+                + File.separator
+                + groupId.replaceAll("\\.", File.separator)
+                + File.separator
+                + artifactId
+                + File.separator;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            final MavenLibrary that = (MavenLibrary) o;
+
+            if (groupId != null ? !groupId.equals(that.groupId) : that.groupId != null) return false;
+            if (artifactId != null ? !artifactId.equals(that.artifactId) : that.artifactId != null) return false;
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = groupId != null ? groupId.hashCode() : 0;
+            result = 31 * result + (artifactId != null ? artifactId.hashCode() : 0);
+            return result;
+        }
+    }
+}

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/ProviderList.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/ProviderList.java
@@ -12,9 +12,9 @@ public class ProviderList {
 
     ProviderList(ProviderParametersParser paramParser) {
         wellKnownProviders = new ProviderInfo[] {
-            new TestNgProviderInfo(paramParser),
+            new TestNgProviderInfo(),
             new JUnitCoreProviderInfo(paramParser),
-            new JUnit4ProviderInfo(paramParser)};
+            new JUnit4ProviderInfo()};
     }
 
     @SuppressWarnings("unchecked")

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/ProviderParametersParser.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/ProviderParametersParser.java
@@ -2,41 +2,19 @@ package org.arquillian.smart.testing.surefire.provider;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Pattern;
 import org.apache.maven.surefire.providerapi.ProviderParameters;
 
 import static org.arquillian.smart.testing.surefire.provider.Validate.isNotEmpty;
 
 public class ProviderParametersParser {
 
-    private static final Pattern JUNIT_PATTERN = Pattern.compile(".*/junit/junit/.*/junit-.*\\.jar");
-    private static final Pattern TEST_NG_PATTERN = Pattern.compile(".*/org/testng/testng/.*/testng-.*\\.jar");
-    private static final Pattern SUREFIRE_BOOTER_PATTERN =
-        Pattern.compile(".*/org/apache/maven/surefire/surefire-api/.*/surefire-api-.*\\.jar");
-
-    private String junitVersion;
-    private String testNgVersion;
     private List<String> includes;
     private List<String> excludes;
 
-    private String surefireApiVersion;
     private final ProviderParameters providerParameters;
 
     public ProviderParametersParser(ProviderParameters providerParameters) {
         this.providerParameters = providerParameters;
-
-        int i = 0;
-        String classpathUrl = null;
-        while (isNotEmpty(classpathUrl = getProperty("classPathUrl." + i++))) {
-
-            if (JUNIT_PATTERN.matcher(classpathUrl).matches()) {
-                junitVersion = getVersion(classpathUrl, "/junit/junit/");
-            } else if (TEST_NG_PATTERN.matcher(classpathUrl).matches()) {
-                testNgVersion = getVersion(classpathUrl, "/org/testng/testng/");
-            } else if (SUREFIRE_BOOTER_PATTERN.matcher(classpathUrl).matches()) {
-                surefireApiVersion = getVersion(classpathUrl, "org/apache/maven/surefire/surefire-api/");
-            }
-        }
     }
 
     public List<String> getIncludes() {
@@ -64,32 +42,12 @@ public class ProviderParametersParser {
         return paramList;
     }
 
-    private String getVersion(String classpathUrl, String prefix) {
-        String[] pathSplit = classpathUrl.split(prefix);
-        if (pathSplit.length == 2) {
-            return pathSplit[1].substring(0, pathSplit[1].indexOf("/"));
-        }
-        return null;
-    }
-
     public String getProperty(String key) {
         return trimMultiline(providerParameters.getProviderProperties().get(key));
     }
 
     public boolean containsProperty(String key) {
         return providerParameters.getProviderProperties().containsKey(key);
-    }
-
-    public String getJunitVersion() {
-        return junitVersion;
-    }
-
-    public String getTestNgVersion() {
-        return testNgVersion;
-    }
-
-    public String getSurefireApiVersion() {
-        return surefireApiVersion;
     }
 
     private String trimMultiline(String toTrim) {

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/info/JUnit4ProviderInfo.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/info/JUnit4ProviderInfo.java
@@ -1,14 +1,11 @@
 package org.arquillian.smart.testing.surefire.provider.info;
 
-import org.arquillian.smart.testing.surefire.provider.ProviderParametersParser;
+import org.arquillian.smart.testing.surefire.provider.LoaderVersionExtractor;
 
 public class JUnit4ProviderInfo extends JUnitProviderInfo {
 
-    private ProviderParametersParser paramParser;
-
-    public JUnit4ProviderInfo(ProviderParametersParser paramParser) {
-        super(paramParser.getJunitVersion());
-        this.paramParser = paramParser;
+    public JUnit4ProviderInfo() {
+        super(LoaderVersionExtractor.getJunitVersion());
     }
 
     public String getProviderClassName() {
@@ -16,10 +13,10 @@ public class JUnit4ProviderInfo extends JUnitProviderInfo {
     }
 
     public boolean isApplicable() {
-        return getJunitDepVersion() != null && isAnyJunit4() && paramParser.getSurefireApiVersion() != null;
+        return getJunitDepVersion() != null && isAnyJunit4() && LoaderVersionExtractor.getSurefireBooterVersion() != null;
     }
 
     public String getDepCoordinates() {
-        return "org.apache.maven.surefire:surefire-junit4:" + paramParser.getSurefireApiVersion();
+        return "org.apache.maven.surefire:surefire-junit4:" + LoaderVersionExtractor.getSurefireBooterVersion();
     }
 }

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/info/JUnitCoreProviderInfo.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/info/JUnitCoreProviderInfo.java
@@ -2,6 +2,7 @@ package org.arquillian.smart.testing.surefire.provider.info;
 
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.surefire.booter.ProviderParameterNames;
+import org.arquillian.smart.testing.surefire.provider.LoaderVersionExtractor;
 import org.arquillian.smart.testing.surefire.provider.ProviderParametersParser;
 import org.arquillian.smart.testing.surefire.provider.SurefireDependencyResolver;
 import org.arquillian.smart.testing.surefire.provider.Validate;
@@ -11,7 +12,7 @@ public class JUnitCoreProviderInfo extends JUnitProviderInfo {
     private ProviderParametersParser paramParser;
 
     public JUnitCoreProviderInfo(ProviderParametersParser paramParser) {
-        super(paramParser.getJunitVersion());
+        super(LoaderVersionExtractor.getJunitVersion());
         this.paramParser = paramParser;
     }
 
@@ -31,11 +32,11 @@ public class JUnitCoreProviderInfo extends JUnitProviderInfo {
         final boolean isJunitArtifact47 = isAnyJunit4() && isJunit47Compatible(junitDepVersion);
         final boolean isAny47ProvidersForcers = isAnyConcurrencySelected() || isAnyGroupsSelected();
         return isAny47ProvidersForcers && (isJunitArtifact47 || is47CompatibleJunitDep())
-            && paramParser.getSurefireApiVersion() != null;
+            && LoaderVersionExtractor.getSurefireBooterVersion() != null;
     }
 
     public String getDepCoordinates() {
-        return "org.apache.maven.surefire:surefire-junit47:" + paramParser.getSurefireApiVersion();
+        return "org.apache.maven.surefire:surefire-junit47:" + LoaderVersionExtractor.getSurefireBooterVersion();
     }
 
     private boolean isJunit47Compatible(ArtifactVersion artifactVersion) {

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/info/TestNgProviderInfo.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/info/TestNgProviderInfo.java
@@ -1,13 +1,11 @@
 package org.arquillian.smart.testing.surefire.provider.info;
 
-import org.arquillian.smart.testing.surefire.provider.ProviderParametersParser;
+import org.arquillian.smart.testing.surefire.provider.LoaderVersionExtractor;
 
 public class TestNgProviderInfo implements ProviderInfo {
 
-    private ProviderParametersParser paramParser;
 
-    public TestNgProviderInfo(ProviderParametersParser paramParser) {
-        this.paramParser = paramParser;
+    public TestNgProviderInfo() {
     }
 
     public String getProviderClassName() {
@@ -15,11 +13,11 @@ public class TestNgProviderInfo implements ProviderInfo {
     }
 
     public boolean isApplicable() {
-        return paramParser.getTestNgVersion() != null
-            && paramParser.getSurefireApiVersion() != null;
+        return LoaderVersionExtractor.getTestNgVersion() != null
+            && LoaderVersionExtractor.getSurefireBooterVersion() != null;
     }
 
     public String getDepCoordinates() {
-        return "org.apache.maven.surefire:surefire-testng:" + paramParser.getSurefireApiVersion();
+        return "org.apache.maven.surefire:surefire-testng:" + LoaderVersionExtractor.getSurefireBooterVersion();
     }
 }

--- a/surefire-provider/src/test/java/org/arquillian/smart/testing/surefire/provider/LoaderVersionExtractorJUnitTest.java
+++ b/surefire-provider/src/test/java/org/arquillian/smart/testing/surefire/provider/LoaderVersionExtractorJUnitTest.java
@@ -1,0 +1,49 @@
+package org.arquillian.smart.testing.surefire.provider;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.Collection;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class LoaderVersionExtractorJUnitTest {
+
+    private String junitVersion;
+
+    public LoaderVersionExtractorJUnitTest(String junitVersion) {
+        this.junitVersion = junitVersion;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<String> data() {
+        return Arrays.asList(new String[] {"4.9", "4.10", "4.11", "4.12"});
+    }
+
+    @Test
+    public void test_should_load_junit_version() throws MalformedURLException {
+        // given
+        File junitFile = Maven
+            .resolver()
+            .resolve("junit:junit:" + junitVersion)
+            .withoutTransitivity()
+            .asSingleFile();
+
+        URL[] junitUrl = {junitFile.toURI().toURL()};
+        URLClassLoader urlClassLoader = new URLClassLoader(junitUrl, (ClassLoader) null);
+
+        // when
+        String junitVersion =
+            LoaderVersionExtractor.getVersionFromClassLoader(LoaderVersionExtractor.LIBRARY_JUNIT, urlClassLoader);
+
+        // then
+        assertThat(junitVersion).isEqualTo(junitVersion);
+    }
+}

--- a/surefire-provider/src/test/java/org/arquillian/smart/testing/surefire/provider/LoaderVersionExtractorSurefireBooterTest.java
+++ b/surefire-provider/src/test/java/org/arquillian/smart/testing/surefire/provider/LoaderVersionExtractorSurefireBooterTest.java
@@ -1,0 +1,50 @@
+package org.arquillian.smart.testing.surefire.provider;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.Collection;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class LoaderVersionExtractorSurefireBooterTest {
+
+    private String surefireBooterVersion;
+
+    public LoaderVersionExtractorSurefireBooterTest(String surefireBooterVersion) {
+        this.surefireBooterVersion = surefireBooterVersion;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<String> data() {
+        return Arrays.asList(new String[] {"2.8", "2.13", "2.19.1", "2.20"});
+    }
+
+    @Test
+    public void test_should_load_surefire_booter_version() throws MalformedURLException {
+        // given
+        File junitFile = Maven
+            .resolver()
+            .resolve("org.apache.maven.surefire:surefire-booter:" + surefireBooterVersion)
+            .withoutTransitivity()
+            .asSingleFile();
+
+        URL[] junitUrl = {junitFile.toURI().toURL()};
+        URLClassLoader urlClassLoader = new URLClassLoader(junitUrl, (ClassLoader) null);
+
+        // when
+        String junitVersion =
+            LoaderVersionExtractor.getVersionFromClassLoader(LoaderVersionExtractor.LIBRARY_SUREFIRE_BOOTER,
+                urlClassLoader);
+
+        // then
+        assertThat(junitVersion).isEqualTo(surefireBooterVersion);
+    }
+}

--- a/surefire-provider/src/test/java/org/arquillian/smart/testing/surefire/provider/LoaderVersionExtractorTestNgTest.java
+++ b/surefire-provider/src/test/java/org/arquillian/smart/testing/surefire/provider/LoaderVersionExtractorTestNgTest.java
@@ -1,0 +1,49 @@
+package org.arquillian.smart.testing.surefire.provider;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.Collection;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class LoaderVersionExtractorTestNgTest {
+
+    private String testNgVersion;
+
+    public LoaderVersionExtractorTestNgTest(String testNgVersion) {
+        this.testNgVersion = testNgVersion;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<String> data() {
+        return Arrays.asList(new String[] {"6.8.8", "6.9.4", "6.9.10", "6.10", "6.11"});
+    }
+
+    @Test
+    public void test_should_load_testng_version() throws MalformedURLException {
+        // given
+        File junitFile = Maven
+            .resolver()
+            .resolve("org.testng:testng:" + testNgVersion)
+            .withoutTransitivity()
+            .asSingleFile();
+
+        URL[] junitUrl = {junitFile.toURI().toURL()};
+        URLClassLoader urlClassLoader = new URLClassLoader(junitUrl);
+
+        // when
+        String junitVersion =
+            LoaderVersionExtractor.getVersionFromClassLoader(LoaderVersionExtractor.LIBRARY_TEST_NG, urlClassLoader);
+
+        // then
+        assertThat(junitVersion).isEqualTo(testNgVersion);
+    }
+}

--- a/surefire-provider/src/test/java/org/arquillian/smart/testing/surefire/provider/ProviderParameterParserTest.java
+++ b/surefire-provider/src/test/java/org/arquillian/smart/testing/surefire/provider/ProviderParameterParserTest.java
@@ -50,7 +50,10 @@ public class ProviderParameterParserTest {
     }
 
     @Test
-    public void parser_should_return_parsed_includes(){
-        // my laptop is dying - I'll finish it later
+    public void parser_should_return_parsed_includes_and_excludes() {
+        ProviderParametersParser parametersParser = new ProviderParametersParser(providerParameters);
+        softly.assertThat(parametersParser.getIncludes())
+            .containsExactly("**/Test*.java", "**/*Test.java", "**/*TestCase.java");
+        softly.assertThat(parametersParser.getExcludes()).containsExactly("**/*$*", "**/*Failing.java");
     }
 }

--- a/surefire-provider/src/test/java/org/arquillian/smart/testing/surefire/provider/ProviderParameterParserTest.java
+++ b/surefire-provider/src/test/java/org/arquillian/smart/testing/surefire/provider/ProviderParameterParserTest.java
@@ -42,14 +42,6 @@ public class ProviderParameterParserTest {
     }
 
     @Test
-    public void parser_should_return_parsed_versions() {
-        ProviderParametersParser parametersParser = new ProviderParametersParser(providerParameters);
-        softly.assertThat(parametersParser.getSurefireApiVersion()).isEqualTo("2.19.1");
-        softly.assertThat(parametersParser.getJunitVersion()).isEqualTo("4.12");
-        softly.assertThat(parametersParser.getTestNgVersion()).isEqualTo("6.11");
-    }
-
-    @Test
     public void parser_should_return_parsed_includes_and_excludes() {
         ProviderParametersParser parametersParser = new ProviderParametersParser(providerParameters);
         softly.assertThat(parametersParser.getIncludes())


### PR DESCRIPTION
Instead of taking versions from parameter list it finds a corresponding manifest file (according to groupId and artifactId) and takes version from the path of this file.
I had also a solution that was taking versions directly from the file (manifest) but for example JUnit 4.11 doesn't contain any information about the version there. This is why I'm parsing the file path.