### PR TITLE
fix(#23) Applier checks if the returned test classes should be really run

### DIFF
--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/TestStrategyApplier.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/TestStrategyApplier.java
@@ -60,6 +60,7 @@ class TestStrategyApplier {
             final List<? extends Class<?>> tests = plannerForStrategy.getTests()
                 .stream()
                 .filter(this::presentOnClasspath)
+                .filter(this::isInTestToRun)
                 .map(testClass -> {
                     try {
                         return Class.forName(testClass);
@@ -80,5 +81,9 @@ class TestStrategyApplier {
         } catch (ClassNotFoundException e) {
             return false;
         }
+    }
+
+    private boolean isInTestToRun(String testClass) {
+        return testsToRun.getClassByName(testClass) != null;
     }
 }

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/info/TestNgProviderInfo.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/info/TestNgProviderInfo.java
@@ -12,6 +12,7 @@ public class TestNgProviderInfo implements ProviderInfo {
 
     public String getProviderClassName() {
         return "org.apache.maven.surefire.testng.TestNGProvider";
+
     }
 
     public boolean isApplicable() {

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/info/TestNgProviderInfo.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/info/TestNgProviderInfo.java
@@ -12,7 +12,6 @@ public class TestNgProviderInfo implements ProviderInfo {
 
     public String getProviderClassName() {
         return "org.apache.maven.surefire.testng.TestNGProvider";
-
     }
 
     public boolean isApplicable() {

--- a/surefire-provider/src/test/java/org/arquillian/smart/testing/surefire/provider/TestStrategyApplierTest.java
+++ b/surefire-provider/src/test/java/org/arquillian/smart/testing/surefire/provider/TestStrategyApplierTest.java
@@ -37,6 +37,7 @@ public class TestStrategyApplierTest {
 
         final Set<Class<?>> defaultTestsToRun = new HashSet<>();
         defaultTestsToRun.add(ProviderParameterParserTest.class);
+        defaultTestsToRun.add(TestExecutionPlannerLoaderTest.class);
 
         final TestsToRun testsToRun = new TestsToRun(defaultTestsToRun);
 
@@ -71,6 +72,7 @@ public class TestStrategyApplierTest {
         final Set<Class<?>> defaultTestsToRun = new LinkedHashSet<>();
         defaultTestsToRun.add(ProviderParameterParserTest.class);
         defaultTestsToRun.add(TestStrategyApplierTest.class);
+        defaultTestsToRun.add(TestExecutionPlannerLoaderTest.class);
 
         final TestsToRun testsToRun = new TestsToRun(defaultTestsToRun);
 
@@ -102,6 +104,7 @@ public class TestStrategyApplierTest {
 
         final Set<Class<?>> defaultTestsToRun = new HashSet<>();
         defaultTestsToRun.add(ProviderParameterParserTest.class);
+        defaultTestsToRun.add(TestExecutionPlannerLoaderTest.class);
 
         final TestsToRun testsToRun = new TestsToRun(defaultTestsToRun);
 


### PR DESCRIPTION
It checks if it is in the list (`TestToRun`) that was previously retrieved when the classpath was scanned. 