### PR TITLE
New strategy is looking for new files in commit range, staged area, untracked files & changed strategy is looking for modified files in the commit, staged area, modified but not staged

### DIFF
--- a/strategies/changed/src/main/java/org/arquillian/smart/testing/vcs/git/ChangedFilesDetector.java
+++ b/strategies/changed/src/main/java/org/arquillian/smart/testing/vcs/git/ChangedFilesDetector.java
@@ -1,12 +1,60 @@
 package org.arquillian.smart.testing.vcs.git;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import org.eclipse.jgit.diff.DiffEntry;
 
 public class ChangedFilesDetector extends GitChangesDetector {
 
+    private static final Logger logger = Logger.getLogger(ChangedFilesDetector.class.getName());
+
     public ChangedFilesDetector(File currentDir, String previous, String head, String... globPatterns) {
         super(currentDir, previous, head, globPatterns);
+    }
+
+    @Override
+    public Collection<String> getTests() {
+        final Collection<String> tests = super.getTests();
+
+        final Set<String> files = this.gitChangeResolver.modifiedChanges();
+        final List<String> modifiedLocalTests = files.stream()
+            .filter(this::matchPatterns)
+            .map(file -> {
+                try {
+                    final File sourceFile = new File(repoRoot, file);
+                    return extractFullyQualifiedName(sourceFile);
+                } catch (FileNotFoundException e) {
+                    throw new IllegalArgumentException(e);
+                }
+            })
+            .peek(test -> logger.log(Level.FINEST, String.format("%s test added either because modified or staged as modified file", test)))
+            .collect(Collectors.toList());
+
+        tests.addAll(modifiedLocalTests);
+
+        return tests;
+    }
+
+    @Override
+    public Set<File> getFiles() {
+
+        final Set<File> files = super.getFiles();
+        final Set<String> modifiedLocalFiles = gitChangeResolver.modifiedChanges();
+
+        files.addAll(
+            modifiedLocalFiles.stream()
+                .filter(this::matchPatterns)
+                .map(file -> new File(repoRoot, file))
+                .collect(Collectors.toSet())
+        );
+
+        return files;
     }
 
     @Override

--- a/strategies/changed/src/main/java/org/arquillian/smart/testing/vcs/git/NewFilesDetector.java
+++ b/strategies/changed/src/main/java/org/arquillian/smart/testing/vcs/git/NewFilesDetector.java
@@ -22,8 +22,8 @@ public class NewFilesDetector extends GitChangesDetector {
     public Collection<String> getTests() {
         final Collection<String> tests = super.getTests();
 
-        final Set<String> files = this.gitChangeResolver.uncommitted();
-        final List<String> notCommittedTests = files.stream()
+        final Set<String> files = this.gitChangeResolver.newChanges();
+        final List<String> newLocalTests = files.stream()
             .filter(this::matchPatterns)
             .map(file -> {
                 try {
@@ -33,10 +33,11 @@ public class NewFilesDetector extends GitChangesDetector {
                     throw new IllegalArgumentException(e);
                 }
             })
-            .peek(test -> logger.log(Level.FINEST, String.format("%s test added because not committed", test)))
+            .peek(
+                test -> logger.log(Level.FINEST, String.format("%s test added either because untracked or staged as new file", test)))
             .collect(Collectors.toList());
 
-        tests.addAll(notCommittedTests);
+        tests.addAll(newLocalTests);
 
         return tests;
     }
@@ -45,10 +46,10 @@ public class NewFilesDetector extends GitChangesDetector {
     public Set<File> getFiles() {
 
         final Set<File> files = super.getFiles();
-        final Set<String> uncommittedFiles = gitChangeResolver.uncommitted();
+        final Set<String> newLocalFiles = gitChangeResolver.newChanges();
 
         files.addAll(
-                uncommittedFiles.stream()
+                newLocalFiles.stream()
                 .filter(this::matchPatterns)
                 .map(file -> new File(repoRoot, file))
                 .collect(Collectors.toSet())

--- a/strategies/changed/src/test/java/org/arquillian/smart/testing/vcs/git/GitChangeResolverTest.java
+++ b/strategies/changed/src/test/java/org/arquillian/smart/testing/vcs/git/GitChangeResolverTest.java
@@ -62,10 +62,10 @@ public class GitChangeResolverTest {
         final GitChangeResolver gitChangeResolver = new GitChangeResolver(gitFolder.getRoot());
 
         // when
-        final Set<String> notCommitted = gitChangeResolver.uncommitted();
+        final Set<String> untrackedChanges = gitChangeResolver.newChanges();
 
         // then
-        assertThat(notCommitted).hasSize(1)
+        assertThat(untrackedChanges).hasSize(1)
             .containsExactly("untracked.txt");
     }
 
@@ -77,10 +77,10 @@ public class GitChangeResolverTest {
         GitRepositoryOperations.addFile(gitFolder.getRoot(), "newadd.txt");
 
         // when
-        final Set<String> notCommitted = gitChangeResolver.uncommitted();
+        final Set<String> newStagedChanges = gitChangeResolver.newChanges();
 
         // then
-        assertThat(notCommitted).hasSize(1)
+        assertThat(newStagedChanges).hasSize(1)
             .containsExactly("newadd.txt");
     }
 
@@ -92,10 +92,10 @@ public class GitChangeResolverTest {
         Files.write(readme, "More".getBytes(), StandardOpenOption.APPEND);
 
         // when
-        final Set<String> notCommitted = gitChangeResolver.uncommitted();
+        final Set<String> modifiedChanges = gitChangeResolver.modifiedChanges();
 
         // then
-        assertThat(notCommitted).hasSize(1)
+        assertThat(modifiedChanges).hasSize(1)
             .containsExactly("README.adoc");
     }
 

--- a/strategies/changed/src/test/java/org/arquillian/smart/testing/vcs/git/NewFilesDetectorTest.java
+++ b/strategies/changed/src/test/java/org/arquillian/smart/testing/vcs/git/NewFilesDetectorTest.java
@@ -1,5 +1,6 @@
 package org.arquillian.smart.testing.vcs.git;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -7,6 +8,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Collection;
+import org.eclipse.jgit.api.errors.GitAPIException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -43,7 +45,8 @@ public class NewFilesDetectorTest {
     public void should_find_none_new_classes_in_the_range_of_commits_when_not_matching_pattern() throws Exception {
         // given
         final NewFilesDetector
-            newFilesDetector = new NewFilesDetector(gitFolder.getRoot(), "a4261d5", "1ee4abf", "**/*IntegrationTest.java");
+            newFilesDetector =
+            new NewFilesDetector(gitFolder.getRoot(), "a4261d5", "1ee4abf", "**/*IntegrationTest.java");
 
         // when
         final Iterable<String> newTests = newFilesDetector.getTests();
@@ -53,10 +56,47 @@ public class NewFilesDetectorTest {
     }
 
     @Test
-    public void should_find_not_committed_files_as_new() throws IOException {
+    public void should_find_local_untracked_files_as_new() throws IOException {
+        //given
+        final File testFile = gitFolder.newFile("core/src/test/java/org/arquillian/smart/testing/CalculatorTest.java");
+        Files.write(testFile.toPath(), getContentsOfClass().getBytes(), StandardOpenOption.APPEND);
+
+        final NewFilesDetector
+            newFilesDetector = new NewFilesDetector(gitFolder.getRoot(), "a4261d5", "1ee4abf");
+
+        // when
+        final Collection<String> newTests = newFilesDetector.getTests();
+
+        // then
+        assertThat(newTests).containsExactly(NewFilesDetectorTest.class.getCanonicalName(),
+            "org.arquillian.smart.testing.CalculatorTest");
+    }
+
+    @Test
+    public void should_find_local_newly_staged_files_as_new() throws IOException, GitAPIException {
+        //given
+        final File testFile = gitFolder.newFile("core/src/test/java/org/arquillian/smart/testing/CalculatorTest.java");
+        Files.write(testFile.toPath(), getContentsOfClass().getBytes(), StandardOpenOption.APPEND);
+
+        GitRepositoryOperations.addFile(gitFolder.getRoot(), testFile.getAbsolutePath());
+
+        final NewFilesDetector
+            newFilesDetector = new NewFilesDetector(gitFolder.getRoot(), "a4261d5", "1ee4abf");
+
+        // when
+        final Collection<String> newTests = newFilesDetector.getTests();
+
+        // then
+        assertThat(newTests).containsExactly(NewFilesDetectorTest.class.getCanonicalName(),
+            "org.arquillian.smart.testing.CalculatorTest");
+    }
+
+    @Test
+    public void should_not_find_local_modified_file_as_new() throws IOException {
         //given
         final Path testFile =
-            Paths.get(gitFolder.getRoot().getAbsolutePath(), "core/src/test/java/org/arquillian/smart/testing/FilesTest.java");
+            Paths.get(gitFolder.getRoot().getAbsolutePath(),
+                "core/src/test/java/org/arquillian/smart/testing/FilesTest.java");
 
         Files.write(testFile, "//This is a test".getBytes(), StandardOpenOption.APPEND);
 
@@ -67,8 +107,20 @@ public class NewFilesDetectorTest {
         final Collection<String> newTests = newFilesDetector.getTests();
 
         // then
-        assertThat(newTests).containsExactly(NewFilesDetectorTest.class.getCanonicalName(), "org.arquillian.smart.testing.FilesTest");
-
+        assertThat(newTests).doesNotContain("org.arquillian.smart.testing.FilesTest");
     }
 
+    private String getContentsOfClass() {
+        return "package org.arquillian.smart.testing;\n"
+            + "\n"
+            + "import org.junit.Assert;\n"
+            + "import org.junit.Test;\n"
+            + "\n"
+            + "public class CalculatorTest {\n"
+            + "    @Test\n"
+            + "    public void should_add_numbers() {\n"
+            + "        Assert.assertEquals(6, 4 + 2);\n"
+            + "    }\n"
+            + "}";
+    }
 }


### PR DESCRIPTION
#### Short description of what this resolves:
* Now `new` strategy is only looking for new files in commit range, staged area & untracked files.
* Now `changed` strategy is only looking for modified files in the commit, staged area, modified but not staged

#### Changes proposed in this pull request:
`NewFilesDetector` will track new tests from following 
* `new file` in the commit .
* `new file` in the staged area
* untracked files

`ChangedFilesDetector` will track changed tests from following
* `modified` in the commit 
* `modified` in the staged area
* `modified` but not staged 


**Fixes**: #24 & #34
