### PR TITLE
Debug modes for Test Bed embedded build.

### DIFF
--- a/functional-tests/test-bed/pom.xml
+++ b/functional-tests/test-bed/pom.xml
@@ -49,12 +49,6 @@
       <version>${version.jgit}</version>
     </dependency>
     <dependency>
-      <groupId>org.arquillian.spacelift</groupId>
-      <artifactId>arquillian-spacelift</artifactId>
-      <version>${version.arquillian.spacelift}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/functional-tests/test-bed/pom.xml
+++ b/functional-tests/test-bed/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
-      <version>3.3.9</version>
+      <version>${version.maven}</version>
     </dependency>
   </dependencies>
 

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/Project.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/Project.java
@@ -18,7 +18,7 @@ public class Project implements AutoCloseable {
     public Project(Path root) throws IOException {
         this.root = root;
         this.repository = getRepository(root);
-        this.projectBuilder = new ProjectBuilder(root);
+        this.projectBuilder = new ProjectBuilder(root, this);
     }
 
     private Repository getRepository(Path root) throws IOException {
@@ -43,9 +43,8 @@ public class Project implements AutoCloseable {
         this.repository.close();
     }
 
-    public Project withEnvVariables(String ... envVariablesPairs) {
-        projectBuilder.withEnvVariables(envVariablesPairs);
-        return this;
+    public ProjectBuilder buildOptions() {
+        return this.projectBuilder;
     }
 
     public List<TestResult> build() {

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
@@ -121,7 +121,7 @@ public class ProjectBuilder {
         final BuiltProject build = embeddedMaven
                     .setGoals(goals)
                     .setDebug(isMavenDebugOutputEnabled())
-                    .setQuiet(!isMavenDebugOutputEnabled() && quietMode)
+                    .setQuiet(disableQuietWhenAnyDebugModeEnabled() && quietMode)
                     .skipTests(false)
                     .setProperties(systemProperties)
                     .ignoreFailure()
@@ -135,10 +135,13 @@ public class ProjectBuilder {
         return accumulatedTestResults();
     }
 
+    private boolean disableQuietWhenAnyDebugModeEnabled() {
+        return !isMavenDebugOutputEnabled() && !isSurefireRemoteDebuggingEnabled() && !isRemoteDebugEnabled();
+    }
+
     private void enableDebugOptions(PomEquippedEmbeddedMaven embeddedMaven) {
         if (isRemoteDebugEnabled()) {
             final String debugOptions = String.format(MVN_DEBUG_AGENT, shouldSuspend(), getRemotePort());
-            System.out.println(">>> Executing build with debug options: " + debugOptions);
             embeddedMaven.setMavenOpts(debugOptions);
         }
 

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
@@ -23,7 +23,8 @@ import static org.arquillian.smart.testing.ftest.testbed.testresults.SurefireRep
 public class ProjectBuilder {
 
     private static final String TEST_REPORT_PREFIX = "TEST-";
-    private static final String MVN_DEBUG_MODE = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=%s,address=%s";
+    private static final String MVN_DEBUG_AGENT = "-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=%s,address=%s";
+    private static final String SUREFIRE_DEBUG_SETTINGS = " -Xnoagent -Djava.compiler=NONE";
     private static final int DEFAULT_DEBUG_PORT = 8000;
     private static final int DEFAULT_SUREFIRE_DEBUG_PORT = 5005;
 
@@ -38,7 +39,6 @@ public class ProjectBuilder {
     private boolean suspend = true;
     private boolean mvnDebugOutput;
     private boolean enableSurefireRemoteDebugging = false;
-    private boolean surefireRemoteDebuggingEnabled;
 
     ProjectBuilder(Path root, Project project) {
         this.root = root;
@@ -79,6 +79,7 @@ public class ProjectBuilder {
     public ProjectBuilder withRemoteSurefireDebugging(int surefireRemotePort, boolean suspend) {
         this.surefireRemotePort = surefireRemotePort;
         this.suspend = suspend;
+        this.enableSurefireRemoteDebugging = true;
         return this;
     }
 
@@ -136,15 +137,14 @@ public class ProjectBuilder {
 
     private void enableDebugOptions(PomEquippedEmbeddedMaven embeddedMaven) {
         if (isRemoteDebugEnabled()) {
-            final String debugOptions = String.format(MVN_DEBUG_MODE, shouldSuspend(), getRemotePort());
+            final String debugOptions = String.format(MVN_DEBUG_AGENT, shouldSuspend(), getRemotePort());
             System.out.println(">>> Executing build with debug options: " + debugOptions);
             embeddedMaven.setMavenOpts(debugOptions);
         }
 
         if (isSurefireRemoteDebuggingEnabled()) {
             this.systemProperties.put("maven.surefire.debug",
-                String.format("Xdebug -Xrunjdwp:transport=dt_socket,server=y,"
-                    + "suspend=%s,address=%s -Xnoagent -Djava.compiler=NONE", shouldSuspend(), getSurefireDebugPort()));
+                String.format(MVN_DEBUG_AGENT, shouldSuspend(), getSurefireDebugPort()) + SUREFIRE_DEBUG_SETTINGS);
         }
     }
 

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
@@ -5,6 +5,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
@@ -12,26 +13,99 @@ import java.util.stream.Collectors;
 import org.arquillian.smart.testing.ftest.testbed.testresults.TestResult;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.BuiltProject;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.EmbeddedMaven;
+import org.jboss.shrinkwrap.resolver.api.maven.embedded.pom.equipped.PomEquippedEmbeddedMaven;
 
 import static org.arquillian.smart.testing.ftest.testbed.testresults.Status.FAILURE;
 import static org.arquillian.smart.testing.ftest.testbed.testresults.Status.PASSED;
 import static org.arquillian.smart.testing.ftest.testbed.testresults.SurefireReportReader.loadTestResults;
 
-class ProjectBuilder {
+public class ProjectBuilder {
 
     private static final String TEST_REPORT_PREFIX = "TEST-";
+    private static final String MVN_DEBUG_MODE = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=%s,address=%s";
+    private static final int DEFAULT_DEBUG_PORT = 5005;
 
     private final Path root;
+    private final Project project;
     private final Properties envVariables = new Properties();
 
-    ProjectBuilder(Path root) {
+    private int remotePort = DEFAULT_DEBUG_PORT;
+    private boolean quietMode = true;
+    private boolean enableRemoteDebugging = false;
+    private boolean suspend = true;
+    private boolean mvnDebugOutput;
+
+    ProjectBuilder(Path root, Project project) {
         this.root = root;
+        this.project = project;
+    }
+
+    public Project configure() {
+        return this.project;
+    }
+
+    /**
+     * Enables remote debugging of embedded maven build so we can troubleshoot our extension and provider
+     * By default it sets suspend to 'y', so the build will wait until we attach remote debugger to the port DEFAULT_DEBUG_PORT
+     */
+    public ProjectBuilder withRemoteDebugging() {
+        return withRemoteDebugging(DEFAULT_DEBUG_PORT, true);
+    }
+
+    public ProjectBuilder withRemoteDebugging(int port) {
+        return withRemoteDebugging(port, true);
+    }
+
+    public ProjectBuilder withRemoteDebugging(int port, boolean suspend) {
+        this.enableRemoteDebugging = true;
+        this.remotePort = port;
+        this.suspend = suspend;
+        return this;
+    }
+
+    public ProjectBuilder quiet(boolean quiet) {
+        this.quietMode = quiet;
+        return this;
+    }
+
+    /**
+     * Enables mvn debug output (-X) flag.
+     */
+    public ProjectBuilder withDebugOutput() {
+        this.mvnDebugOutput = true;
+        quiet(false);
+        return this;
+    }
+
+    public ProjectBuilder withEnvVariables(String ... envVariablesPairs) {
+        if (envVariablesPairs.length % 2 != 0) {
+            throw new IllegalArgumentException("Expecting even amount of variable name - value pairs to be passed. Got "
+                + envVariablesPairs.length
+                + " entries. "
+                + Arrays.toString(envVariablesPairs));
+        }
+
+        for (int i = 0; i < envVariablesPairs.length; i += 2) {
+            this.envVariables.put(envVariablesPairs[i], envVariablesPairs[i + 1]);
+        }
+
+        return this;
     }
 
     List<TestResult> build(String... goals) {
-        final BuiltProject build = EmbeddedMaven.forProject(root.toAbsolutePath().toString() + "/pom.xml")
+        final PomEquippedEmbeddedMaven embeddedMaven =
+            EmbeddedMaven.forProject(root.toAbsolutePath().toString() + "/pom.xml");
+
+        if (isRemoteDebugEnabled()) {
+            final String debugOptions = String.format(MVN_DEBUG_MODE, shouldSuspend(), getRemotePort());
+            System.out.println(">>> Executing build with debug options: " + debugOptions);
+            embeddedMaven.setMavenOpts(debugOptions);
+        }
+
+        final BuiltProject build = embeddedMaven
                     .setGoals(goals)
-                    .setQuiet()
+                    .setDebug(isMavenDebugOutputEnabled())
+                    .setQuiet(!isMavenDebugOutputEnabled() && quietMode)
                     .skipTests(false)
                     .setProperties(envVariables)
                     .ignoreFailure()
@@ -43,21 +117,6 @@ class ProjectBuilder {
         }
 
         return accumulatedTestResults();
-    }
-
-    ProjectBuilder withEnvVariables(String ... envVariablesPairs) {
-        if (envVariablesPairs.length % 2 != 0) {
-            throw new IllegalArgumentException("Expecting even amount of variable name - value pairs to be passed. Got "
-                + envVariablesPairs.length
-                + " entries. "
-                + envVariablesPairs);
-        }
-
-        for (int i = 0; i < envVariablesPairs.length; i += 2) {
-            this.envVariables.put(envVariablesPairs[i], envVariablesPairs[i + 1]);
-        }
-
-        return this;
     }
 
     private List<TestResult> accumulatedTestResults() {
@@ -81,5 +140,23 @@ class ProjectBuilder {
         } catch (IOException e) {
             throw new RuntimeException("Failed extracting test results", e);
         }
+    }
+
+    private boolean isRemoteDebugEnabled() {
+        return Boolean.valueOf(System.getProperty("test.bed.mvn.remote.debug", Boolean.toString(this.enableRemoteDebugging)));
+    }
+
+    private String shouldSuspend() {
+        final Boolean suspend =
+            Boolean.valueOf(System.getProperty("test.bed.mvn.remote.debug.suspend", Boolean.toString(this.suspend)));
+        return suspend ? "y" : "n";
+    }
+
+    int getRemotePort() {
+        return Integer.valueOf(System.getProperty("test.bed.mvn.remote.debug.port", Integer.toString(this.remotePort)));
+    }
+
+    boolean isMavenDebugOutputEnabled() {
+        return Boolean.valueOf(System.getProperty("test.bed.mvn.debug.output", Boolean.toString(this.mvnDebugOutput)));
     }
 }

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
@@ -27,7 +27,7 @@ public class ProjectBuilder {
 
     private final Path root;
     private final Project project;
-    private final Properties envVariables = new Properties();
+    private final Properties systemProperties = new Properties();
 
     private int remotePort = DEFAULT_DEBUG_PORT;
     private boolean quietMode = true;
@@ -77,16 +77,16 @@ public class ProjectBuilder {
         return this;
     }
 
-    public ProjectBuilder withEnvVariables(String ... envVariablesPairs) {
-        if (envVariablesPairs.length % 2 != 0) {
+    public ProjectBuilder withSystemProperties(String ... systemPropertiesPairs) {
+        if (systemPropertiesPairs.length % 2 != 0) {
             throw new IllegalArgumentException("Expecting even amount of variable name - value pairs to be passed. Got "
-                + envVariablesPairs.length
+                + systemPropertiesPairs.length
                 + " entries. "
-                + Arrays.toString(envVariablesPairs));
+                + Arrays.toString(systemPropertiesPairs));
         }
 
-        for (int i = 0; i < envVariablesPairs.length; i += 2) {
-            this.envVariables.put(envVariablesPairs[i], envVariablesPairs[i + 1]);
+        for (int i = 0; i < systemPropertiesPairs.length; i += 2) {
+            this.systemProperties.put(systemPropertiesPairs[i], systemPropertiesPairs[i + 1]);
         }
 
         return this;
@@ -107,7 +107,7 @@ public class ProjectBuilder {
                     .setDebug(isMavenDebugOutputEnabled())
                     .setQuiet(!isMavenDebugOutputEnabled() && quietMode)
                     .skipTests(false)
-                    .setProperties(envVariables)
+                    .setProperties(systemProperties)
                     .ignoreFailure()
                 .build();
 

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/TestBedTemplate.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/TestBedTemplate.java
@@ -49,7 +49,6 @@ public abstract class TestBedTemplate {
     @BeforeClass
     public static void cloneTestProject() throws IOException {
         TMP_FOLDER.create();
-        System.out.println(REPO_NAME);
         GIT_REPO_FOLDER = TMP_FOLDER.getRoot().getAbsolutePath() + File.separator + REPO_NAME;
         cloneRepository(GIT_REPO_FOLDER, ORIGIN);
     }
@@ -74,6 +73,7 @@ public abstract class TestBedTemplate {
         for (int i = 0; i < sources.size(); i++) {
             Files.copy(sources.get(i), targets.get(i));
         }
+        System.out.println("Cloned test repository to: " + target);
         return target;
     }
 

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/TestBedTemplate.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/TestBedTemplate.java
@@ -7,9 +7,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import org.arquillian.smart.testing.ftest.testbed.project.Project;
-import org.arquillian.spacelift.Spacelift;
-import org.arquillian.spacelift.process.CommandBuilder;
-import org.arquillian.spacelift.task.os.CommandTool;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -47,7 +46,7 @@ public abstract class TestBedTemplate {
     protected Project project;
 
     @BeforeClass
-    public static void cloneTestProject() throws IOException {
+    public static void cloneTestProject() throws Exception {
         TMP_FOLDER.create();
         GIT_REPO_FOLDER = TMP_FOLDER.getRoot().getAbsolutePath() + File.separator + REPO_NAME;
         cloneRepository(GIT_REPO_FOLDER, ORIGIN);
@@ -81,11 +80,14 @@ public abstract class TestBedTemplate {
         return GIT_REPO_FOLDER + "_" + getClass().getSimpleName() + "_" + name.getMethodName();
     }
 
-    static void cloneRepository(String repoTarget, String repo) {
-        Spacelift.task(CommandTool.class)
-            .command(new CommandBuilder("git")
-                .parameters("clone", repo, "-b", "master",
-                    repoTarget).build())
-            .execute().await();
+    static void cloneRepository(String repoTarget, String repo) throws GitAPIException {
+        Git.cloneRepository()
+                .setURI(repo)
+                .setDirectory(new File(repoTarget))
+                .setCloneAllBranches(true)
+            .call()
+                .checkout()
+                    .setName("master")
+            .call();
     }
 }

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/affected/HistoricalChangesAffectedTestsSelectionExecutionFunctionalTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/affected/HistoricalChangesAffectedTestsSelectionExecutionFunctionalTest.java
@@ -23,7 +23,11 @@ public class HistoricalChangesAffectedTestsSelectionExecutionFunctionalTest exte
             .applyAsCommits("Single method body modification - sysout");
 
         // when
-        final List<TestResult> actualTestResults = project.withEnvVariables("git.commit", "HEAD", "git.previous.commit", "HEAD~").build();
+        final List<TestResult> actualTestResults = project
+            .buildOptions()
+                .withEnvVariables("git.commit", "HEAD", "git.previous.commit", "HEAD~")
+                .configure()
+            .build();
 
         // then
         assertThat(actualTestResults).containsAll(expectedTestResults).hasSameSizeAs(expectedTestResults);
@@ -43,7 +47,9 @@ public class HistoricalChangesAffectedTestsSelectionExecutionFunctionalTest exte
 
         // when
         final List<TestResult> actualTestResults = project
-            .withEnvVariables("git.last.commits", "2")
+            .buildOptions()
+                .withEnvVariables("git.last.commits", "2")
+                .configure()
             .build();
 
         // then

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/affected/HistoricalChangesAffectedTestsSelectionExecutionFunctionalTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/affected/HistoricalChangesAffectedTestsSelectionExecutionFunctionalTest.java
@@ -25,7 +25,7 @@ public class HistoricalChangesAffectedTestsSelectionExecutionFunctionalTest exte
         // when
         final List<TestResult> actualTestResults = project
             .buildOptions()
-                .withEnvVariables("git.commit", "HEAD", "git.previous.commit", "HEAD~")
+                .withSystemProperties("git.commit", "HEAD", "git.previous.commit", "HEAD~")
                 .configure()
             .build();
 
@@ -48,7 +48,7 @@ public class HistoricalChangesAffectedTestsSelectionExecutionFunctionalTest exte
         // when
         final List<TestResult> actualTestResults = project
             .buildOptions()
-                .withEnvVariables("git.last.commits", "2")
+                .withSystemProperties("git.last.commits", "2")
                 .configure()
             .build();
 

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/newtests/HistoricalChangesNewTestsSelectionExecutionFunctionalTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/newtests/HistoricalChangesNewTestsSelectionExecutionFunctionalTest.java
@@ -25,7 +25,7 @@ public class HistoricalChangesNewTestsSelectionExecutionFunctionalTest extends T
         // when
         final List<TestResult> actualTestResults = project
             .buildOptions()
-                .withEnvVariables("git.commit", "HEAD", "git.previous.commit", "HEAD~")
+                .withSystemProperties("git.commit", "HEAD", "git.previous.commit", "HEAD~")
                 .configure()
             .build();
 
@@ -52,7 +52,7 @@ public class HistoricalChangesNewTestsSelectionExecutionFunctionalTest extends T
         // when
         final List<TestResult> actualTestResults = project
             .buildOptions()
-                .withEnvVariables("git.last.commits", "3")
+                .withSystemProperties("git.last.commits", "3")
                 .configure()
             .build();
 

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/newtests/HistoricalChangesNewTestsSelectionExecutionFunctionalTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/newtests/HistoricalChangesNewTestsSelectionExecutionFunctionalTest.java
@@ -23,7 +23,11 @@ public class HistoricalChangesNewTestsSelectionExecutionFunctionalTest extends T
             .applyAsCommits("Adds new unit test");
 
         // when
-        final List<TestResult> actualTestResults = project.withEnvVariables("git.commit", "HEAD", "git.previous.commit", "HEAD~").build();
+        final List<TestResult> actualTestResults = project
+            .buildOptions()
+                .withEnvVariables("git.commit", "HEAD", "git.previous.commit", "HEAD~")
+                .configure()
+            .build();
 
         // then
         assertThat(actualTestResults).containsAll(expectedTestResults).hasSameSizeAs(expectedTestResults);
@@ -47,7 +51,9 @@ public class HistoricalChangesNewTestsSelectionExecutionFunctionalTest extends T
 
         // when
         final List<TestResult> actualTestResults = project
-            .withEnvVariables("git.last.commits", "3")
+            .buildOptions()
+                .withEnvVariables("git.last.commits", "3")
+                .configure()
             .build();
 
         // then


### PR DESCRIPTION
### Overview

This feature brings the ability to execute embedded build in Test Bed in the debug mode. This gives is better analysis of the build execution, as it lets us connect to the build execution to analyze behaviour of our extension in the runtime,

### Features

Enhanced project configuration DSL for enabling debug mode directly in the code:

```java
final List<TestResult> actualTestResults = project
    .buildOptions()
        .withRemoteDebugging()
        .withRemoteSurefireDebugging()
        .withDebugOutput()
        .configure()
    .build();
```

Setting up any of the debugging modes would set agent in suspend mode for both maven execution and surefire execution, thus giving you time to attach debuggers to both.

But this can be also achieved through system properties which you can set as part of your "Run Configuration" in the IDE. Following system properties are available:

  * `test.bed.mvn.remote.debug` - enables remote debugging of the embedded maven build with `suspend` set to `y` (so the build will wait until we attach remote debugger to the port) and port `8000` to listen.
  * `test.bed.mvn.remote.debug.suspend` - `true` or `false` (both for maven and surefire)
  * `test.bed.mvn.remote.debug.port` - valid port used for remote debugging of maven execution
  * `test.bed.mvn.surefire.remote.debug` - enables [remote debugging for surefire](http://maven.apache.org/surefire/maven-surefire-plugin/examples/debugging.html) 
  * `test.bed.mvn.surefire.remote.debug.port` - valid port used for remoting debugging of surefire execution
  * `test.bed.mvn.debug.output` - `true` or `false` - sets `-X` flag for embedded maven build for more details build log.

**NOTE**: if both system property and the programmatic option is used system property takes precedence.