### PR TITLE
Travis and Test Bed enhacement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,12 @@ jdk:
   - oraclejdk8
 
 before_script:
-  - wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz -P ~/.arquillian/resolver/maven/download
-  - tar -xf ~/.arquillian/resolver/maven/download/apache-maven-3.3.9-bin.tar.gz -C ~/.arquillian/resolver/maven/
+  - mkdir -p /home/travis/.arquillian/mvn
+  - wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz -P /home/travis/.arquillian/resolver/maven/download
+  - tar -xf /home/travis/.arquillian/resolver/maven/download/apache-maven-3.3.9-bin.tar.gz -C ~/.arquillian/mvn
+
+env:
+  - TEST_BED_M2_HOME=/home/travis/.arquillian/mvn/apache-maven-3.3.9
 
 script:
   - ./mvnw clean verify -P travis -DJAVA_OPTS="-XX:-UseLoopPredicate"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ jdk:
   - oraclejdk8
 
 before_script:
-  - wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz -P ~/.arquillian/resolver/maven/
+  - wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz -P ~/.arquillian/resolver/maven/download
+  - tar -xf ~/.arquillian/resolver/maven/download/apache-maven-3.3.9-bin.tar.gz -C ~/.arquillian/resolver/maven/
 
 script:
   - ./mvnw clean verify -P travis -DJAVA_OPTS="-XX:-UseLoopPredicate"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
   - oraclejdk8
 
 before_script:
-  - wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz -P ~/.arquillian/resolver/maven/apache-maven-3.3.9-bin.tar.gz
+  - wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz -P ~/.arquillian/resolver/maven/
 
 script:
   - ./mvnw clean verify -P travis -DJAVA_OPTS="-XX:-UseLoopPredicate"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,8 @@ language: java
 jdk:
   - oraclejdk8
 
+before_script:
+  - wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz -P ~/.arquillian/resolver/maven/apache-maven-3.3.9-bin.tar.gz
+
 script:
   - ./mvnw clean verify -P travis -DJAVA_OPTS="-XX:-UseLoopPredicate"

--- a/functional-tests/test-bed/pom.xml
+++ b/functional-tests/test-bed/pom.xml
@@ -70,7 +70,7 @@
           <forkCount>${surefire.fork.count}</forkCount>
           <threadCount>${surefire.thread.count}</threadCount>
           <reuseForks>true</reuseForks>
-          <argLine>-Xmx1024m</argLine>
+          <argLine>-Xmx2048m</argLine>
           <parallel>classesAndMethods</parallel>
         </configuration>
 

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
@@ -1,5 +1,6 @@
 package org.arquillian.smart.testing.ftest.testbed.project;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -134,7 +135,7 @@ public class ProjectBuilder {
         enableDebugOptions(embeddedMaven);
 
         final BuiltProject build = embeddedMaven
-                    .useMaven3Version("3.3.9")
+                    .useInstallation(new File("~/.arquillian/resolver/maven/"))
                     .setShowVersion(true)
                     .setGoals(goals)
                     .setDebug(isMavenDebugOutputEnabled())

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
@@ -134,8 +134,12 @@ public class ProjectBuilder {
 
         enableDebugOptions(embeddedMaven);
 
+        final String mvnInstallation = System.getenv("TEST_BED_M2_HOME");
+        if (mvnInstallation != null) {
+            embeddedMaven.useInstallation(new File(mvnInstallation));
+        }
+
         final BuiltProject build = embeddedMaven
-                    .useInstallation(new File("~/.arquillian/resolver/maven/"))
                     .setShowVersion(true)
                     .setGoals(goals)
                     .setDebug(isMavenDebugOutputEnabled())

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
@@ -41,6 +41,8 @@ public class ProjectBuilder {
     private boolean enableSurefireRemoteDebugging = false;
 
     ProjectBuilder(Path root, Project project) {
+        systemProperties.put("surefire.exitTimeout", "-1"); // see http://bit.ly/2vARQ5p
+        systemProperties.put("surefire.timeout", "0"); // see http://bit.ly/2u7xCAH
         this.root = root;
         this.project = project;
     }
@@ -137,6 +139,7 @@ public class ProjectBuilder {
                     .setQuiet(disableQuietWhenAnyDebugModeEnabled() && quietMode)
                     .skipTests(false)
                     .setProperties(systemProperties)
+                    .setMavenOpts("-Xms512m -Xmx1024m")
                     .ignoreFailure()
                 .build();
 

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
@@ -134,6 +134,8 @@ public class ProjectBuilder {
         enableDebugOptions(embeddedMaven);
 
         final BuiltProject build = embeddedMaven
+                    .useMaven3Version("3.3.9")
+                    .setShowVersion(true)
                     .setGoals(goals)
                     .setDebug(isMavenDebugOutputEnabled())
                     .setQuiet(disableQuietWhenAnyDebugModeEnabled() && quietMode)


### PR DESCRIPTION
Introduces ability to specify arbitrary Maven distribution to run embedded mvn builds through environment variable `TEST_BED_M2_HOME`.

Tried other attempts, but these were leading to errors, as explained below.

### Explictly setting mvn version for embedded Maven

`embeddedMaven.useMaven3Version("3.3.9")` leads to error on Travis:

```
should_only_execute_tests_related_to_single_local_change_in_production_code_when_affected_is_enabled(org.arquillian.smart.testing.ftest.affected.LocalChangesAffectedTestsSelectionExecutionFunctionalTest)  Time elapsed: 2.522 sec  <<< ERROR!
java.lang.IllegalStateException: Something bad happened when the file: /home/travis/.arquillian/resolver/maven/apache-maven-3.3.9-bin.tar.gz was being extracted. For more information see the stacktrace
```

### Above but with downloaded distribution

```
Caused by: org.apache.maven.shared.invoker.MavenInvocationException: Error configuring command-line. Reason: Maven executable not found at: /home/travis/build/arquillian/smart-testing/functional-tests/test-bed/target/resolver-maven/516923b3955b6035ba6b0a5b031fbd8b/apache-maven-3.3.9/bin/mvn
```

probably due to mvn embedded build not being thread-safe.