### PR TITLE
issue #62 When TestNG provider is used, then non-positive threadcount param is removed

### DIFF
--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/ProviderParametersParser.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/ProviderParametersParser.java
@@ -65,4 +65,8 @@ public class ProviderParametersParser {
         }
         return builder.toString().trim();
     }
+
+    public ProviderParameters getProviderParameters() {
+        return providerParameters;
+    }
 }

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/SmartTestingSurefireProvider.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/SmartTestingSurefireProvider.java
@@ -3,7 +3,6 @@ package org.arquillian.smart.testing.surefire.provider;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.ServiceLoader;
 import org.apache.maven.surefire.providerapi.ProviderParameters;
 import org.apache.maven.surefire.providerapi.SurefireProvider;
 import org.apache.maven.surefire.report.ReporterException;
@@ -16,14 +15,14 @@ public class SmartTestingSurefireProvider implements SurefireProvider {
 
     private SurefireProvider surefireProvider;
     private ProviderParametersParser paramParser;
-    private Class<SurefireProvider> providerClass;
+    private SurefireProviderFactory surefireProviderFactory;
     private ProviderParameters bootParams;
 
     public SmartTestingSurefireProvider(ProviderParameters bootParams) {
         this.bootParams = bootParams;
         this.paramParser = new ProviderParametersParser(this.bootParams);
-        this.providerClass = new ProviderList(this.paramParser).resolve();
-        this.surefireProvider = createSurefireProviderInstance();
+        this.surefireProviderFactory = new SurefireProviderFactory(this.paramParser);
+        this.surefireProvider = surefireProviderFactory.createInstance();
     }
 
     private TestsToRun getTestsToRun() {
@@ -54,12 +53,8 @@ public class SmartTestingSurefireProvider implements SurefireProvider {
     public RunResult invoke(Object forkTestSet)
         throws TestSetFailedException, ReporterException, InvocationTargetException {
         TestsToRun orderedTests = getTestsToRun();
-        surefireProvider = createSurefireProviderInstance();
+        surefireProvider = surefireProviderFactory.createInstance();
         return surefireProvider.invoke(orderedTests);
-    }
-
-    private SurefireProvider createSurefireProviderInstance(){
-        return SecurityUtils.newInstance(providerClass, new Class[] {ProviderParameters.class}, new Object[] {bootParams});
     }
 
     public void cancel() {

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/info/JUnitProviderInfo.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/info/JUnitProviderInfo.java
@@ -2,6 +2,7 @@ package org.arquillian.smart.testing.surefire.provider.info;
 
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.surefire.providerapi.ProviderParameters;
 import org.arquillian.smart.testing.surefire.provider.SurefireDependencyResolver;
 
 abstract class JUnitProviderInfo implements ProviderInfo {
@@ -22,4 +23,8 @@ abstract class JUnitProviderInfo implements ProviderInfo {
         return junitDepVersion;
     }
 
+    @Override
+    public ProviderParameters convertProviderParameters(ProviderParameters providerParameters) {
+        return providerParameters;
+    }
 }

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/info/ProviderInfo.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/info/ProviderInfo.java
@@ -19,6 +19,8 @@ package org.arquillian.smart.testing.surefire.provider.info;
  * under the License.
  */
 
+import org.apache.maven.surefire.providerapi.ProviderParameters;
+
 public interface ProviderInfo {
 
     String getProviderClassName();
@@ -26,4 +28,6 @@ public interface ProviderInfo {
     boolean isApplicable();
 
     String getDepCoordinates();
+
+    ProviderParameters convertProviderParameters(ProviderParameters providerParameters);
 }

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/info/TestFramework.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/info/TestFramework.java
@@ -1,6 +1,0 @@
-package org.arquillian.smart.testing.surefire.provider.info;
-
-public enum TestFramework {
-
-    TESTNG, JUNIT;
-}

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/info/TestFramework.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/info/TestFramework.java
@@ -1,0 +1,6 @@
+package org.arquillian.smart.testing.surefire.provider.info;
+
+public enum TestFramework {
+
+    TESTNG, JUNIT;
+}

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/info/TestNgProviderInfo.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/info/TestNgProviderInfo.java
@@ -1,6 +1,10 @@
 package org.arquillian.smart.testing.surefire.provider.info;
 
+import org.apache.commons.lang.StringUtils;
+import org.apache.maven.surefire.providerapi.ProviderParameters;
 import org.arquillian.smart.testing.surefire.provider.LoaderVersionExtractor;
+
+import static org.apache.maven.surefire.booter.ProviderParameterNames.THREADCOUNT_PROP;
 
 public class TestNgProviderInfo implements ProviderInfo {
 
@@ -19,5 +23,16 @@ public class TestNgProviderInfo implements ProviderInfo {
 
     public String getDepCoordinates() {
         return "org.apache.maven.surefire:surefire-testng:" + LoaderVersionExtractor.getSurefireBooterVersion();
+    }
+
+    @Override
+    public ProviderParameters convertProviderParameters(ProviderParameters providerParameters) {
+        // remove threadcount property where the value is lower than 1 or is not numeric
+        // workaround for https://issues.apache.org/jira/browse/SUREFIRE-1398
+        String threadCount = providerParameters.getProviderProperties().get(THREADCOUNT_PROP);
+        if (!StringUtils.isNumeric(threadCount) || Integer.parseInt(threadCount) < 1){
+            providerParameters.getProviderProperties().remove(THREADCOUNT_PROP);
+        }
+        return providerParameters;
     }
 }

--- a/surefire-provider/src/test/java/org/arquillian/smart/testing/surefire/provider/TestNgParametersTest.java
+++ b/surefire-provider/src/test/java/org/arquillian/smart/testing/surefire/provider/TestNgParametersTest.java
@@ -1,0 +1,54 @@
+package org.arquillian.smart.testing.surefire.provider;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.maven.surefire.providerapi.ProviderParameters;
+import org.arquillian.smart.testing.surefire.provider.info.TestNgProviderInfo;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.apache.maven.surefire.booter.ProviderParameterNames.PARALLEL_PROP;
+import static org.apache.maven.surefire.booter.ProviderParameterNames.THREADCOUNT_PROP;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public class TestNgParametersTest {
+
+    @Test
+    public void should_remove_zero_thread_count() {
+        // given
+        ProviderParameters providerParameters = prepareProviderParams("0");
+
+        // when
+        TestNgProviderInfo testNgProviderInfo = new TestNgProviderInfo();
+        ProviderParameters convertedProviderParams = testNgProviderInfo.convertProviderParameters(providerParameters);
+
+        // then
+        assertThat(convertedProviderParams.getProviderProperties()).hasSize(1).doesNotContainKeys(THREADCOUNT_PROP);
+    }
+
+    @Test
+    public void should_not_remove_positive_thread_count() {
+        // given
+        ProviderParameters providerParameters = prepareProviderParams("1");
+
+        // when
+        TestNgProviderInfo testNgProviderInfo = new TestNgProviderInfo();
+        ProviderParameters convertedProviderParams = testNgProviderInfo.convertProviderParameters(providerParameters);
+
+        // then
+        assertThat(convertedProviderParams.getProviderProperties()).hasSize(2).containsKeys(THREADCOUNT_PROP);
+    }
+
+
+    private ProviderParameters prepareProviderParams(String threadCount){
+        Map<String, String> providerProperties = new HashMap<>();
+        providerProperties.put(PARALLEL_PROP, "none");
+        providerProperties.put(THREADCOUNT_PROP, threadCount);
+
+        ProviderParameters providerParameters = Mockito.mock(ProviderParameters.class);
+        when(providerParameters.getProviderProperties()).thenReturn(providerProperties);
+
+        return providerParameters;
+    }
+}


### PR DESCRIPTION
When TestNG provider is used, then if the threadcount value is lower than 1 then the param is removed. Having the method `convertProviderParameters` opens possibilities for other future changes/workarounds.

Part of this commit is also a change from ProviderList to SurefireProviderFactory to keep related logic in one place

