### PR TITLE
fix(classloader) For loading provider class it uses context classloader of the current thread

### DIFF
--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/SurefireDependencyResolver.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/SurefireDependencyResolver.java
@@ -35,7 +35,7 @@ public class SurefireDependencyResolver {
     public static ClassLoader addProviderToClasspath(ProviderInfo providerInfo) {
         if (providerInfo != null) {
             File[] files = resolve(providerInfo);
-            ClassLoader classLoader = ClassLoader.getSystemClassLoader();
+            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
             try {
                 return new URLClassLoader(toURLs(files), classLoader);
             } catch (Exception e) {


### PR DESCRIPTION
in the same way, it is done in Surefire when an instance of the provider is created. 
Otherwise. it would fail with 
`NoClassDefFoundError: org/junit/runner/notification/RunNotifier`
as it cannot find the necessary JUnit jar.