### PR TITLE
fix(surefire version) gets the version from manifest file of surefire-api jar

### DIFF
--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/LoaderVersionExtractor.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/LoaderVersionExtractor.java
@@ -20,8 +20,8 @@ import static java.lang.Thread.currentThread;
  */
 public class LoaderVersionExtractor {
 
-    public static final MavenLibrary LIBRARY_SUREFIRE_BOOTER =
-        new MavenLibrary("org.apache.maven.surefire", "surefire-booter");
+    public static final MavenLibrary LIBRARY_SUREFIRE_API =
+        new MavenLibrary("org.apache.maven.surefire", "surefire-api");
     public static final MavenLibrary LIBRARY_JUNIT = new MavenLibrary("junit", "junit");
     public static final MavenLibrary LIBRARY_TEST_NG = new MavenLibrary("org.testng", "testng");
     private static final Logger logger = Logger.getLogger(LoaderVersionExtractor.class);
@@ -29,13 +29,13 @@ public class LoaderVersionExtractor {
     private static List<MavenLibrary> initLibraries = new ArrayList<>();
 
     static {
-        initLibraries.add(LIBRARY_SUREFIRE_BOOTER);
+        initLibraries.add(LIBRARY_SUREFIRE_API);
         initLibraries.add(LIBRARY_JUNIT);
         initLibraries.add(LIBRARY_TEST_NG);
     }
 
-    public static String getSurefireBooterVersion() {
-        return getVersionFromClassLoader(LIBRARY_SUREFIRE_BOOTER, currentThread().getContextClassLoader());
+    public static String getSurefireApiVersion() {
+        return getVersionFromClassLoader(LIBRARY_SUREFIRE_API, currentThread().getContextClassLoader());
     }
 
     public static String getJunitVersion() {

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/info/JUnit4ProviderInfo.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/info/JUnit4ProviderInfo.java
@@ -13,10 +13,10 @@ public class JUnit4ProviderInfo extends JUnitProviderInfo {
     }
 
     public boolean isApplicable() {
-        return getJunitDepVersion() != null && isAnyJunit4() && LoaderVersionExtractor.getSurefireBooterVersion() != null;
+        return getJunitDepVersion() != null && isAnyJunit4() && LoaderVersionExtractor.getSurefireApiVersion() != null;
     }
 
     public String getDepCoordinates() {
-        return "org.apache.maven.surefire:surefire-junit4:" + LoaderVersionExtractor.getSurefireBooterVersion();
+        return "org.apache.maven.surefire:surefire-junit4:" + LoaderVersionExtractor.getSurefireApiVersion();
     }
 }

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/info/JUnitCoreProviderInfo.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/info/JUnitCoreProviderInfo.java
@@ -32,11 +32,11 @@ public class JUnitCoreProviderInfo extends JUnitProviderInfo {
         final boolean isJunitArtifact47 = isAnyJunit4() && isJunit47Compatible(junitDepVersion);
         final boolean isAny47ProvidersForcers = isAnyConcurrencySelected() || isAnyGroupsSelected();
         return isAny47ProvidersForcers && (isJunitArtifact47 || is47CompatibleJunitDep())
-            && LoaderVersionExtractor.getSurefireBooterVersion() != null;
+            && LoaderVersionExtractor.getSurefireApiVersion() != null;
     }
 
     public String getDepCoordinates() {
-        return "org.apache.maven.surefire:surefire-junit47:" + LoaderVersionExtractor.getSurefireBooterVersion();
+        return "org.apache.maven.surefire:surefire-junit47:" + LoaderVersionExtractor.getSurefireApiVersion();
     }
 
     private boolean isJunit47Compatible(ArtifactVersion artifactVersion) {

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/info/TestNgProviderInfo.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/info/TestNgProviderInfo.java
@@ -18,11 +18,11 @@ public class TestNgProviderInfo implements ProviderInfo {
 
     public boolean isApplicable() {
         return LoaderVersionExtractor.getTestNgVersion() != null
-            && LoaderVersionExtractor.getSurefireBooterVersion() != null;
+            && LoaderVersionExtractor.getSurefireApiVersion() != null;
     }
 
     public String getDepCoordinates() {
-        return "org.apache.maven.surefire:surefire-testng:" + LoaderVersionExtractor.getSurefireBooterVersion();
+        return "org.apache.maven.surefire:surefire-testng:" + LoaderVersionExtractor.getSurefireApiVersion();
     }
 
     @Override

--- a/surefire-provider/src/test/java/org/arquillian/smart/testing/surefire/provider/LoaderVersionExtractorSurefireApiTest.java
+++ b/surefire-provider/src/test/java/org/arquillian/smart/testing/surefire/provider/LoaderVersionExtractorSurefireApiTest.java
@@ -14,11 +14,11 @@ import org.junit.runners.Parameterized;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Parameterized.class)
-public class LoaderVersionExtractorSurefireBooterTest {
+public class LoaderVersionExtractorSurefireApiTest {
 
     private String surefireBooterVersion;
 
-    public LoaderVersionExtractorSurefireBooterTest(String surefireBooterVersion) {
+    public LoaderVersionExtractorSurefireApiTest(String surefireBooterVersion) {
         this.surefireBooterVersion = surefireBooterVersion;
     }
 
@@ -28,11 +28,11 @@ public class LoaderVersionExtractorSurefireBooterTest {
     }
 
     @Test
-    public void test_should_load_surefire_booter_version() throws MalformedURLException {
+    public void test_should_load_surefire_api_version() throws MalformedURLException {
         // given
         File junitFile = Maven
             .resolver()
-            .resolve("org.apache.maven.surefire:surefire-booter:" + surefireBooterVersion)
+            .resolve("org.apache.maven.surefire:surefire-api:" + surefireBooterVersion)
             .withoutTransitivity()
             .asSingleFile();
 
@@ -41,7 +41,7 @@ public class LoaderVersionExtractorSurefireBooterTest {
 
         // when
         String junitVersion =
-            LoaderVersionExtractor.getVersionFromClassLoader(LoaderVersionExtractor.LIBRARY_SUREFIRE_BOOTER,
+            LoaderVersionExtractor.getVersionFromClassLoader(LoaderVersionExtractor.LIBRARY_SUREFIRE_API,
                 urlClassLoader);
 
         // then


### PR DESCRIPTION
Previously, I was using `surefire-booter` jar for this retrieval, but the jar is not available in some cases - eg. when:
`<reuseForks>false</reuseForks>`
is set