### PR TITLE
fix(surefire 2.20 compatibility) extension adds surefire-api dependency to the list of dependencies

### DIFF
--- a/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/ApplicablePlugins.java
+++ b/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/ApplicablePlugins.java
@@ -1,0 +1,31 @@
+package org.arquillian.smart.testing.mvn.ext;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public enum ApplicablePlugins {
+
+    SUREFIRE("maven-surefire-plugin"),
+    FAILSAFE("maven-failsafe-plugin");
+
+    public static final List<String> ARTIFACT_IDS_LIST =
+        Arrays.stream(values()).map(plugin -> plugin.getArtifactId()).collect(Collectors.toList());
+    private final String artifactId;
+
+    ApplicablePlugins(String artifactId) {
+        this.artifactId = artifactId;
+    }
+
+    public static boolean contains(String artifactId) {
+        return ARTIFACT_IDS_LIST.contains(artifactId);
+    }
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    public boolean hasSameArtifactId(String artifactId){
+        return getArtifactId().equals(artifactId);
+    }
+}

--- a/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/MavenProjectConfigurator.java
+++ b/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/MavenProjectConfigurator.java
@@ -55,9 +55,8 @@ class MavenProjectConfigurator {
     private void addSurefireApiDependency(Model model) {
         if (surefireVersion != null && surefireVersion.toString() != null) {
             boolean alreadyContains = model.getDependencies().stream()
-                .filter(dep ->
-                    dep.getGroupId().equals("org.apache.maven.surefire") && dep.getArtifactId().equals("surefire-api"))
-                .findFirst().isPresent();
+                .anyMatch(dep ->
+                    "org.apache.maven.surefire".equals(dep.getGroupId()) && "surefire-api".equals(dep.getArtifactId()));
             if (!alreadyContains) {
                 model.addDependency(getSurefireApiDependency(surefireVersion.toString()));
             }

--- a/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/MavenProjectConfigurator.java
+++ b/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/MavenProjectConfigurator.java
@@ -3,7 +3,6 @@ package org.arquillian.smart.testing.mvn.ext;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -20,12 +19,12 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 class MavenProjectConfigurator {
 
     private static final Version MINIMUM_VERSION = Version.from("2.19.1");
-    private static final List<String> APPLICABLE_PLUGINS =
-        Arrays.asList("maven-surefire-plugin", "maven-failsafe-plugin");
 
     private static Logger logger = Logger.getLogger(MavenProjectConfigurator.class);
 
     private final Configuration configuration;
+
+    private Version surefireVersion;
 
     MavenProjectConfigurator(Configuration configuration) {
         this.configuration = configuration;
@@ -47,9 +46,21 @@ class MavenProjectConfigurator {
                 final Dependency dependency = dependencies.get(strategy);
                 model.addDependency(dependency);
             }
+            if (surefireVersion != null && surefireVersion.toString() != null) {
+                model.addDependency(getSurefireApiDependency(surefireVersion.toString()));
+            }
         } catch (IOException e) {
             throw new RuntimeException("Unable to load strategy definitions", e);
         }
+    }
+
+    private Dependency getSurefireApiDependency(String version){
+        final Dependency dependency = new Dependency();
+        dependency.setGroupId("org.apache.maven.surefire");
+        dependency.setArtifactId("surefire-api");
+        dependency.setVersion(version);
+        dependency.setScope("runtime");
+        return dependency;
     }
 
     void showPom(Model model) {
@@ -60,11 +71,17 @@ class MavenProjectConfigurator {
         }
     }
 
-    void configureTestRunner(Model model) {
+    Version configureTestRunner(Model model) {
         final List<Plugin> testRunnerPluginConfigurations = model.getBuild().getPlugins()
             .stream()
-            .filter(plugin -> APPLICABLE_PLUGINS.contains(plugin.getArtifactId()))
-            .filter(plugin -> Version.from(plugin.getVersion().trim()).isGreaterOrEqualThan(MINIMUM_VERSION))
+            .filter(plugin -> ApplicablePlugins.contains(plugin.getArtifactId()))
+            .filter(plugin -> {
+                Version version = Version.from(plugin.getVersion().trim());
+                if (ApplicablePlugins.SUREFIRE.hasSameArtifactId(plugin.getArtifactId())) {
+                    surefireVersion = version;
+                }
+                return version.isGreaterOrEqualThan(MINIMUM_VERSION);
+            })
             .filter(plugin -> {
                 if (configuration.isApplyToDefined()) {
                     return configuration.getApplyTo().equals(plugin.getArtifactId());
@@ -78,11 +95,11 @@ class MavenProjectConfigurator {
 
             logger.severe(
                 "Smart testing must be used with any of %s plugins with minimum version %s. Please add or update one of the plugin in <plugins> section in your pom.xml",
-                APPLICABLE_PLUGINS, MINIMUM_VERSION);
+                ApplicablePlugins.ARTIFACT_IDS_LIST, MINIMUM_VERSION);
             logCurrentPlugins(model);
             throw new IllegalStateException(
                 String.format("Smart testing must be used with any of %s plugins with minimum version %s",
-                    APPLICABLE_PLUGINS, MINIMUM_VERSION));
+                    ApplicablePlugins.ARTIFACT_IDS_LIST, MINIMUM_VERSION));
         }
 
         for (Plugin testRunnerPlugin : testRunnerPluginConfigurations) {
@@ -95,6 +112,7 @@ class MavenProjectConfigurator {
                 properties.addChild(defineTestSelectionCriteria());
             }
         }
+        return surefireVersion;
     }
 
     private boolean areNotApplicableTestingPlugins(List<Plugin> testRunnerPluginConfigurations) {
@@ -109,7 +127,7 @@ class MavenProjectConfigurator {
 
         model.getBuild().getPlugins()
             .stream()
-            .filter(plugin -> APPLICABLE_PLUGINS.contains(plugin.getArtifactId()))
+            .filter(plugin -> ApplicablePlugins.contains(plugin.getArtifactId()))
             .forEach(plugin -> logger.severe("Current applicable plugin: %s:%s:%s", plugin.getGroupId(),
                 plugin.getArtifactId(), plugin.getVersion()));
     }

--- a/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/MavenProjectConfigurator.java
+++ b/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/MavenProjectConfigurator.java
@@ -46,11 +46,21 @@ class MavenProjectConfigurator {
                 final Dependency dependency = dependencies.get(strategy);
                 model.addDependency(dependency);
             }
-            if (surefireVersion != null && surefireVersion.toString() != null) {
-                model.addDependency(getSurefireApiDependency(surefireVersion.toString()));
-            }
+            addSurefireApiDependency(model);
         } catch (IOException e) {
             throw new RuntimeException("Unable to load strategy definitions", e);
+        }
+    }
+
+    private void addSurefireApiDependency(Model model) {
+        if (surefireVersion != null && surefireVersion.toString() != null) {
+            boolean alreadyContains = model.getDependencies().stream()
+                .filter(dep ->
+                    dep.getGroupId().equals("org.apache.maven.surefire") && dep.getArtifactId().equals("surefire-api"))
+                .findFirst().isPresent();
+            if (!alreadyContains) {
+                model.addDependency(getSurefireApiDependency(surefireVersion.toString()));
+            }
         }
     }
 

--- a/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/PreBuildTestOptimizer.java
+++ b/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/PreBuildTestOptimizer.java
@@ -75,8 +75,8 @@ class PreBuildTestOptimizer extends AbstractMavenLifecycleParticipant {
         final MavenProjectConfigurator mavenProjectConfigurator = new MavenProjectConfigurator(configuration);
         session.getAllProjects().forEach(mavenProject -> {
             final Model model = mavenProject.getModel();
-            mavenProjectConfigurator.addRequiredDependencies(model);
             mavenProjectConfigurator.configureTestRunner(model);
+            mavenProjectConfigurator.addRequiredDependencies(model);
         });
     }
 }

--- a/surefire-provider/pom.xml
+++ b/surefire-provider/pom.xml
@@ -43,6 +43,7 @@
       <groupId>org.apache.maven.surefire</groupId>
       <artifactId>surefire-api</artifactId>
       <version>${version.surefire}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.arquillian.smart.testing</groupId>


### PR DESCRIPTION
Our `smart-testing-surefire-provider` uses the `surefire-api` dependency (2.19.1 version). If the user uses a newer version of surefire plugin, then it throws this exception:

`java.lang.ClassNotFoundException: org.apache.maven.plugin.surefire.log.api.ConsoleLogger`

The reason is that this class has been moved to a new module `surefire-logger-api` which is (in a normal way) transitively fetched. Since our smart-testing-provider has this dependency in the list of dependencies, then the version `2.19.1` is transitively fetched and (thus) the new logger module is missing.
This is why I have to add the `surefire-api`dependency to the project `Model`- to override the our one.

