### PR TITLE
chore(refactor): Abstracts graph elements form JavaAssist

### DIFF
--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/AffectedTestsDetector.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/AffectedTestsDetector.java
@@ -8,7 +8,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.arquillian.smart.testing.Logger;
 import org.arquillian.smart.testing.TestSelection;
-import org.arquillian.smart.testing.filter.TestVerifier;
 import org.arquillian.smart.testing.hub.storage.ChangeStorage;
 import org.arquillian.smart.testing.scm.Change;
 import org.arquillian.smart.testing.scm.spi.ChangeResolver;
@@ -61,7 +60,7 @@ public class AffectedTestsDetector implements TestExecutionPlanner {
         // TODO In case of Arquillian core is an improvement of 500 ms per module
         // Scan disk finding all tests of current project
         final Set<File> allTestsOfCurrentProject = this.testClassDetector.detect();
-        classFileIndex.addTestJavaFiles(allTestsOfCurrentProject);
+        classFileIndex.buildTestDependencyGraph(allTestsOfCurrentProject);
 
         final Collection<Change> files = changeStorage.read()
             .orElseGet(() -> {

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ClassFileIndex.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ClassFileIndex.java
@@ -28,8 +28,6 @@
 package org.arquillian.smart.testing.strategies.affected;
 
 import java.io.File;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -50,7 +48,7 @@ public class ClassFileIndex {
     private Logger logger = Logger.getLogger(ClassFileIndex.class);
 
     private final JavaClassBuilder builder;
-    private DirectedGraph<JavaClass, DefaultEdge> graph;
+    private DirectedGraph<JavaElement, DefaultEdge> graph;
     private List<String> globPatterns;
 
     public ClassFileIndex(ClasspathProvider classpath) {
@@ -82,7 +80,7 @@ public class ClassFileIndex {
         for (String changedTestClassNames : testClassesNames) {
             JavaClass javaClass = builder.getClass(changedTestClassNames);
             if (javaClass != null) {
-                addToIndex(javaClass);
+                addToIndex(new JavaElement(javaClass), javaClass.getImports());
                 changedTestClasses.add(javaClass);
             }
         }
@@ -90,88 +88,91 @@ public class ClassFileIndex {
         return changedTestClasses;
     }
 
-    public JavaClass findJavaClass(String classname) {
-        JavaClass clazz = findClass(classname);
+    public JavaElement findJavaClass(String classname) {
+        JavaElement clazz = findClass(classname);
         if (clazz == null) {
-            clazz = builder.getClass(classname);
-            if (clazz.locatedInClassFile()) {
-                addToIndex(clazz);
+            JavaClass javaClass = builder.getClass(classname);
+            clazz = new JavaElement(javaClass);
+            if (javaClass.locatedInClassFile()) {
+                addToIndex(clazz, javaClass.getImports());
             }
         }
         return clazz;
     }
 
-    private JavaClass findClass(String classname) {
-        for (JavaClass jClass : graph.vertexSet()) {
-            if (jClass.getName().equals(classname)) {
+    private JavaElement findClass(String classname) {
+        for (JavaElement jClass : graph.vertexSet()) {
+            if (jClass.getClassName().equals(classname)) {
                 return jClass;
             }
         }
         return null;
     }
 
-    private void addToIndex(JavaClass newClass) {
-        addToGraph(newClass);
-        updateParentReferences(newClass);
+    private void addToIndex(JavaElement javaElement, String[] imports) {
+        addToGraph(javaElement);
+        updateParentReferences(javaElement, imports);
     }
 
-    private void addToGraph(JavaClass newClass) {
+    private void addToGraph(JavaElement newClass) {
         if (!graph.addVertex(newClass)) {
             replaceVertex(newClass);
         }
     }
 
-    private List<JavaClass> getParents(JavaClass childClass) {
+    private List<JavaElement> getParents(JavaElement childClass) {
         return predecessorListOf(graph, childClass);
     }
 
-    private void replaceVertex(JavaClass newClass) {
-        List<JavaClass> incomingEdges = getParents(newClass);
+    private void replaceVertex(JavaElement newClass) {
+        List<JavaElement> incomingEdges = getParents(newClass);
 
         graph.removeVertex(newClass);
         graph.addVertex(newClass);
-        for (JavaClass each : incomingEdges) {
+        for (JavaElement each : incomingEdges) {
             graph.addEdge(each, newClass);
         }
     }
 
-    private void updateParentReferences(JavaClass parentClass) {
-        for (String child : parentClass.getImports()) {
-            JavaClass childClass = findJavaClass(child);
-            if ((childClass != null) && !childClass.equals(parentClass)) {
+    private void updateParentReferences(JavaElement javaElementParentClass,
+        String[] imports) {
+        for (String child : imports) {
+            JavaElement childClass = findJavaClass(child);
+            if ((childClass != null) && !childClass.equals(javaElementParentClass)) {
                 if (graph.containsVertex(childClass)) {
-                    graph.addEdge(parentClass, childClass);
+                    graph.addEdge(javaElementParentClass, childClass);
                 } else {
                     graph.addVertex(childClass);
-                    graph.addEdge(parentClass, childClass);
+                    graph.addEdge(javaElementParentClass, childClass);
                 }
             }
         }
     }
 
     public Set<String> findTestsDependingOn(Set<File> classes) {
-        final Set<JavaClass> javaClasses = classes.stream()
+        final Set<JavaElement> javaClasses = classes.stream()
             .map(javaClass -> JavaToClassLocation.transform(javaClass, globPatterns))
             .map(this.builder::classFileChanged)
             .map(this.builder::getClass)
+            .map(JavaElement::new)
             .filter(graph::containsVertex)
             .collect(Collectors.toSet());
 
         return findTestsDependingOnAsJavaClass(javaClasses);
     }
 
-    private Set<String> findTestsDependingOnAsJavaClass(Set<JavaClass> classes) {
+    private Set<String> findTestsDependingOnAsJavaClass(Set<JavaElement> classes) {
         Set<String> changedParents = new HashSet<>();
-        for (JavaClass jclass : classes) {
+        for (JavaElement jclass : classes) {
             findParents(jclass, changedParents);
         }
         return changedParents;
     }
 
-    private void findParents(JavaClass jclass, Set<String> changedParents) {
-        for (JavaClass parent : getParents(jclass)) {
-            if (changedParents.add(parent.getName())) {
-                logger.finest("%s test has been added because it depends on %s", parent.getName(), jclass.getName());
+    private void findParents(JavaElement jclass, Set<String> changedParents) {
+        for (JavaElement parent : getParents(jclass)) {
+            if (changedParents.add(parent.getClassName())) {
+                logger.finest("%s test has been added because it depends on %s", parent.getClassName(), jclass.getClassName());
                 findParents(parent, changedParents);
             }
         }
@@ -187,9 +188,9 @@ public class ClassFileIndex {
 
     public Set<String> getIndexedClasses() {
         Set<String> classes = new HashSet<>();
-        Set<JavaClass> vertexSet = graph.vertexSet();
-        for (JavaClass each : vertexSet) {
-            classes.add(each.getName());
+        Set<JavaElement> vertexSet = graph.vertexSet();
+        for (JavaElement each : vertexSet) {
+            classes.add(each.getClassName());
         }
         return classes;
     }
@@ -202,22 +203,6 @@ public class ClassFileIndex {
         defaultEdges.stream().forEach(de -> s.append(de.toString()).append(System.lineSeparator()));
 
         return s.toString();
-    }
-
-    public String toString(String classname) {
-        return graph.edgeSet().stream()
-            .filter(de -> getObject(de, "getSource").equals(classname))
-            .collect(Collectors.toList()).toString();
-    }
-
-    private String getObject(DefaultEdge defaultEdge, String methodName) {
-        try {
-            final Method method = defaultEdge.getClass().getMethod(methodName);
-            method.setAccessible(true);
-            return method.invoke(defaultEdge).toString();
-        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-            return "ERROR on reflection call " + e.getMessage();
-        }
     }
 
 }

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ClassFileIndex.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ClassFileIndex.java
@@ -117,12 +117,10 @@ public class ClassFileIndex {
         for (String importz : imports) {
             JavaElement importClass = new JavaElement(importz);
             if (!importClass.equals(javaElementParentClass)) {
-                if (graph.containsVertex(importClass)) {
-                    graph.addEdge(javaElementParentClass, importClass);
-                } else {
+                if (!graph.containsVertex(importClass)) {
                     graph.addVertex(importClass);
-                    graph.addEdge(javaElementParentClass, importClass);
                 }
+                graph.addEdge(javaElementParentClass, importClass);
             }
         }
     }

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/JavaElement.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/JavaElement.java
@@ -8,6 +8,12 @@ public class JavaElement {
     private final String className;
     private final File classFile;
 
+
+    public JavaElement(String className) {
+        this.className = className;
+        this.classFile = null;
+    }
+
     /**
      * Constructor for creating a Java element.
      * @param className of the java element.

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/JavaElement.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/JavaElement.java
@@ -1,0 +1,57 @@
+package org.arquillian.smart.testing.strategies.affected;
+
+import java.io.File;
+import org.arquillian.smart.testing.strategies.affected.ast.JavaClass;
+
+public class JavaElement {
+
+    private final String className;
+    private final File classFile;
+
+    /**
+     * Constructor for creating a Java element.
+     * @param className of the java element.
+     * @param classFile location of the java element. Can be null.
+     */
+    public JavaElement(String className, File classFile) {
+        this.className = className;
+        this.classFile = classFile;
+    }
+
+    public JavaElement(JavaClass javaClass) {
+        this.className = javaClass.getName();
+        this.classFile = javaClass.getClassFile();
+    }
+
+    public File getClassFile() {
+        return classFile;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        final JavaElement that = (JavaElement) o;
+
+        return className != null ? className.equals(that.className) : that.className == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return className != null ? className.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("JavaElement{");
+        sb.append("className='").append(className).append('\'');
+        sb.append(", classFile=").append(classFile);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ast/AbstractJavaClass.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ast/AbstractJavaClass.java
@@ -25,7 +25,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.arquillian.smart.testing.strategies.affected;
+package org.arquillian.smart.testing.strategies.affected.ast;
 
 import org.arquillian.smart.testing.strategies.affected.ast.JavaClass;
 

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ast/JavaAssistClass.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ast/JavaAssistClass.java
@@ -41,7 +41,6 @@ import javassist.bytecode.ConstPool;
 import javassist.bytecode.MethodInfo;
 import javassist.bytecode.ParameterAnnotationsAttribute;
 import javassist.bytecode.annotation.Annotation;
-import org.arquillian.smart.testing.strategies.affected.AbstractJavaClass;
 
 import static javassist.bytecode.AnnotationsAttribute.invisibleTag;
 import static javassist.bytecode.AnnotationsAttribute.visibleTag;

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ast/JavaAssistClassParser.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ast/JavaAssistClassParser.java
@@ -44,7 +44,6 @@ import javassist.CtClass;
 import javassist.NotFoundException;
 import org.arquillian.smart.testing.FilesCodec;
 import org.arquillian.smart.testing.strategies.affected.MissingClassException;
-import org.arquillian.smart.testing.strategies.affected.UnparsableClass;
 
 import static java.io.File.pathSeparator;
 

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ast/JavaAssistClassParser.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ast/JavaAssistClassParser.java
@@ -137,11 +137,10 @@ public class JavaAssistClassParser {
 
     /**
      * Returns the classname of given .class file.
-     * @param file
-     * @return
+     *
      * @throws IOException
      */
-    public String classFileChanged(File file) throws IOException {
+    public String getClassName(File file) throws IOException {
         String sha1 = FilesCodec.sha1(file);
         CacheEntry entry = BY_PATH.get(file.getAbsolutePath());
         if ((entry != null) && (entry.sha1.equals(sha1))) {
@@ -149,8 +148,7 @@ public class JavaAssistClassParser {
         }
 
         try (InputStream inputStream = new FileInputStream(file)) {
-
-            CtClass ctClass = getClassPool().makeClass(inputStream);
+            CtClass ctClass = makeClass(inputStream);
             String classname = ctClass.getName();
 
             CLASSES_BY_NAME.remove(classname);
@@ -158,6 +156,16 @@ public class JavaAssistClassParser {
 
             return classname;
         }
+    }
+
+    CtClass makeClass(String className) throws IOException {
+            CtClass ctClass = getClassPool().makeClass(className);
+            return ctClass;
+    }
+
+    CtClass makeClass(InputStream className) throws IOException {
+        CtClass ctClass = getClassPool().makeClass(className);
+        return ctClass;
     }
 
     private boolean unparsableClass(CtClass cachedClass) {

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ast/JavaClassBuilder.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ast/JavaClassBuilder.java
@@ -29,6 +29,7 @@ package org.arquillian.smart.testing.strategies.affected.ast;
 
 import java.io.File;
 import java.io.IOException;
+import javassist.CtClass;
 import javassist.NotFoundException;
 import org.arquillian.smart.testing.strategies.affected.ClasspathProvider;
 import org.arquillian.smart.testing.strategies.affected.MissingClassException;
@@ -57,8 +58,17 @@ public class JavaClassBuilder {
         } catch (RuntimeException e) {
             // Can occur when a cached class disappears from the file system
             rethrowIfSerious(e);
-            return new UnparsableClass(classname);
+            return explicitlyCreateJavaClass(classname);
         } catch (MissingClassException e) {
+            return explicitlyCreateJavaClass(classname);
+        }
+    }
+
+    private JavaClass explicitlyCreateJavaClass(String classname) {
+        try {
+            parser.makeClass(classname);
+            return parser.getClass(classname);
+        } catch(Exception e) {
             return new UnparsableClass(classname);
         }
     }
@@ -70,7 +80,7 @@ public class JavaClassBuilder {
      */
     public String classFileChanged(File file) {
         try {
-            return parser.classFileChanged(file);
+            return parser.getClassName(file);
         } catch (RuntimeException e) {
             // If the class goes missing after we read it in but before we
             // process it,

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ast/JavaClassBuilder.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ast/JavaClassBuilder.java
@@ -32,7 +32,6 @@ import java.io.IOException;
 import javassist.NotFoundException;
 import org.arquillian.smart.testing.strategies.affected.ClasspathProvider;
 import org.arquillian.smart.testing.strategies.affected.MissingClassException;
-import org.arquillian.smart.testing.strategies.affected.UnparsableClass;
 
 /**
  * @author Ben Rady

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ast/UnparsableClass.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ast/UnparsableClass.java
@@ -25,7 +25,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package org.arquillian.smart.testing.strategies.affected;
+package org.arquillian.smart.testing.strategies.affected.ast;
 
 import java.io.File;
 import org.arquillian.smart.testing.strategies.affected.ast.JavaClass;
@@ -57,5 +57,13 @@ public class UnparsableClass implements JavaClass {
     @Override
     public boolean locatedInClassFile() {
         return false;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("UnparsableClass{");
+        sb.append("classname='").append(classname).append('\'');
+        sb.append('}');
+        return sb.toString();
     }
 }

--- a/strategies/affected/src/test/java/org/arquillian/smart/testing/strategies/affected/ClassFileIndexTest.java
+++ b/strategies/affected/src/test/java/org/arquillian/smart/testing/strategies/affected/ClassFileIndexTest.java
@@ -23,7 +23,7 @@ public class ClassFileIndexTest {
             Collections.singletonList("**/*Test.java"));
 
         final String testLocation = MyBusinessObjectTest.class.getResource("MyBusinessObjectTest.class").getPath();
-        classFileIndex.addTestJavaFiles(Arrays.asList(new File(testLocation)));
+        classFileIndex.buildTestDependencyGraph(Arrays.asList(new File(testLocation)));
 
         // when
 
@@ -48,7 +48,7 @@ public class ClassFileIndexTest {
 
         final String testLocation = MyBusinessObjectTest.class.getResource("MyBusinessObjectTest.class").getPath();
         final String testLocation2 = MyBusinessObjectTest.class.getResource("MySecondBusinessObjectTest.class").getPath();
-        classFileIndex.addTestJavaFiles(Arrays.asList(new File(testLocation), new File(testLocation2)));
+        classFileIndex.buildTestDependencyGraph(Arrays.asList(new File(testLocation), new File(testLocation2)));
 
         // when
 
@@ -75,7 +75,7 @@ public class ClassFileIndexTest {
 
         final String testLocation = MyBusinessObjectTest.class.getResource("MyBusinessObjectTest.class").getPath();
         final String testLocation2 = MyBusinessObjectTest.class.getResource("MySecondBusinessObjectTest.class").getPath();
-        classFileIndex.addTestJavaFiles(Arrays.asList(new File(testLocation), new File(testLocation2)));
+        classFileIndex.buildTestDependencyGraph(Arrays.asList(new File(testLocation), new File(testLocation2)));
 
         // when
 
@@ -101,7 +101,7 @@ public class ClassFileIndexTest {
 
         final String testLocation = MyBusinessObjectTest.class.getResource("MyBusinessObjectTest.class").getPath();
         final String testLocation2 = MyBusinessObjectTest.class.getResource("MySecondBusinessObjectTest.class").getPath();
-        classFileIndex.addTestJavaFiles(Arrays.asList(new File(testLocation), new File(testLocation2)));
+        classFileIndex.buildTestDependencyGraph(Arrays.asList(new File(testLocation), new File(testLocation2)));
 
         // when
 


### PR DESCRIPTION
Abstracts graph elements form JavaAssist to a custom type, so equals does not depend on anything except the information we require.
With this solution we have `JavaElement` class which abstracts us in the case of JavaAssist cannot parse a Java Class because it is out of classloader.