### PR TITLE
fix(forks) Includes and excludes has to be taken from directoryScannerParameters

### DIFF
--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/ProviderParametersParser.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/ProviderParametersParser.java
@@ -1,15 +1,9 @@
 package org.arquillian.smart.testing.surefire.provider;
 
-import java.util.ArrayList;
 import java.util.List;
 import org.apache.maven.surefire.providerapi.ProviderParameters;
 
-import static org.arquillian.smart.testing.surefire.provider.Validate.isNotEmpty;
-
 public class ProviderParametersParser {
-
-    private List<String> includes;
-    private List<String> excludes;
 
     private final ProviderParameters providerParameters;
 
@@ -18,36 +12,15 @@ public class ProviderParametersParser {
     }
 
     public List<String> getIncludes() {
-        if (includes == null) {
-            includes = getParameterList("includes");
-        }
-        return includes;
+        return providerParameters.getDirectoryScannerParameters().getIncludes();
     }
 
     public List<String> getExcludes() {
-        if (excludes == null) {
-            excludes = getParameterList("excludes");
-        }
-        return excludes;
-    }
-
-    private List<String> getParameterList(String parameterKeyPrefix) {
-        List<String> paramList = new ArrayList<>();
-
-        int i = 0;
-        String includesPattern = null;
-        while (isNotEmpty(includesPattern = getProperty(parameterKeyPrefix + i++))) {
-            paramList.add(includesPattern);
-        }
-        return paramList;
+        return providerParameters.getDirectoryScannerParameters().getExcludes();
     }
 
     public String getProperty(String key) {
         return trimMultiline(providerParameters.getProviderProperties().get(key));
-    }
-
-    public boolean containsProperty(String key) {
-        return providerParameters.getProviderProperties().containsKey(key);
     }
 
     private String trimMultiline(String toTrim) {

--- a/surefire-provider/src/test/java/org/arquillian/smart/testing/surefire/provider/ProviderParameterParserTest.java
+++ b/surefire-provider/src/test/java/org/arquillian/smart/testing/surefire/provider/ProviderParameterParserTest.java
@@ -1,8 +1,10 @@
 package org.arquillian.smart.testing.surefire.provider;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
 import org.apache.maven.surefire.providerapi.ProviderParameters;
+import org.apache.maven.surefire.testset.DirectoryScannerParameters;
 import org.assertj.core.api.JUnitSoftAssertions;
 import org.junit.Before;
 import org.junit.Rule;
@@ -26,26 +28,23 @@ public class ProviderParameterParserTest {
 
     @Before
     public void feedParameters() {
-        Map<String, String> providerProperties = new HashMap<>();
-        providerProperties.put("classPathUrl.0", "/home/mjobanek/.m2/repository/org/testng/testng/6.11/testng-6.11.jar");
-        providerProperties.put("classPathUrl.1", "/home/mjobanek/.m2/repository/junit/junit/4.12/junit-4.12.jar");
-        providerProperties.put("classPathUrl.2",
-            "/home/john//.m2/repository/org/apache/maven/surefire/surefire-api/2.19.1/surefire-api-2.19.1.jar");
-        providerProperties.put("includes1", "**/*Test.java");
-        providerProperties.put("includes2", "**/*TestCase.java");
-        providerProperties.put("includes0", "**/Test*.java");
-        providerProperties.put("excludes0", "**/*$*");
-        providerProperties.put("excludes1", "**/*Failing.java");
+        DirectoryScannerParameters directoryScannerParameters = new DirectoryScannerParameters(
+            new File(""),
+            Arrays.asList(new String[] {"**/*Test.java", "**/*TestCase.java", "**/Test*.java"}),
+            Arrays.asList(new String[] {"**/*$*", "**/*Failing.java"}),
+            new ArrayList<>(),
+            false,
+            "filesystem");
 
         providerParameters = Mockito.mock(ProviderParameters.class);
-        when(providerParameters.getProviderProperties()).thenReturn(providerProperties);
+        when(providerParameters.getDirectoryScannerParameters()).thenReturn(directoryScannerParameters);
     }
 
     @Test
     public void parser_should_return_parsed_includes_and_excludes() {
         ProviderParametersParser parametersParser = new ProviderParametersParser(providerParameters);
         softly.assertThat(parametersParser.getIncludes())
-            .containsExactly("**/Test*.java", "**/*Test.java", "**/*TestCase.java");
+            .containsExactly("**/*Test.java", "**/*TestCase.java", "**/Test*.java");
         softly.assertThat(parametersParser.getExcludes()).containsExactly("**/*$*", "**/*Failing.java");
     }
 }


### PR DESCRIPTION
The reason is that when `reuseForks=fales` or `threadCount=0` then the parameters(`includes` & `excludes`) are not available in the `providerProperties`
