### PR TITLE
Functional test for surefire fork configuration options

### DIFF
--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/SurefireForksConfigurationTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/SurefireForksConfigurationTest.java
@@ -68,9 +68,10 @@ public class SurefireForksConfigurationTest {
         // when
         final List<TestResult> actualTestResults =
             project
-                .buildOptions()
+                .build()
+                .options()
                 .withSystemProperties(systemPropertiesPairs).configure()
-                .build();
+                .run();
 
         // then
         assertThat(actualTestResults).containsAll(expectedTestResults).hasSameSizeAs(expectedTestResults);

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/SurefireForksConfigurationTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/SurefireForksConfigurationTest.java
@@ -1,5 +1,6 @@
 package org.arquillian.smart.testing.ftest.configuration;
 
+import java.util.Collection;
 import java.util.List;
 import org.arquillian.smart.testing.ftest.testbed.project.Project;
 import org.arquillian.smart.testing.ftest.testbed.rules.GitClone;
@@ -62,7 +63,7 @@ public class SurefireForksConfigurationTest {
             .inMode(SELECTING)
             .enable();
 
-        final List<TestResult> expectedTestResults = project
+        Collection<TestResult> expectedTestResults = project
             .applyAsLocalChanges("Inlined variable in a method", "Adds new unit test");
 
         // when

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/SurefireForksConfigurationTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/SurefireForksConfigurationTest.java
@@ -1,0 +1,78 @@
+package org.arquillian.smart.testing.ftest.configuration;
+
+import java.util.List;
+import org.arquillian.smart.testing.ftest.testbed.project.Project;
+import org.arquillian.smart.testing.ftest.testbed.rules.GitClone;
+import org.arquillian.smart.testing.ftest.testbed.rules.TestBed;
+import org.arquillian.smart.testing.ftest.testbed.testresults.TestResult;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.arquillian.smart.testing.ftest.testbed.configuration.Mode.SELECTING;
+import static org.arquillian.smart.testing.ftest.testbed.configuration.Strategy.AFFECTED;
+import static org.arquillian.smart.testing.ftest.testbed.configuration.Strategy.NEW;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SurefireForksConfigurationTest {
+
+    @ClassRule
+    public static final GitClone GIT_CLONE = new GitClone();
+
+    @Rule
+    public TestBed testBed = new TestBed(GIT_CLONE);
+
+    @Test
+    public void test_with_reuse_forks_false() {
+        verifyTestSuiteExecution("reuseForks", "false");
+    }
+
+    @Test
+    public void test_with_fork_count_zero() {
+        verifyTestSuiteExecution("forkCount", "0");
+    }
+
+    @Test
+    public void test_with_fork_count_one() {
+        verifyTestSuiteExecution("forkCount", "1");
+    }
+
+    @Test
+    public void test_with_fork_count_ten() {
+        verifyTestSuiteExecution("forkCount", "10");
+    }
+
+    @Test
+    public void test_with_fork_count_ten_not_reusing_forks() {
+        verifyTestSuiteExecution("forkCount", "10", "reuseForks", "false");
+    }
+
+    @Test
+    public void test_with_fork_count_zero_not_reusing_forks() {
+        verifyTestSuiteExecution("forkCount", "0", "reuseForks", "false");
+    }
+
+
+    private void verifyTestSuiteExecution(String... systemPropertiesPairs){
+        // given
+        final Project project = testBed.getProject();
+
+        project.configureSmartTesting()
+            .executionOrder(NEW, AFFECTED)
+            .inMode(SELECTING)
+            .enable();
+
+        final List<TestResult> expectedTestResults = project
+            .applyAsLocalChanges("Inlined variable in a method", "Adds new unit test");
+
+        // when
+        final List<TestResult> actualTestResults =
+            project
+                .buildOptions()
+                .withSystemProperties(systemPropertiesPairs).configure()
+                .build();
+
+        // then
+        assertThat(actualTestResults).containsAll(expectedTestResults).hasSameSizeAs(expectedTestResults);
+    }
+}

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/AffectedChangesDetectorFactory.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/AffectedChangesDetectorFactory.java
@@ -20,7 +20,7 @@ public class AffectedChangesDetectorFactory implements TestExecutionPlannerFacto
 
     @Override
     public TestExecutionPlanner create(File projectDir, TestVerifier verifier) {
-        return new AffectedTestsDetector(new FileSystemTestClassDetector(projectDir, verifier), "", verifier);
+        return new AffectedTestsDetector(new FileSystemTestClassDetector(projectDir, verifier), StandaloneClasspath.systemClasspath(), verifier);
     }
 
 }

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/StandaloneClasspath.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/StandaloneClasspath.java
@@ -45,10 +45,6 @@ public class StandaloneClasspath implements ClasspathProvider {
         this.classpath = classpath;
     }
 
-    public StandaloneClasspath(List<File> classOutputDirs) {
-        this(classOutputDirs, systemClasspath());
-    }
-
     @Override
     public List<File> getClassOutputDirs() {
         return classDirs;
@@ -67,10 +63,6 @@ public class StandaloneClasspath implements ClasspathProvider {
     @Override
     public List<File> classDirectoriesInClasspath() {
         return classDirsInClasspath;
-    }
-
-    public String getSystemClasspath() {
-        return systemClasspath();
     }
 
     public static String systemClasspath() {


### PR DESCRIPTION
This is a functional test to verify that all possibilities of specifying forks in surefire are working.
Currently, it mainly depends on these two PRs:
https://github.com/arquillian/smart-testing/pull/90 (should fix problem with classloading)
https://github.com/arquillian/smart-testing/pull/93 (should fix problem with not correct includes/excludes)

Then there are two additional problems:
1. in the case of the test [test_with_fork_count_one](https://github.com/arquillian/smart-testing/pull/94/files#diff-3a2ffbf2f0baadc1295fcced8975ff13R36) (which means that it takes the default values) it runs also test classes that are influenced transitively.
in the case of `affected` strategy, the expected is:
`org.jboss.arquillian.config.impl.extension.ConfigurationRegistrarTestCase`
but, apart from this class it runs also:
`org.jboss.arquillian.config.impl.extension.SyspropReplacementInArqXmlTestCase`
`org.jboss.arquillian.config.impl.extension.ArquillianDescriptorPropertiesTestCase`
the log is [here](https://travis-ci.org/arquillian/smart-testing/builds/261125892#L2902-L2911)
In other cases (other test methods) it runs only the expected one.
I tried to change the tag in dogfooding repo, but then fails other tests in the test suite. I'm not sure if I'm doing something wrong, but it seems that the affected strategy returns in some cases different results.
2. when the number of thread is set to more than one, and `reuseForks=true` then it fails with:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.19.1:test (default-test) on project arquillian-config-impl-base: ExecutionException There was an error in the forked process
[ERROR] java.util.NoSuchElementException: 
[ERROR] 	at org.apache.maven.surefire.booter.CommandReader$ClassesIterator.next(CommandReader.java:275)
[ERROR] 	at org.apache.maven.surefire.booter.CommandReader$ClassesIterator.next(CommandReader.java:248)
[ERROR] 	at org.apache.maven.surefire.booter.LazyTestsToRun$BlockingIterator.next(LazyTestsToRun.java:73)
[ERROR] 	at org.apache.maven.surefire.booter.LazyTestsToRun$BlockingIterator.next(LazyTestsToRun.java:61)
[ERROR] 	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:159)
[ERROR] 	at org.arquillian.smart.testing.surefire.provider.SmartTestingSurefireProvider.invoke(SmartTestingSurefireProvider.java:66)
[ERROR] 	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:290)
[ERROR] 	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:242)
[ERROR] 	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:121)
```
