### PR TITLE
Improved documentation for project-persist

### DIFF
--- a/docs/developing.adoc
+++ b/docs/developing.adoc
@@ -102,14 +102,6 @@ for example:
 
 `smart-testing-dogfood-repo_HistoricalChangesAffectedTestsSelectionExecutionFunctionalTest_should_only_execute_tests_related_to_multiple_commits_in_business_logic_when_affected_is_enabled/`
 
-====== Project Persistent
-
-You can check "project under test" for failed tests in `target/projects` with name followed by naming convention:
-
-`getClass().getSimpleName() + "_" + name.getMethodName()`
-
-You can persist project for each test by setting system property `est.bed.project.persist` to true irrespective of test result.
-
 ==== Troubleshooting tests
 
 You can execute embedded build in Test Bed in the debug mode.
@@ -142,4 +134,15 @@ Following system properties are available:
 If both system property and the programmatic option is used system property takes precedence.
 ====
 
+===== Project Persistent
+Project Persistence feature is included in Test Bed to store repository copy used by each and every test method to
+facilitate analysis in case of test failure.
+
+By default this feature is enabled to copy repository only in case of test failure.
+
+In order to copy repository for all tests irrespective of test result, explicitly set system property `test.bed.project.persist` to `true`.
+
+Persisted project are located in `target/projects` with name followed by naming convention:
+
+`getClass().getSimpleName() + "_" + name.getMethodName()`
 

--- a/functional-tests/test-bed/pom.xml
+++ b/functional-tests/test-bed/pom.xml
@@ -62,6 +62,10 @@
       <artifactId>maven-model</artifactId>
       <version>${version.maven}</version>
     </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/mixed/LocalChangesMixedStrategySelectionExecutionFunctionalTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/mixed/LocalChangesMixedStrategySelectionExecutionFunctionalTest.java
@@ -14,6 +14,7 @@ import static org.arquillian.smart.testing.ftest.testbed.configuration.Strategy.
 import static org.arquillian.smart.testing.ftest.testbed.configuration.Mode.SELECTING;
 import static org.assertj.core.api.Assertions.assertThat;
 
+// tag::documentation[]
 public class LocalChangesMixedStrategySelectionExecutionFunctionalTest {
 
     @ClassRule
@@ -22,7 +23,6 @@ public class LocalChangesMixedStrategySelectionExecutionFunctionalTest {
     @Rule
     public TestBed testBed = new TestBed(GIT_CLONE);
 
-    // tag::documentation[]
     @Test
     public void should_execute_all_new_tests_and_related_to_production_code_changes() throws Exception {
         // given
@@ -43,5 +43,5 @@ public class LocalChangesMixedStrategySelectionExecutionFunctionalTest {
         // then
         assertThat(actualTestResults).containsAll(expectedTestResults).hasSameSizeAs(expectedTestResults);
     }
-    // end::documentation[]
 }
+// end::documentation[]

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/testbed/ProjectPersistTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/testbed/ProjectPersistTest.java
@@ -8,13 +8,18 @@ import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
 
+import static java.lang.System.getProperty;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NotThreadSafe
 public class ProjectPersistTest {
+
+    @Rule
+    public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
     @Test
     public void temp_projects_should_copied_in_target_if_test_is_failing() {
@@ -32,6 +37,16 @@ public class ProjectPersistTest {
         assertThat(new File("target/projects/smart-testing-dogfood-repo_ProjectPersistPass_should_pass")).doesNotExist();
     }
 
+    @Test
+    public void temp_test_projects_should_copied_in_target_if_test_is_passing_and_system_property_is_set() {
+        System.setProperty("test.bed.project.persist", "true");
+
+        final Result result = JUnitCore.runClasses(ProjectPersistPass1.class);
+
+        assertThat(result.wasSuccessful()).isTrue();
+        assertThat(new File("target/projects/smart-testing-dogfood-repo_ProjectPersistPass1_should_pass")).isDirectory();
+    }
+
     public static class ProjectPersistFail {
 
         @ClassRule
@@ -47,6 +62,19 @@ public class ProjectPersistTest {
     }
 
     public static class ProjectPersistPass {
+        @ClassRule
+        public static final GitClone GIT_CLONE = new GitClone();
+
+        @Rule
+        public TestBed testBed = new TestBed(GIT_CLONE);
+
+        @Test
+        public void should_pass() throws Exception {
+            Assert.assertTrue(true);
+        }
+    }
+
+    public static class ProjectPersistPass1 {
         @ClassRule
         public static final GitClone GIT_CLONE = new GitClone();
 


### PR DESCRIPTION
#### Short description of what this resolves:
Improves documentation & test for project-persist feature. 

#### Changes proposed in this pull request:

- Adds more elaborative information for Project Persistent
- Adds missing test for setting system property `test.bed.project.persist`
- Changed TestBed example to show complete example with class. So user will know we are using Junit rules.
