### PR TITLE
Disables extension when test execution is skipped

### DIFF
--- a/core/src/main/java/org/arquillian/smart/testing/Configuration.java
+++ b/core/src/main/java/org/arquillian/smart/testing/Configuration.java
@@ -68,5 +68,4 @@ public class Configuration {
     public boolean isDisabled() {
         return disabled;
     }
-
 }

--- a/core/src/main/java/org/arquillian/smart/testing/Configuration.java
+++ b/core/src/main/java/org/arquillian/smart/testing/Configuration.java
@@ -68,4 +68,5 @@ public class Configuration {
     public boolean isDisabled() {
         return disabled;
     }
+
 }

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/BuildConfigurator.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/BuildConfigurator.java
@@ -35,6 +35,7 @@ public class BuildConfigurator {
     private boolean enableSurefireRemoteDebugging = false;
     private boolean ignoreBuildFailure = false;
     private boolean skipTests = false;
+    private String mavenLog = "false";
     private String mavenOpts = "-Xms512m -Xmx1024m";
 
     BuildConfigurator(ProjectBuilder projectBuilder) {
@@ -124,6 +125,11 @@ public class BuildConfigurator {
         return this;
     }
 
+    public BuildConfigurator withMavenLog() {
+        this.mavenLog = "true";
+        return this;
+    }
+
     public BuildConfigurator logBuildOutput() {
         return logBuildOutput(false);
     }
@@ -187,6 +193,14 @@ public class BuildConfigurator {
         }
     }
 
+    void setMavenLog(String mavenLog) {
+        this.mavenLog = mavenLog;
+    }
+
+    String getMavenLog() {
+        return mavenLog;
+    }
+
     void addMavenOpts(String options) {
         this.mavenOpts += " " + options;
     }
@@ -213,6 +227,10 @@ public class BuildConfigurator {
 
     boolean isSkipTestsEnabled() {
         return skipTests;
+    }
+
+    boolean isMavenLoggingEnabled() {
+        return Boolean.valueOf(mavenLog);
     }
 
     String getMavenOpts() {

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/BuildConfigurator.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/BuildConfigurator.java
@@ -34,6 +34,7 @@ public class BuildConfigurator {
     private boolean mvnDebugOutput;
     private boolean enableSurefireRemoteDebugging = false;
     private boolean ignoreBuildFailure = false;
+    private boolean skipTests = false;
     private String mavenOpts = "-Xms512m -Xmx1024m";
 
     BuildConfigurator(ProjectBuilder projectBuilder) {
@@ -115,6 +116,11 @@ public class BuildConfigurator {
 
     public BuildConfigurator ignoreBuildFailure() {
         this.ignoreBuildFailure = true;
+        return this;
+    }
+
+    public BuildConfigurator skipTests(boolean skipTests) {
+        this.skipTests = skipTests;
         return this;
     }
 
@@ -203,6 +209,10 @@ public class BuildConfigurator {
 
     boolean isQuietMode() {
         return quietMode;
+    }
+
+    boolean isSkipTestsEnabled() {
+        return skipTests;
     }
 
     String getMavenOpts() {

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/BuildConfigurator.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/BuildConfigurator.java
@@ -35,7 +35,6 @@ public class BuildConfigurator {
     private boolean enableSurefireRemoteDebugging = false;
     private boolean ignoreBuildFailure = false;
     private boolean skipTests = false;
-    private String mavenLog = "false";
     private String mavenOpts = "-Xms512m -Xmx1024m";
 
     BuildConfigurator(ProjectBuilder projectBuilder) {
@@ -125,11 +124,6 @@ public class BuildConfigurator {
         return this;
     }
 
-    public BuildConfigurator withMavenLog() {
-        this.mavenLog = "true";
-        return this;
-    }
-
     public BuildConfigurator logBuildOutput() {
         return logBuildOutput(false);
     }
@@ -193,14 +187,6 @@ public class BuildConfigurator {
         }
     }
 
-    void setMavenLog(String mavenLog) {
-        this.mavenLog = mavenLog;
-    }
-
-    String getMavenLog() {
-        return mavenLog;
-    }
-
     void addMavenOpts(String options) {
         this.mavenOpts += " " + options;
     }
@@ -227,10 +213,6 @@ public class BuildConfigurator {
 
     boolean isSkipTestsEnabled() {
         return skipTests;
-    }
-
-    boolean isMavenLoggingEnabled() {
-        return Boolean.valueOf(mavenLog);
     }
 
     String getMavenOpts() {

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/Project.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/Project.java
@@ -28,6 +28,10 @@ public class Project implements AutoCloseable {
         return root;
     }
     
+    public String getMavenLog() {
+        return projectBuilder.options().getMavenLog();
+    }
+
     public ProjectConfigurator configureSmartTesting() {
         return new ProjectConfigurator(this, root);
     }

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/Project.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/Project.java
@@ -29,7 +29,7 @@ public class Project implements AutoCloseable {
     }
     
     public String getMavenLog() {
-        return projectBuilder.options().getMavenLog();
+        return projectBuilder.getMavenLog();
     }
 
     public ProjectConfigurator configureSmartTesting() {

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
@@ -71,8 +71,14 @@ public class ProjectBuilder {
                     .ignoreFailure()
                 .build();
 
+        final String mavenLog = build.getMavenLog();
+
+        if (buildConfigurator.isMavenLoggingEnabled()) {
+                buildConfigurator.setMavenLog(mavenLog);
+        }
+
         if (!buildConfigurator.isIgnoreBuildFailure() && build.getMavenBuildExitCode() != 0) {
-            System.out.println(build.getMavenLog());
+            System.out.println(mavenLog);
             throw new IllegalStateException("Maven build has failed, see logs for details");
         }
 

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
@@ -65,8 +65,8 @@ public class ProjectBuilder {
                     .setProjects(buildConfigurator.getModulesToBeBuilt())
                     .setDebug(buildConfigurator.isMavenDebugOutputEnabled())
                     .setQuiet(buildConfigurator.disableQuietWhenAnyDebugModeEnabled() && buildConfigurator.isQuietMode())
-                    .skipTests(false)
                     .setProperties(asProperties(buildConfigurator.getSystemProperties()))
+                    .skipTests(buildConfigurator.isSkipTestsEnabled())
                     .setMavenOpts(buildConfigurator.getMavenOpts())
                     .ignoreFailure()
                 .build();

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
@@ -74,7 +74,7 @@ public class ProjectBuilder {
                 .build();
 
         if (!buildConfigurator.isIgnoreBuildFailure() && build.getMavenBuildExitCode() != 0) {
-            System.out.println(getMavenLog());
+            System.out.println(build.getMavenLog());
             throw new IllegalStateException("Maven build has failed, see logs for details");
         }
 

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/DisabledSmartTestingFunctionalTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/DisabledSmartTestingFunctionalTest.java
@@ -49,30 +49,4 @@ public class DisabledSmartTestingFunctionalTest {
         // then
         assertThat(actualTestResults).hasSize(74);
     }
-
-    @Test
-    public void should_return_empty_set_when_test_execution_is_skipped() throws Exception {
-        // given
-        final Project project = testBed.getProject();
-
-        project.configureSmartTesting()
-            .executionOrder(AFFECTED)
-            .inMode(SELECTING)
-            .enable();
-
-        project
-            .applyAsCommits("Disable surefire and enable just failsafe plugin");
-
-        // when
-        final List<TestResult> actualTestResults = project
-            .build()
-                .options()
-                    .skipTests(true)
-                .configure()
-            .run();
-
-        // then
-        assertThat(actualTestResults).isEmpty();
-    }
-
 }

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/DisabledSmartTestingFunctionalTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/DisabledSmartTestingFunctionalTest.java
@@ -50,4 +50,29 @@ public class DisabledSmartTestingFunctionalTest {
         assertThat(actualTestResults).hasSize(74);
     }
 
+    @Test
+    public void should_return_empty_set_when_test_execution_is_skipped() throws Exception {
+        // given
+        final Project project = testBed.getProject();
+
+        project.configureSmartTesting()
+            .executionOrder(AFFECTED)
+            .inMode(SELECTING)
+            .enable();
+
+        project
+            .applyAsCommits("Disable surefire and enable just failsafe plugin");
+
+        // when
+        final List<TestResult> actualTestResults = project
+            .build()
+                .options()
+                    .skipTests(true)
+                .configure()
+            .run();
+
+        // then
+        assertThat(actualTestResults).isEmpty();
+    }
+
 }

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/SkipTestExecutionFunctionalTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/SkipTestExecutionFunctionalTest.java
@@ -1,0 +1,75 @@
+package org.arquillian.smart.testing.ftest.configuration;
+
+import java.util.Collection;
+import org.arquillian.smart.testing.ftest.testbed.project.Project;
+import org.arquillian.smart.testing.ftest.testbed.rules.GitClone;
+import org.arquillian.smart.testing.ftest.testbed.rules.TestBed;
+import org.arquillian.smart.testing.ftest.testbed.testresults.TestResult;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.arquillian.smart.testing.ftest.testbed.configuration.Mode.ORDERING;
+import static org.arquillian.smart.testing.ftest.testbed.configuration.Strategy.AFFECTED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SkipTestExecutionFunctionalTest {
+
+    @ClassRule
+    public static final GitClone GIT_CLONE = new GitClone();
+
+    @Rule
+    public TestBed testBed = new TestBed(GIT_CLONE);
+
+    private static final String EXPECTED_LOG_PART = "Enabling Smart Testing";
+
+    @Test
+    public void should_execute_all_unit_tests_when_integration_test_execution_is_skipped() throws Exception {
+        // given
+        final Project project = testBed.getProject();
+
+        project.configureSmartTesting()
+                .executionOrder(AFFECTED)
+                .inMode(ORDERING)
+            .enable();
+
+        // when
+        final Collection<TestResult> actualTestResults = project
+            .build("config/impl-base")
+                .options()
+                    .withMavenLog()
+                    .withSystemProperties("skipITs", "true")
+                .configure()
+            .run("clean", "install");
+
+        // then
+        String capturedMavenLog = project.getMavenLog();
+        assertThat(capturedMavenLog).contains(EXPECTED_LOG_PART);
+        assertThat(actualTestResults).size().isEqualTo(5);
+    }
+
+    @Test
+    public void should_disable_smart_testing_and_execute_no_tests_when_test_execution_is_skipped() throws Exception {
+        // given
+        final Project project = testBed.getProject();
+
+        project.configureSmartTesting()
+                .executionOrder(AFFECTED)
+                .inMode(ORDERING)
+            .enable();
+
+        // when
+        final Collection<TestResult> actualTestResults = project
+            .build("config/impl-base")
+                .options()
+                    .withMavenLog()
+                    .skipTests(true)
+                .configure()
+            .run("clean", "install");
+
+        // then
+        String capturedMavenLog = project.getMavenLog();
+        assertThat(capturedMavenLog).doesNotContain(EXPECTED_LOG_PART);
+        assertThat(actualTestResults).size().isEqualTo(0);
+    }
+}

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/SkipTestExecutionFunctionalTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/SkipTestExecutionFunctionalTest.java
@@ -23,6 +23,8 @@ public class SkipTestExecutionFunctionalTest {
 
     private static final String EXPECTED_LOG_PART = "Enabling Smart Testing";
 
+    private static String[] modules = new String[] {"core/api", "core/spi", "core/impl-base"};
+
     @Test
     public void should_execute_all_unit_tests_when_integration_test_execution_is_skipped() throws Exception {
         // given
@@ -35,17 +37,16 @@ public class SkipTestExecutionFunctionalTest {
 
         // when
         final Collection<TestResult> actualTestResults = project
-            .build("config/impl-base")
+            .build(modules)
                 .options()
-                    .withMavenLog()
                     .withSystemProperties("skipITs", "true")
                 .configure()
-            .run("clean", "install");
+            .run();
 
         // then
         String capturedMavenLog = project.getMavenLog();
         assertThat(capturedMavenLog).contains(EXPECTED_LOG_PART);
-        assertThat(actualTestResults).size().isEqualTo(5);
+        assertThat(actualTestResults).size().isEqualTo(20);
     }
 
     @Test
@@ -60,12 +61,11 @@ public class SkipTestExecutionFunctionalTest {
 
         // when
         final Collection<TestResult> actualTestResults = project
-            .build("config/impl-base")
+            .build(modules)
                 .options()
-                    .withMavenLog()
                     .skipTests(true)
                 .configure()
-            .run("clean", "install");
+            .run();
 
         // then
         String capturedMavenLog = project.getMavenLog();

--- a/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/MavenProjectConfigurator.java
+++ b/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/MavenProjectConfigurator.java
@@ -15,6 +15,8 @@ import org.arquillian.smart.testing.mvn.ext.dependencies.ExtensionVersion;
 import org.arquillian.smart.testing.mvn.ext.dependencies.Version;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
+import static org.arquillian.smart.testing.mvn.ext.MavenPropertyResolver.*;
+
 class MavenProjectConfigurator {
 
     private static final Version MINIMUM_VERSION = Version.from("2.19.1");
@@ -88,22 +90,6 @@ class MavenProjectConfigurator {
             .filter(
                 testRunnerPlugin -> !(testRunnerPlugin.getArtifactId().equals("maven-failsafe-plugin") && isSkipITs()))
             .collect(Collectors.toList());
-    }
-
-    boolean isSkipTestExecutionSet() {
-        return isSkipTests() || isSkip();
-    }
-
-    private boolean isSkipTests() {
-        return Boolean.valueOf(System.getProperty("skipTests", "false"));
-    }
-
-    private boolean isSkipITs() {
-        return Boolean.valueOf(System.getProperty("skipITs", "false"));
-    }
-
-    private boolean isSkip() {
-        return Boolean.valueOf(System.getProperty("maven.test.skip", "false"));
     }
 
     private Xpp3Dom defineTestSelectionCriteria() {

--- a/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/MavenPropertyResolver.java
+++ b/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/MavenPropertyResolver.java
@@ -1,0 +1,21 @@
+package org.arquillian.smart.testing.mvn.ext;
+
+class MavenPropertyResolver {
+
+    static boolean isSkipTestExecutionSet() {
+        return isSkipTests() || isSkip();
+    }
+
+    static private boolean isSkipTests() {
+        return Boolean.valueOf(System.getProperty("skipTests", "false"));
+    }
+
+    static boolean isSkipITs() {
+        return Boolean.valueOf(System.getProperty("skipITs", "false"));
+    }
+
+    static private boolean isSkip() {
+        return Boolean.valueOf(System.getProperty("maven.test.skip", "false"));
+    }
+
+}


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Check for `maven.test.skip`, `skipTests` and `skipITs` property honored by Surefire and Failsafe plugins. 
- Ignore smart-testing-extension registration/configuration.
- Tests to verify the change depending on the logger message. 

Fixes #73 
