### PR TITLE
Adds tests for TestSelection

### DIFF
--- a/core/src/main/java/org/arquillian/smart/testing/TestSelection.java
+++ b/core/src/main/java/org/arquillian/smart/testing/TestSelection.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Array;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Objects;
 
 import static java.lang.String.format;
@@ -22,7 +23,7 @@ public class TestSelection {
 
     public TestSelection(String className, String ... type) {
         this.className = className;
-        this.types = new HashSet<>(asList(type));
+        this.types = new LinkedHashSet<>(asList(type));
     }
 
     public String getClassName() {
@@ -50,7 +51,6 @@ public class TestSelection {
         return Objects.hash(getClassName());
     }
 
-    // TODO  test it
     public TestSelection merge(TestSelection other) {
 
         if (!className.equals(other.getClassName())) {

--- a/core/src/test/java/org/arquillian/smart/testing/TestSelectionTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/TestSelectionTest.java
@@ -1,0 +1,78 @@
+package org.arquillian.smart.testing;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestSelectionTest {
+    
+    private static final String NEW = "new";
+    private static final String CHANGED = "changed";
+    private static final String AFFECTED = "affected";
+    private static final String CLASS_NAME_1 = "smart.testing.Class1";
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void should_merge_test_selection_with_different_strategy_for_same_class() {
+        //given
+        final TestSelection testSelection = new TestSelection(CLASS_NAME_1, NEW);
+        
+        //when
+        final TestSelection mergedTestSelection = testSelection.merge(new TestSelection(CLASS_NAME_1, CHANGED));
+        
+        //then
+        assertThat(mergedTestSelection.getTypes()).containsExactly(NEW, CHANGED);
+        assertThat(mergedTestSelection.getClassName()).isEqualTo(CLASS_NAME_1);
+    }
+
+    @Test
+    public void should_merge_test_selection_with_different_strategies_for_same_class_name() {
+        //given
+        final TestSelection testSelection = new TestSelection(CLASS_NAME_1, NEW, AFFECTED);
+
+        //when
+        final TestSelection mergedTestSelection = testSelection.merge(new TestSelection(CLASS_NAME_1, CHANGED));
+
+        //then
+        assertThat(mergedTestSelection.getTypes()).containsExactly(NEW, AFFECTED, CHANGED);
+        assertThat(mergedTestSelection.getClassName()).isEqualTo(CLASS_NAME_1);
+    }
+
+    @Test
+    public void should_not_merge_test_selection_with_different_class_name() {
+        //given
+        final TestSelection testSelection = new TestSelection(getPath("DummyClassWithDefaultPackageName.java"), NEW);
+
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Cannot merge two test selections with different locations (DummyClassWithDefaultPackageName != dummy.cls.DummyClassWithPackageName)");
+
+        //when
+        testSelection.merge(new TestSelection(getPath("DummyClassWithPackageName.java"), CHANGED));
+    }
+
+    @Test
+    public void should_merge_test_selection_with_different_strategies_for_same_class() {
+        //given
+        final Path path = getPath("DummyClassWithDefaultPackageName.java");
+        final TestSelection testSelection = new TestSelection(path, AFFECTED);
+
+        //when
+        final TestSelection mergedTestSelection = testSelection.merge(new TestSelection(path, NEW));
+
+        //then
+        assertThat(mergedTestSelection.getTypes()).containsExactly(AFFECTED, NEW);
+    }
+
+    private Path getPath(String fileName) {
+        return Paths.get(Thread.currentThread().getContextClassLoader().getResource(
+            fileName).getFile());
+    }
+
+}

--- a/core/src/test/java/org/arquillian/smart/testing/TestSelectionTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/TestSelectionTest.java
@@ -21,52 +21,54 @@ public class TestSelectionTest {
 
     @Test
     public void should_merge_test_selection_with_different_strategy_for_same_class() {
-        //given
+        // given
         final TestSelection testSelection = new TestSelection(CLASS_NAME_1, NEW);
         
-        //when
+        // when
         final TestSelection mergedTestSelection = testSelection.merge(new TestSelection(CLASS_NAME_1, CHANGED));
         
-        //then
+        // then
         assertThat(mergedTestSelection.getTypes()).containsExactly(NEW, CHANGED);
         assertThat(mergedTestSelection.getClassName()).isEqualTo(CLASS_NAME_1);
     }
 
     @Test
     public void should_merge_test_selection_with_different_strategies_for_same_class_name() {
-        //given
+        // given
         final TestSelection testSelection = new TestSelection(CLASS_NAME_1, NEW, AFFECTED);
 
-        //when
+        // when
         final TestSelection mergedTestSelection = testSelection.merge(new TestSelection(CLASS_NAME_1, CHANGED));
 
-        //then
+        // then
         assertThat(mergedTestSelection.getTypes()).containsExactly(NEW, AFFECTED, CHANGED);
         assertThat(mergedTestSelection.getClassName()).isEqualTo(CLASS_NAME_1);
     }
 
     @Test
     public void should_not_merge_test_selection_with_different_class_name() {
-        //given
+        // given
         final TestSelection testSelection = new TestSelection(getPath("DummyClassWithDefaultPackageName.java"), NEW);
 
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Cannot merge two test selections with different locations (DummyClassWithDefaultPackageName != dummy.cls.DummyClassWithPackageName)");
 
-        //when
+        // when
         testSelection.merge(new TestSelection(getPath("DummyClassWithPackageName.java"), CHANGED));
+        
+        // then exception should be thrown
     }
 
     @Test
     public void should_merge_test_selection_with_different_strategies_for_same_class() {
-        //given
+        // given
         final Path path = getPath("DummyClassWithDefaultPackageName.java");
         final TestSelection testSelection = new TestSelection(path, AFFECTED);
 
-        //when
+        // when
         final TestSelection mergedTestSelection = testSelection.merge(new TestSelection(path, NEW));
 
-        //then
+        // then
         assertThat(mergedTestSelection.getTypes()).containsExactly(AFFECTED, NEW);
     }
 


### PR DESCRIPTION
#### Short description of what this resolves:
Adds test for TestSelection

#### Changes proposed in this pull request:

- Adds tests for `TestSelection`
- Changed `HashSet` to `LinkedHashSet` to preserve the order, So we can use it reports with same order as user defined in strategy
- 


Fixes #
