### PR TITLE
chore(remove_code): Removes code not used/redundant 

### DIFF
--- a/core/src/main/java/org/arquillian/smart/testing/spi/TestExecutionPlannerFactory.java
+++ b/core/src/main/java/org/arquillian/smart/testing/spi/TestExecutionPlannerFactory.java
@@ -10,6 +10,6 @@ public interface TestExecutionPlannerFactory {
 
     boolean isFor(String name);
 
-    TestExecutionPlanner create(File projectDir, TestVerifier testVerifier, String[] globPatterns);
+    TestExecutionPlanner create(File projectDir, TestVerifier testVerifier);
 
 }

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/AffectedChangesDetectorFactory.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/AffectedChangesDetectorFactory.java
@@ -19,7 +19,7 @@ public class AffectedChangesDetectorFactory implements TestExecutionPlannerFacto
     }
 
     @Override
-    public TestExecutionPlanner create(File projectDir, TestVerifier verifier, String[] globPatterns) {
+    public TestExecutionPlanner create(File projectDir, TestVerifier verifier) {
         return new AffectedTestsDetector(new FileSystemTestClassDetector(projectDir, verifier), "", verifier);
     }
 

--- a/strategies/changed/src/main/java/org/arquillian/smart/testing/vcs/git/ChangedFilesDetectorFactory.java
+++ b/strategies/changed/src/main/java/org/arquillian/smart/testing/vcs/git/ChangedFilesDetectorFactory.java
@@ -18,7 +18,7 @@ public class ChangedFilesDetectorFactory implements TestExecutionPlannerFactory 
     }
 
     @Override
-    public TestExecutionPlanner create(File projectDir, TestVerifier verifier, String[] globPatterns) {
+    public TestExecutionPlanner create(File projectDir, TestVerifier verifier) {
         return new ChangedTestsDetector(verifier);
     }
 }

--- a/strategies/changed/src/main/java/org/arquillian/smart/testing/vcs/git/NewTestsDetectorFactory.java
+++ b/strategies/changed/src/main/java/org/arquillian/smart/testing/vcs/git/NewTestsDetectorFactory.java
@@ -18,7 +18,7 @@ public class NewTestsDetectorFactory implements TestExecutionPlannerFactory {
     }
 
     @Override
-    public TestExecutionPlanner create(File projectDir, TestVerifier verifier, String[] globPatterns) {
+    public TestExecutionPlanner create(File projectDir, TestVerifier verifier) {
         return new NewTestsDetector(verifier);
     }
 }

--- a/strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/FailedTestsDetectorFactory.java
+++ b/strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/FailedTestsDetectorFactory.java
@@ -18,7 +18,7 @@ public class FailedTestsDetectorFactory implements TestExecutionPlannerFactory {
     }
 
     @Override
-    public TestExecutionPlanner create(File projectDir, TestVerifier verifier, String[] globPatterns) {
+    public TestExecutionPlanner create(File projectDir, TestVerifier verifiers) {
         return new FailedTestsDetector();
     }
 

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/SmartTestingSurefireProvider.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/SmartTestingSurefireProvider.java
@@ -43,17 +43,10 @@ public class SmartTestingSurefireProvider implements SurefireProvider {
             new TestExecutionPlannerLoader(new JavaSPILoader(), resource -> {
                 final String className = new ClassNameExtractor().extractFullyQualifiedName(resource);
                 return testsToRun.getClassByName(className) != null;
-            }, getGlobPatterns());
+            });
 
         return new TestStrategyApplier(testsToRun, testExecutionPlannerLoader, bootParams.getTestClassLoader()).apply(
             configuration);
-    }
-
-    private String[] getGlobPatterns() { // FIXME(affected) Only temporarily for affected
-        final List<String> globPatterns = paramParser.getIncludes();
-        // TODO question why exclusions are added too?
-        globPatterns.addAll(paramParser.getExcludes());
-        return globPatterns.toArray(new String[globPatterns.size()]);
     }
 
     public Iterable<Class<?>> getSuites() {

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/TestExecutionPlannerLoader.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/TestExecutionPlannerLoader.java
@@ -12,13 +12,11 @@ class TestExecutionPlannerLoader {
 
     private final Map<String, TestExecutionPlannerFactory> availableStrategies = new HashMap<>();
     private final JavaSPILoader spiLoader;
-    private final String[] globPatterns;
     private final TestVerifier verifier;
 
-    TestExecutionPlannerLoader(JavaSPILoader spiLoader, TestVerifier verifier, String[] globPatterns) {
+    TestExecutionPlannerLoader(JavaSPILoader spiLoader, TestVerifier verifier) {
         this.spiLoader = spiLoader;
         this.verifier = verifier;
-        this.globPatterns = globPatterns;
     }
 
     TestExecutionPlanner getPlannerForStrategy(String strategy) {
@@ -29,7 +27,7 @@ class TestExecutionPlannerLoader {
 
         if (availableStrategies.containsKey(strategy)) {
             final File projectDir = new File(System.getProperty("user.dir"));
-            return availableStrategies.get(strategy).create(projectDir, verifier, globPatterns);
+            return availableStrategies.get(strategy).create(projectDir, verifier);
         }
 
         throw new IllegalArgumentException("No strategy found for [" + strategy + "]. Available strategies are: [" + availableStrategies.keySet()

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/TestStrategyApplier.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/TestStrategyApplier.java
@@ -50,7 +50,6 @@ class TestStrategyApplier {
             .stream()
             .map(TestSelection::getClassName)
             .filter(this::presentOnClasspath)
-            .filter(this::isInTestToRun) // only here because affected strategy doesn't use TestVerifier yet
             .map(testClass -> {
                 try {
                     return Class.forName(testClass);
@@ -69,7 +68,4 @@ class TestStrategyApplier {
         }
     }
 
-    private boolean isInTestToRun(String testClass) {
-        return testsToRun.getClassByName(testClass) != null;
-    }
 }

--- a/surefire-provider/src/test/java/org/arquillian/smart/testing/surefire/provider/TestExecutionPlannerLoaderTest.java
+++ b/surefire-provider/src/test/java/org/arquillian/smart/testing/surefire/provider/TestExecutionPlannerLoaderTest.java
@@ -29,7 +29,7 @@ public class TestExecutionPlannerLoaderTest {
         when(mockedSpiLoader.all(eq(TestExecutionPlannerFactory.class))).thenAnswer(i -> Collections.singletonList(
             new DummyTestExecutionPlannerFactory()));
         final TestExecutionPlannerLoader testExecutionPlannerLoader =
-            new TestExecutionPlannerLoader(mockedSpiLoader, resource -> true,  new String[] {});
+            new TestExecutionPlannerLoader(mockedSpiLoader, resource -> true);
 
         // when
         final TestExecutionPlanner testExecutionPlanner = testExecutionPlannerLoader.getPlannerForStrategy("dummy");
@@ -44,7 +44,7 @@ public class TestExecutionPlannerLoaderTest {
         when(mockedSpiLoader.all(eq(TestExecutionPlannerFactory.class))).thenAnswer(i -> Collections.singletonList(
             new DummyTestExecutionPlannerFactory()));
         final TestExecutionPlannerLoader testExecutionPlannerLoader =
-            new TestExecutionPlannerLoader(mockedSpiLoader, resource -> true, new String[] {});
+            new TestExecutionPlannerLoader(mockedSpiLoader, resource -> true);
 
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("No strategy found for [new]. Available strategies are: [[dummy]]. Please make sure you have corresponding dependency defined.");
@@ -59,7 +59,7 @@ public class TestExecutionPlannerLoaderTest {
         final JavaSPILoader mockedSpiLoader = mock(JavaSPILoader.class);
         when(mockedSpiLoader.all(eq(TestExecutionPlannerFactory.class))).thenReturn(Collections.emptyList());
         final TestExecutionPlannerLoader testExecutionPlannerLoader =
-            new TestExecutionPlannerLoader(mockedSpiLoader, resource -> true, new String[] {});
+            new TestExecutionPlannerLoader(mockedSpiLoader, resource -> true);
 
         expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage("There is no strategy available. Please make sure you have corresponding dependencies defined.");
@@ -80,7 +80,7 @@ public class TestExecutionPlannerLoaderTest {
         }
 
         @Override
-        public TestExecutionPlanner create(File projectDir, TestVerifier verifier, String[] globPatterns) {
+        public TestExecutionPlanner create(File projectDir, TestVerifier verifier) {
             return new TestExecutionPlanner() {
                 @Override
                 public Collection<TestSelection> getTests() {


### PR DESCRIPTION
#### Short description of what this resolves:

Removes code not used/redundant because of changes in affected strategy, glob patterns are not used anymore in any strategy.

#### Changes proposed in this pull request:

- Removes glob pattern logic
- Removes check in `TestStrategyApplier` of `testInRun` check since now affected also uses `TestVerifier`

Fixes #109 
