### PR TITLE
Ability to dump graph as a dot file

### DIFF
--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/SurefireForksConfigurationTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/SurefireForksConfigurationTest.java
@@ -8,6 +8,7 @@ import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 
 import java.util.Collection;
 import java.util.List;
@@ -24,6 +25,9 @@ public class SurefireForksConfigurationTest {
 
     @Rule
     public TestBed testBed = new TestBed(GIT_CLONE);
+
+    @Rule
+    public TestName name= new TestName();
 
     @Test
     public void test_with_reuse_forks_false() {
@@ -71,9 +75,13 @@ public class SurefireForksConfigurationTest {
         // when
         final List<TestResult> actualTestResults =
             project
-                .build("config/impl-base")
+                .build()
                 .options()
+                    //.withRemoteDebugging()
+                    //.withRemoteSurefireDebugging()
                     .withSystemProperties(systemPropertiesPairs)
+                    .withSystemProperties("graph.name", name.getMethodName())
+                    .withSystemProperties("smart.testing.debug", "true") // This will only be propagated to surefire for "not_reusing_forks" option
                     .configure()
                 .run();
 

--- a/strategies/affected/pom.xml
+++ b/strategies/affected/pom.xml
@@ -32,6 +32,11 @@
       <artifactId>jgrapht-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jgrapht</groupId>
+      <artifactId>jgrapht-ext</artifactId>
+      <version>1.0.1</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ClassDependenciesGraph.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ClassDependenciesGraph.java
@@ -27,19 +27,19 @@
  */
 package org.arquillian.smart.testing.strategies.affected;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import org.arquillian.smart.testing.filter.TestVerifier;
 import org.arquillian.smart.testing.strategies.affected.ast.JavaClass;
 import org.arquillian.smart.testing.strategies.affected.ast.JavaClassBuilder;
 import org.jgrapht.DirectedGraph;
 import org.jgrapht.graph.DefaultDirectedGraph;
 import org.jgrapht.graph.DefaultEdge;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.jgrapht.Graphs.predecessorListOf;
 
@@ -75,6 +75,10 @@ public class ClassDependenciesGraph {
             if (javaClass != null) {
                 addToIndex(new JavaElement(javaClass), javaClass.getImports());
             }
+        }
+
+        if (Boolean.valueOf(System.getProperty("smart.testing.debug", "false"))) {
+            new GraphExporter().dumpGraph(this.graph, System.getProperty("graph.name", UUID.randomUUID().toString()));
         }
     }
 

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/GraphExporter.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/GraphExporter.java
@@ -1,0 +1,21 @@
+package org.arquillian.smart.testing.strategies.affected;
+
+import org.jgrapht.DirectedGraph;
+import org.jgrapht.ext.DOTExporter;
+import org.jgrapht.ext.ExportException;
+import org.jgrapht.graph.DefaultEdge;
+
+import java.io.File;
+
+class GraphExporter
+{
+    public void dumpGraph(DirectedGraph<JavaElement, DefaultEdge> graph, String graphName) {
+        try {
+            new DOTExporter<JavaElement, DefaultEdge>(component -> "\"" + component.getClassName() + "\"",
+                null, null)
+                .exportGraph(graph, new File(System.getProperty("java.io.tmpdir") + "/graph-" + graphName + ".dot"));
+        } catch (ExportException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ast/JavaAssistClassParser.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ast/JavaAssistClassParser.java
@@ -78,8 +78,7 @@ class JavaAssistClassParser {
         return classPool;
     }
 
-    private URL[] getLoadedClasses()
-    {
+    private URL[] getLoadedClasses() {
         return ((URLClassLoader) (Thread.currentThread().getContextClassLoader())).getURLs();
     }
 


### PR DESCRIPTION
#### Short description of what this resolves:

While working on issues with Affected strategy I wrote a simple piece of code dumping graph to a `dot` format. This can be later used either using regular text `diff` or make an image out of it. For example 

```shell
$ dot /tmp/graph-test_with_fork_count_one.dot -Tpng
``` 

will produce graph in PNG format.

#### Changes proposed in this pull request:

- `GraphExporter` producing dot files
- Graph is dumped when debug mode is enabled (should be aligned with #91)
- File name is either consisting of `graph.name` property or has random UUID instead

As an example (to be removed before final merge) I used our forking test - this shows that we really need configuration file instead of relying on properties, as we are not propagating them to surefire forked processes and some tests don't dump their graphs.
