### PR TITLE
Fixes build execution when using multiple forks

### DIFF
--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
@@ -70,6 +70,7 @@ public class ProjectBuilder {
                     .setProperties(asProperties(buildConfigurator.getSystemProperties()))
                     .skipTests(buildConfigurator.isSkipTestsEnabled())
                     .setMavenOpts(buildConfigurator.getMavenOpts())
+                    .setAlsoMake(true)
                     .ignoreFailure()
                 .build();
 

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/SurefireForksConfigurationTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/SurefireForksConfigurationTest.java
@@ -39,7 +39,6 @@ public class SurefireForksConfigurationTest {
     }
 
     @Test
-    //@Ignore("FIXME https://github.com/arquillian/smart-testing/issues/124")
     public void test_with_multiple_forks() {
         verifyTestSuiteExecution("forkCount", "2");
     }
@@ -71,7 +70,6 @@ public class SurefireForksConfigurationTest {
             project
                 .build()
                 .options()
-                    //.withRemoteSurefireDebugging()
                     .withSystemProperties(systemPropertiesPairs)
                     .configure()
                 .run();

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/SurefireForksConfigurationTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/SurefireForksConfigurationTest.java
@@ -1,16 +1,14 @@
 package org.arquillian.smart.testing.ftest.configuration;
 
+import java.util.Collection;
+import java.util.List;
 import org.arquillian.smart.testing.ftest.testbed.project.Project;
 import org.arquillian.smart.testing.ftest.testbed.rules.GitClone;
 import org.arquillian.smart.testing.ftest.testbed.rules.TestBed;
 import org.arquillian.smart.testing.ftest.testbed.testresults.TestResult;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.util.Collection;
-import java.util.List;
 
 import static org.arquillian.smart.testing.ftest.testbed.configuration.Mode.SELECTING;
 import static org.arquillian.smart.testing.ftest.testbed.configuration.Strategy.AFFECTED;
@@ -41,7 +39,7 @@ public class SurefireForksConfigurationTest {
     }
 
     @Test
-    @Ignore("FIXME https://github.com/arquillian/smart-testing/issues/124")
+    //@Ignore("FIXME https://github.com/arquillian/smart-testing/issues/124")
     public void test_with_multiple_forks() {
         verifyTestSuiteExecution("forkCount", "2");
     }
@@ -73,6 +71,7 @@ public class SurefireForksConfigurationTest {
             project
                 .build()
                 .options()
+                    //.withRemoteSurefireDebugging()
                     .withSystemProperties(systemPropertiesPairs)
                     .configure()
                 .run();

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/SurefireForksConfigurationTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/SurefireForksConfigurationTest.java
@@ -68,7 +68,7 @@ public class SurefireForksConfigurationTest {
         // when
         final List<TestResult> actualTestResults =
             project
-                .build()
+                .build("config/impl-base")
                 .options()
                     .withSystemProperties(systemPropertiesPairs)
                     .configure()

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/SmartTestingSurefireProvider.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/SmartTestingSurefireProvider.java
@@ -22,6 +22,7 @@ public class SmartTestingSurefireProvider implements SurefireProvider {
     private SurefireProviderFactory surefireProviderFactory;
     private ProviderParameters bootParams;
 
+    @SuppressWarnings("unused") // Used by Surefire Core
     public SmartTestingSurefireProvider(ProviderParameters bootParams) {
         this.bootParams = bootParams;
         this.paramParser = new ProviderParametersParser(this.bootParams);
@@ -36,6 +37,30 @@ public class SmartTestingSurefireProvider implements SurefireProvider {
         this.surefireProvider = surefireProviderFactory.createInstance();
     }
 
+    public Iterable<Class<?>> getSuites() {
+        return getOptimizedTestsToRun((TestsToRun) surefireProvider.getSuites());
+    }
+
+    public RunResult invoke(Object forkTestSet) throws TestSetFailedException, ReporterException, InvocationTargetException {
+        final TestsToRun orderedTests = getTestsToRun(forkTestSet);
+        this.surefireProvider = surefireProviderFactory.createInstance();
+        return surefireProvider.invoke(orderedTests);
+    }
+
+    public void cancel() {
+        surefireProvider.cancel();
+    }
+
+    private TestsToRun getTestsToRun(Object forkTestSet) throws TestSetFailedException {
+        if (forkTestSet instanceof TestsToRun) {
+            return (TestsToRun) forkTestSet;
+        } else if (forkTestSet instanceof Class) {
+            return fromClass((Class<?>) forkTestSet);
+        } else {
+            return (TestsToRun) getSuites();
+        }
+    }
+
     private TestsToRun getOptimizedTestsToRun(TestsToRun testsToRun) {
         Set<TestSelection> selection = SmartTesting
             .with(className -> testsToRun.getClassByName(className) != null)
@@ -48,37 +73,5 @@ public class SmartTestingSurefireProvider implements SurefireProvider {
     private String getBasedir() {
         final String path = this.bootParams.getReporterConfiguration().getReportsDirectory().getPath();
         return path.substring(0, path.indexOf(File.separator + "target"));
-    }
-
-    public Iterable<Class<?>> getSuites() {
-        Iterable<Class<?>> originalSuites = surefireProvider.getSuites();
-        return getOptimizedTestsToRun((TestsToRun) originalSuites);
-    }
-
-    public RunResult invoke(Object forkTestSet)
-        throws TestSetFailedException, ReporterException, InvocationTargetException {
-
-        final TestsToRun orderedTests = getTestsToRun(forkTestSet);
-        if (orderedTests.containsExactly(0)) {
-            orderedTests.markTestSetFinished();
-            return RunResult.noTestsRun();
-        }
-        surefireProvider = surefireProviderFactory.createInstance();
-        return surefireProvider.invoke(orderedTests);
-    }
-
-    private TestsToRun getTestsToRun(Object forkTestSet) throws TestSetFailedException {
-
-        if (forkTestSet instanceof TestsToRun) {
-            return (TestsToRun) forkTestSet;
-        } else if (forkTestSet instanceof Class) {
-            return fromClass((Class<?>) forkTestSet);
-        } else {
-            return (TestsToRun) getSuites();
-        }
-    }
-
-    public void cancel() {
-        surefireProvider.cancel();
     }
 }


### PR DESCRIPTION
#### Short description of what this resolves:

This fix solves the remaining issue when using Smart Testing provider with forked surefires.

What I have noticed during the analysis of this problem is that provider is executed on both sides - the main thread (booter) and forked processes. It can happen that the forked process might have none tests passed (probably) but then we are marking execution of this process as completed with result `noTestsToRun` and we don't call actual provider (delegate). This somehow seems to break the protocol (shared output stream) between fork booter and surefire forks. Thus we have `NoSuchElementException` as we prematurely mark process as finishedin the `CommandReader`

#### Changes proposed in this pull request:

- Removes now not needed check if `orderedTests` contain any elements and mark execution as finished with no tests to run. It was introduced to mitigate the problem of surefire failing when `selecting` mode had no tests for the given module. This is solved by additional method `getTestsToRun()` added after this bit.
- Shuffled `public` and `private` methods in the provider for better structure

Fixes #124
