### PR TITLE
fix(projectDir) The root dir is not retrived only from the reporterConfiguration

### DIFF
--- a/core/src/main/java/org/arquillian/smart/testing/impl/ConfiguredSmartTestingImpl.java
+++ b/core/src/main/java/org/arquillian/smart/testing/impl/ConfiguredSmartTestingImpl.java
@@ -14,7 +14,7 @@ public class ConfiguredSmartTestingImpl implements ConfiguredSmartTesting {
     private final Configuration configuration;
     private TestExecutionPlannerLoader testExecutionPlannerLoader;
     private TestVerifier testVerifier;
-    private File projectDir = new File(System.getProperty("user.dir"));
+    private File projectDir;
 
     public ConfiguredSmartTestingImpl(TestVerifier testVerifier, Configuration configuration) {
         this.testVerifier = testVerifier;
@@ -49,6 +49,9 @@ public class ConfiguredSmartTestingImpl implements ConfiguredSmartTesting {
     }
 
     private TestStrategyApplier createApplier() {
+        if (projectDir == null){
+            projectDir = new File(System.getProperty("basedir"));
+        }
         if (testExecutionPlannerLoader == null) {
             testExecutionPlannerLoader =
                 new TestExecutionPlannerLoaderImpl(new JavaSPILoader(), testVerifier, projectDir);

--- a/core/src/main/java/org/arquillian/smart/testing/impl/TestStrategyApplierImpl.java
+++ b/core/src/main/java/org/arquillian/smart/testing/impl/TestStrategyApplierImpl.java
@@ -112,6 +112,6 @@ class TestStrategyApplierImpl implements TestStrategyApplier {
     }
 
     private boolean isReportEnabled() {
-        return Boolean.valueOf(System.getProperty(ENABLE_REPORT_PROPERTY, Boolean.toString(false)));
+        return Boolean.valueOf(System.getProperty(ENABLE_REPORT_PROPERTY, "false"));
     }
 }

--- a/core/src/main/java/org/arquillian/smart/testing/impl/TestStrategyApplierImpl.java
+++ b/core/src/main/java/org/arquillian/smart/testing/impl/TestStrategyApplierImpl.java
@@ -19,6 +19,8 @@ import org.arquillian.smart.testing.api.TestStrategyApplier;
 import org.arquillian.smart.testing.report.SmartTestingReportGenerator;
 import org.arquillian.smart.testing.spi.TestExecutionPlanner;
 
+import static org.arquillian.smart.testing.report.SmartTestingReportGenerator.ENABLE_REPORT_PROPERTY;
+
 class TestStrategyApplierImpl implements TestStrategyApplier {
 
     private static final Logger logger = Logger.getLogger(TestStrategyApplierImpl.class);
@@ -110,6 +112,6 @@ class TestStrategyApplierImpl implements TestStrategyApplier {
     }
 
     private boolean isReportEnabled() {
-        return Boolean.valueOf(System.getProperty("smart.testing.report.enable", Boolean.toString(false)));
+        return Boolean.valueOf(System.getProperty(ENABLE_REPORT_PROPERTY, Boolean.toString(false)));
     }
 }

--- a/core/src/main/java/org/arquillian/smart/testing/report/ExecutionReportMarshaller.java
+++ b/core/src/main/java/org/arquillian/smart/testing/report/ExecutionReportMarshaller.java
@@ -8,6 +8,8 @@ import java.nio.file.Paths;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 
+import static org.arquillian.smart.testing.report.SmartTestingReportGenerator.DEFAULT_REPORT_FILE_NAME;
+
 class ExecutionReportMarshaller {
 
     private final String reportDir;
@@ -17,7 +19,7 @@ class ExecutionReportMarshaller {
     ExecutionReportMarshaller(String baseDir, String reportDir, String fileName) {
         this.baseDir = baseDir;
         this.reportDir = reportDir != null ? getReportDir(reportDir) : getDefaultReportDir();
-        this.fileName = fileName != null ? getFileName(fileName) : "smart-testing-report.xml";
+        this.fileName = fileName != null ? getFileName(fileName) : DEFAULT_REPORT_FILE_NAME;
     }
 
     void marshal(Object object) {

--- a/core/src/main/java/org/arquillian/smart/testing/report/SmartTestingReportGenerator.java
+++ b/core/src/main/java/org/arquillian/smart/testing/report/SmartTestingReportGenerator.java
@@ -14,6 +14,9 @@ import org.arquillian.smart.testing.report.model.TestConfiguration;
 
 public class SmartTestingReportGenerator {
 
+    public static final String DEFAULT_REPORT_FILE_NAME = "smart-testing-report.xml";
+    public static final String ENABLE_REPORT_PROPERTY = "smart.testing.report.enable";
+
     static final String SMART_TESTING_REPORT_DIR = "smart.testing.report.dir";
     static final String SMART_TESTING_REPORT_NAME = "smart.testing.report.name";
 

--- a/core/src/test/java/org/arquillian/smart/testing/report/ExecutionReporterTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/report/ExecutionReporterTest.java
@@ -6,7 +6,6 @@ import org.arquillian.smart.testing.TestSelection;
 import org.junit.Test;
 
 import static java.util.Arrays.asList;
-import static org.arquillian.smart.testing.report.ExecutionReporterHelper.getBaseDir;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ExecutionReporterTest {
@@ -17,7 +16,7 @@ public class ExecutionReporterTest {
         final TestSelection testSelectionNew = new TestSelection(ExecutionReporterTest.class.getName(), "new");
         final TestSelection testSelectionChanged = new TestSelection(ExecutionReporterTest.class.getName(), "changed");
         final SmartTestingReportGenerator smartTestingReportGenerator =
-            new SmartTestingReportGenerator(asList(testSelectionNew, testSelectionChanged), Configuration.load(),  getBaseDir(getClass()));
+            new SmartTestingReportGenerator(asList(testSelectionNew, testSelectionChanged), Configuration.load(),  System.getProperty("user.dir"));
 
         // when
         smartTestingReportGenerator.generateReport();

--- a/core/src/test/java/org/arquillian/smart/testing/report/ExecutionReporterUsingPropertyTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/report/ExecutionReporterUsingPropertyTest.java
@@ -14,7 +14,6 @@ import org.junit.experimental.categories.Category;
 import static java.util.Arrays.asList;
 import static org.arquillian.smart.testing.Configuration.SMART_TESTING;
 import static org.arquillian.smart.testing.Configuration.SMART_TESTING_MODE;
-import static org.arquillian.smart.testing.report.ExecutionReporterHelper.getBaseDir;
 import static org.arquillian.smart.testing.report.SmartTestingReportGenerator.SMART_TESTING_REPORT_DIR;
 import static org.arquillian.smart.testing.report.SmartTestingReportGenerator.SMART_TESTING_REPORT_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,7 +41,7 @@ public class ExecutionReporterUsingPropertyTest {
         System.setProperty(SMART_TESTING_MODE, "selecting");
         final TestSelection newChangedTestSelection = new TestSelection(ExecutionReporterTest.class.getName(), "new", "changed");
         final TestSelection newTestSelection = new TestSelection(ExecutionReporterUsingPropertyTest.class.getName(), "new");
-        smartTestingReportGenerator = new SmartTestingReportGenerator(asList(newChangedTestSelection, newTestSelection), Configuration.load(), getBaseDir(getClass()));
+        smartTestingReportGenerator = new SmartTestingReportGenerator(asList(newChangedTestSelection, newTestSelection), Configuration.load(), System.getProperty("user.dir"));
 
         // when
         smartTestingReportGenerator.generateReport();

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
@@ -94,6 +94,10 @@ public class ProjectBuilder {
         return builtProject.getMavenLog();
     }
 
+    public BuiltProject getBuiltProject() {
+        return builtProject;
+    }
+
     private Properties asProperties(Map<String, String> propertyMap) {
         final Properties properties = new Properties();
         properties.putAll(propertyMap);

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/SmartTestingSurefireProvider.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/SmartTestingSurefireProvider.java
@@ -64,14 +64,17 @@ public class SmartTestingSurefireProvider implements SurefireProvider {
     private TestsToRun getOptimizedTestsToRun(TestsToRun testsToRun) {
         Set<TestSelection> selection = SmartTesting
             .with(className -> testsToRun.getClassByName(className) != null)
-            .in(getBasedir())
+            .in(getProjectDir())
             .applyOnClasses(testsToRun);
 
         return new TestsToRun(SmartTesting.getClasses(selection));
     }
 
-    private String getBasedir() {
-        final String path = this.bootParams.getReporterConfiguration().getReportsDirectory().getPath();
-        return path.substring(0, path.indexOf(File.separator + "target"));
+    private File getProjectDir() {
+        if (System.getProperty("basedir") == null) {
+            return bootParams.getTestRequest().getTestSourceDirectory().getParentFile().getParentFile().getParentFile();
+        } else {
+            return new File(System.getProperty("basedir"));
+        }
     }
 }


### PR DESCRIPTION
When `basedir` property is null (multiple forks) then project directory is retrieved from `testSourceDirectory` property. 
I expect that the location of the test-source directory is changed less frequently than the location of the reports.

Added also some refactoring changes & test verifying the presence of generated reports in all fork-config test