### PR TITLE
Sets skipAfterFailureCount to 1 for ordering mode (#96)

### DIFF
--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -12,7 +12,7 @@ and then the rest.
 
 In order to define the mode use `smart.testing.mode` Java system property with either one.
 
-IMPORTANT: To get fast feedback loop *Smart testing* is setting `skipAfterFailureCount` to `1`. However you can overwrite it by setting system
+IMPORTANT: To get fast feedback loop *Smart testing* is setting `http://maven.apache.org/surefire/maven-surefire-plugin/examples/skip-after-failure.html[skipAfterFailureCount]` to `1`. However you can overwrite it by setting system
 property `surefire.skipAfterFailureCount` to required value. This behaviour is applicable only if user is using `surefire` plugin to execute
 test having smart testing enabled with `ordering` mode. This is not applicable for `selecting` mode because user can execute all `new/modified/affected`
 tests, identify all failed tests using results and rework on it at once.

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -12,6 +12,11 @@ and then the rest.
 
 In order to define the mode use `smart.testing.mode` Java system property with either one.
 
+IMPORTANT: To get fast feedback loop *Smart testing* is setting `skipAfterFailureCount` to `1`. However you can overwrite it by setting system
+property `surefire.skipAfterFailureCount` to required value. This behaviour is applicable only if user is using `surefire` plugin to execute
+test having smart testing enabled with `ordering` mode. This is not applicable for `selecting` mode because user can execute all `new/modified/affected`
+tests, identify all failed tests using results and rework on it at once.
+
 === Strategies
 
 Until now, you've read that smart testing is changing test execution plan running or only including important tests.

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/SkipAfterFailureCountTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/SkipAfterFailureCountTest.java
@@ -1,0 +1,78 @@
+package org.arquillian.smart.testing.ftest.configuration;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.arquillian.smart.testing.ftest.testbed.project.Project;
+import org.arquillian.smart.testing.ftest.testbed.rules.GitClone;
+import org.arquillian.smart.testing.ftest.testbed.rules.TestBed;
+import org.arquillian.smart.testing.ftest.testbed.testresults.Status;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.arquillian.smart.testing.ftest.testbed.configuration.Mode.ORDERING;
+import static org.arquillian.smart.testing.ftest.testbed.configuration.Strategy.CHANGED;
+import static org.arquillian.smart.testing.ftest.testbed.testresults.Status.SKIPPED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SkipAfterFailureCountTest {
+
+    @ClassRule
+    public static final GitClone GIT_CLONE = new GitClone();
+
+    @Rule
+    public final TestBed testBed = new TestBed(GIT_CLONE);
+
+    @Test
+    public void should_skip_all_remaining_tests_with_first_failure_when_ordering_enabled() throws Exception {
+        // given
+        final Project project = testBed.getProject();
+
+        project.configureSmartTesting()
+            .executionOrder(CHANGED)
+            .inMode(ORDERING)
+            .enable();
+
+        project.applyAsCommits("Introduces error by changing return value");
+
+        // when
+        final Map<Status, Long> resultCount = new LinkedHashMap<>();
+
+        project.build("container/impl-base")
+            .options()
+                .ignoreBuildFailure()
+            .configure()
+            .run(resultCount);
+
+
+        // then
+        final Long skippedCount = resultCount.get(SKIPPED);
+        assertThat(skippedCount).isGreaterThan(4);
+    }
+
+    @Test
+    public void should_override_skip_after_failure_count_system_property_when_ordering_enabled() throws Exception {
+        // given
+        final Project project = testBed.getProject();
+
+        project.configureSmartTesting()
+            .executionOrder(CHANGED)
+            .inMode(ORDERING)
+            .enable();
+
+        project.applyAsCommits("Introduces error by changing return value");
+
+        // when
+        final Map<Status, Long> resultStatusCount = new LinkedHashMap<>();
+        project.build("container/impl-base")
+            .options()
+                .withSystemProperties("surefire.skipAfterFailureCount", "0")
+                .ignoreBuildFailure()
+            .configure()
+            .run(resultStatusCount);
+
+        // then
+        final Long skippedCount = resultStatusCount.get(SKIPPED);
+        assertThat(skippedCount).isEqualTo(4);
+    }
+}

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/SkipAfterFailureCountTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/SkipAfterFailureCountTest.java
@@ -2,23 +2,22 @@ package org.arquillian.smart.testing.ftest.configuration;
 
 import org.arquillian.smart.testing.ftest.testbed.project.Project;
 import org.arquillian.smart.testing.ftest.testbed.project.TestResults;
-import org.arquillian.smart.testing.ftest.testbed.rules.GitClone;
-import org.arquillian.smart.testing.ftest.testbed.rules.TestBed;
-import org.arquillian.smart.testing.ftest.testbed.testresults.TestResult;
+import org.arquillian.smart.testing.rules.TestBed;
+import org.arquillian.smart.testing.rules.git.GitClone;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import static org.arquillian.smart.testing.ftest.configuration.assertions.TestResultAssert.assertThat;
+import static org.arquillian.smart.testing.ftest.testbed.TestRepository.testRepository;
 import static org.arquillian.smart.testing.ftest.testbed.configuration.Mode.ORDERING;
 import static org.arquillian.smart.testing.ftest.testbed.configuration.Strategy.CHANGED;
 import static org.arquillian.smart.testing.ftest.testbed.testresults.Status.SKIPPED;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
 
 public class SkipAfterFailureCountTest {
 
     @ClassRule
-    public static final GitClone GIT_CLONE = new GitClone();
+    public static final GitClone GIT_CLONE = new GitClone(testRepository());
 
     @Rule
     public final TestBed testBed = new TestBed(GIT_CLONE);
@@ -44,13 +43,12 @@ public class SkipAfterFailureCountTest {
 
         // then
         assertThat(testResults.testsWithStatuses(SKIPPED))
-            .extracting(TestResult::getClassName, TestResult::getTestMethod)
-            .contains(
-                tuple("org.jboss.arquillian.container.impl.client.container.ContainerLifecycleControllerTestCase", "org.jboss.arquillian.container.impl.client.container.ContainerLifecycleControllerTestCase"),
-                tuple("org.jboss.arquillian.container.impl.client.container.DeploymentExceptionHandlerTestCase", "org.jboss.arquillian.container.impl.client.container.DeploymentExceptionHandlerTestCase"),
-                tuple("org.jboss.arquillian.container.impl.client.container.ContainerRegistryCreatorTestCase", "org.jboss.arquillian.container.impl.client.container.ContainerRegistryCreatorTestCase"),
-                tuple("org.jboss.arquillian.container.impl.client.container.ContainerDeployControllerTestCase", "org.jboss.arquillian.container.impl.client.container.ContainerDeployControllerTestCase"),
-                tuple("org.jboss.arquillian.container.impl.client.deployment.ArchiveDeploymentExporterTestCase", "org.jboss.arquillian.container.impl.client.deployment.ArchiveDeploymentExporterTestCase")
+            .hasSkippedClasses(
+                "org.jboss.arquillian.container.impl.client.container.ContainerLifecycleControllerTestCase",
+                "org.jboss.arquillian.container.impl.client.container.DeploymentExceptionHandlerTestCase",
+                "org.jboss.arquillian.container.impl.client.container.ContainerRegistryCreatorTestCase",
+                "org.jboss.arquillian.container.impl.client.container.ContainerDeployControllerTestCase",
+                "org.jboss.arquillian.container.impl.client.deployment.ArchiveDeploymentExporterTestCase"
             );
     }
 
@@ -75,14 +73,12 @@ public class SkipAfterFailureCountTest {
             .run();
 
         // then
-        assertThat(testResults.testsWithStatuses(SKIPPED))
-            .extracting(TestResult::getClassName, TestResult::getTestMethod)
-            .doesNotContain(
-                tuple("org.jboss.arquillian.container.impl.client.container.ContainerLifecycleControllerTestCase", "org.jboss.arquillian.container.impl.client.container.ContainerLifecycleControllerTestCase"),
-                tuple("org.jboss.arquillian.container.impl.client.container.DeploymentExceptionHandlerTestCase", "org.jboss.arquillian.container.impl.client.container.DeploymentExceptionHandlerTestCase"),
-                tuple("org.jboss.arquillian.container.impl.client.container.ContainerRegistryCreatorTestCase", "org.jboss.arquillian.container.impl.client.container.ContainerRegistryCreatorTestCase"),
-                tuple("org.jboss.arquillian.container.impl.client.container.ContainerDeployControllerTestCase", "org.jboss.arquillian.container.impl.client.container.ContainerDeployControllerTestCase"),
-                tuple("org.jboss.arquillian.container.impl.client.deployment.ArchiveDeploymentExporterTestCase", "org.jboss.arquillian.container.impl.client.deployment.ArchiveDeploymentExporterTestCase")
+        assertThat(testResults.testsWithStatuses(SKIPPED)).doesNotHaveSkippedClasses(
+                "org.jboss.arquillian.container.impl.client.container.ContainerLifecycleControllerTestCase",
+                "org.jboss.arquillian.container.impl.client.container.DeploymentExceptionHandlerTestCase",
+                "org.jboss.arquillian.container.impl.client.container.ContainerRegistryCreatorTestCase",
+                "org.jboss.arquillian.container.impl.client.container.ContainerDeployControllerTestCase",
+                "org.jboss.arquillian.container.impl.client.deployment.ArchiveDeploymentExporterTestCase"
             );
     }
 }

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/assertions/TestResultAssert.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/assertions/TestResultAssert.java
@@ -1,0 +1,36 @@
+package org.arquillian.smart.testing.ftest.configuration.assertions;
+
+import java.util.Arrays;
+import java.util.List;
+import org.arquillian.smart.testing.ftest.testbed.testresults.TestResult;
+import org.assertj.core.api.ListAssert;
+import org.assertj.core.groups.Tuple;
+
+import static org.assertj.core.api.Assertions.tuple;
+
+public class TestResultAssert extends ListAssert<TestResult> {
+
+    private TestResultAssert(List<TestResult> testResults) {
+        super(testResults);
+    }
+
+    public static TestResultAssert assertThat(List<TestResult> testResults) {
+        return new TestResultAssert(testResults);
+    }
+
+    // Verifying TestResult has same className & methodName, which indicates it's skipped by either
+    // skipAfterFailureCount or `@Ignore` on class level.
+    public TestResultAssert hasSkippedClasses(String... classes) {
+         this.extracting(TestResult::getClassName, TestResult::getTestMethod)
+            .contains(Arrays.stream(classes).map(className -> tuple(className, className)).toArray(Tuple[]::new));
+
+         return this;
+    }
+
+    public TestResultAssert doesNotHaveSkippedClasses(String... classes) {
+        this.extracting(TestResult::getClassName, TestResult::getTestMethod)
+            .doesNotContain(Arrays.stream(classes).map(className -> tuple(className, className)).toArray(Tuple[]::new));
+
+        return this;
+    }
+}

--- a/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/MavenProjectConfigurator.java
+++ b/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/MavenProjectConfigurator.java
@@ -59,10 +59,9 @@ class MavenProjectConfigurator {
         final Xpp3Dom count = pluginConfiguration.getChild(skipAfterFailureCountProperty);
         if (count == null) {
             final Xpp3Dom xpp3Dom = new Xpp3Dom(skipAfterFailureCountProperty);
-            final String skipAfterFailureCount = System.getProperty("surefire.skipAfterFailureCount");
-            final String skipAfterFailureCountValue = skipAfterFailureCount != null ? skipAfterFailureCount : "1";
-
-            xpp3Dom.setValue(skipAfterFailureCountValue);
+            final String failureCount = System.getProperty("surefire.skipAfterFailureCount", "1");
+            xpp3Dom.setValue(failureCount);
+            logger.info("Setting `skipAfterFailureCount` to %s by Smart Testing", failureCount);
             pluginConfiguration.addChild(xpp3Dom);
         }
     }

--- a/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/MavenProjectConfigurator.java
+++ b/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/MavenProjectConfigurator.java
@@ -5,6 +5,7 @@ import java.util.StringJoiner;
 import java.util.stream.Collectors;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginExecution;
 import org.arquillian.smart.testing.Configuration;
 import org.arquillian.smart.testing.Logger;
 import org.arquillian.smart.testing.mvn.ext.dependencies.DependencyResolver;
@@ -39,9 +40,30 @@ class MavenProjectConfigurator {
                     .collect(Collectors.toList()).toString(), model.getArtifactId());
 
             dependencyResolver.addRequiredDependencies(model);
+            effectiveTestRunnerPluginConfigurations.forEach(this::configurePlugin);
+        }
+    }
 
-            effectiveTestRunnerPluginConfigurations
-                .forEach(dependencyResolver::addAsPluginDependency);
+    private void configurePlugin(Plugin testRunnerPlugin) {
+            dependencyResolver.addAsPluginDependency(testRunnerPlugin);
+
+            if (!this.configuration.isSelectingMode()) {
+                final List<PluginExecution> executions = testRunnerPlugin.getExecutions();
+                executions.forEach(this::addSkipAfterFailureCount);
+            }
+    }
+
+    private void addSkipAfterFailureCount(PluginExecution pluginExecution) {
+        final Xpp3Dom pluginConfiguration = getOrCreatePluginConfiguration(pluginExecution);
+        final String skipAfterFailureCountProperty = "skipAfterFailureCount";
+        final Xpp3Dom count = pluginConfiguration.getChild(skipAfterFailureCountProperty);
+        if (count == null) {
+            final Xpp3Dom xpp3Dom = new Xpp3Dom(skipAfterFailureCountProperty);
+            final String skipAfterFailureCount = System.getProperty("surefire.skipAfterFailureCount");
+            final String skipAfterFailureCountValue = skipAfterFailureCount != null ? skipAfterFailureCount : "1";
+
+            xpp3Dom.setValue(skipAfterFailureCountValue);
+            pluginConfiguration.addChild(xpp3Dom);
         }
     }
 
@@ -72,29 +94,13 @@ class MavenProjectConfigurator {
             .collect(Collectors.toList());
     }
 
-    private Xpp3Dom defineTestSelectionCriteria() {
-        final Xpp3Dom strategies = new Xpp3Dom("strategies");
-        final StringJoiner stringJoiner = new StringJoiner(",");
-        for (final String strategy : configuration.getStrategies()) {
-            stringJoiner.add(strategy);
+    private Xpp3Dom getOrCreatePluginConfiguration(PluginExecution pluginExecution) {
+        Xpp3Dom configuration = (Xpp3Dom) pluginExecution.getConfiguration();
+        if (configuration == null) {
+            configuration = new Xpp3Dom("configuration");
+            pluginExecution.setConfiguration(configuration);
         }
-        strategies.setValue(stringJoiner.toString());
-        return strategies;
-    }
-
-    private Xpp3Dom defineUsageMode() {
-        final Xpp3Dom usage = new Xpp3Dom("usage");
-        usage.setValue(configuration.getMode().getName());
-        return usage;
-    }
-
-    private Xpp3Dom getOrCreatePropertiesChild(Xpp3Dom configurationDom) {
-        Xpp3Dom properties = configurationDom.getChild("properties");
-        if (properties == null) {
-            properties = new Xpp3Dom("properties");
-            configurationDom.addChild(properties);
-        }
-        return properties;
+        return configuration;
     }
 
     private void failBecauseOfPluginVersionMismatch(Model model) {

--- a/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/SmartTestingMavenConfigurer.java
+++ b/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/SmartTestingMavenConfigurer.java
@@ -17,6 +17,7 @@ import org.arquillian.smart.testing.spi.JavaSPILoader;
 import org.codehaus.plexus.component.annotations.Component;
 
 import static java.util.stream.StreamSupport.stream;
+import static org.arquillian.smart.testing.Configuration.SMART_TESTING_DISABLE;
 import static org.arquillian.smart.testing.mvn.ext.MavenPropertyResolver.isSkipTestExecutionSet;
 import static org.arquillian.smart.testing.mvn.ext.MavenPropertyResolver.isSpecificTestClassSet;
 
@@ -62,7 +63,7 @@ class SmartTestingMavenConfigurer extends AbstractMavenLifecycleParticipant {
         String reason = "Not Defined";
 
         if (configuration.isDisabled()) {
-            reason = "System Property `SMART_TESTING_DISABLE` is set.";
+            reason = "System Property " + SMART_TESTING_DISABLE + " is set.";
         } else if (isSkipTestExecutionSet()) {
             reason = "Test Execution has been skipped.";
         } else if (isSpecificTestClassSet()) {


### PR DESCRIPTION

#### Short description of what this resolves:
Setting `skipAfterFailureCount` to 1 in case ordering mode

#### Changes proposed in this pull request:

- Sets `skipAfterFailureCount` to 1
- You can override `skipAfterFailureCount` using `surefire.skipAfterFailureCount` property for `ordering` mode



Fixes #96
