### PR TITLE
Removes cloned directory from tmp after test execution

### DIFF
--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/rules/GitClone.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/rules/GitClone.java
@@ -12,7 +12,6 @@ import java.util.Comparator;
 import java.util.logging.Logger;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.lib.Repository;
 import org.junit.rules.ExternalResource;
 
 public class GitClone extends ExternalResource {
@@ -53,7 +52,8 @@ public class GitClone extends ExternalResource {
                 Files.walk(tempFolder.toPath(), FileVisitOption.FOLLOW_LINKS)
                     .sorted(Comparator.reverseOrder())
                     .map(Path::toFile)
-                    .forEach(File::deleteOnExit);
+                    .forEach(File::delete);
+                tempFolder.delete();
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
@@ -83,19 +83,12 @@ public class GitClone extends ExternalResource {
     }
 
     private static void cloneRepository(String repoTarget, String repo) throws GitAPIException, IOException {
-        final Repository repository = Git.cloneRepository()
+        Git.cloneRepository()
                     .setURI(repo)
                     .setDirectory(new File(repoTarget))
                     .setCloneAllBranches(true)
-                .call()
-            .getRepository();
-
-        if (!repository.getFullBranch().endsWith("master")) {
-            Git.wrap(repository)
-                .checkout()
-                    .setName("master")
+                    .setBranch("master")
                 .call();
-        }
 
         LOGGER.info("Cloned test repository to: " + repoTarget);
     }

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/rules/TestBed.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/rules/TestBed.java
@@ -42,15 +42,15 @@ public class TestBed implements TestRule {
 
     private void succeeded(Description description) {
         if (isPersistFolderEnabled()) {
-            copyTmpProjectInTarget();
+            copyTmpProjectToTarget();
         }
     }
 
     private void failed(Throwable e, Description description) {
-        copyTmpProjectInTarget();
+        copyTmpProjectToTarget();
     }
 
-    private void copyTmpProjectInTarget() {
+    private void copyTmpProjectToTarget() {
         String path = "target" + File.separator + "test-bed-executions" + File.separator + Instant.now().toEpochMilli();
         final File projectDir = new File(path);
         if (!projectDir.exists()) {


### PR DESCRIPTION
#### Short description of what this resolves:

The previous implementation didn't clean up cloned repository properly using `deleteOnExit`

#### Changes proposed in this pull request:

- deletes files and git directory immediately on `after` phase
- minor improvements to clone logic.