### PR TITLE
Moved report to target/smart-testing/reporting/report.xml

### DIFF
--- a/core/src/main/java/org/arquillian/smart/testing/Configuration.java
+++ b/core/src/main/java/org/arquillian/smart/testing/Configuration.java
@@ -5,9 +5,6 @@ public class Configuration {
     public static final String DEFAULT_MODE = "selecting";
     public static final String DEFAULT_STRATEGIES = "";
     public static final String ENABLE_REPORT_PROPERTY = "smart.testing.report.enable";
-    public static final String DEFAULT_REPORT_FILE_NAME = "smart-testing-report.xml";
-    public static final String SMART_TESTING_REPORT_DIR = "smart.testing.report.dir";
-    public static final String SMART_TESTING_REPORT_NAME = "smart.testing.report.name";
 
     public static final String SMART_TESTING = "smart.testing";
     public static final String SMART_TESTING_MODE = "smart.testing.mode";

--- a/core/src/main/java/org/arquillian/smart/testing/report/ExecutionReportMarshaller.java
+++ b/core/src/main/java/org/arquillian/smart/testing/report/ExecutionReportMarshaller.java
@@ -1,55 +1,20 @@
 package org.arquillian.smart.testing.report;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 
 class ExecutionReportMarshaller {
 
-    private final String reportDir;
-    private final String fileName;
-    private final String baseDir;
-
-    ExecutionReportMarshaller(String baseDir, String reportDir, String fileName) {
-        this.baseDir = baseDir;
-        this.reportDir = getReportDir(reportDir);
-        this.fileName = getFileName(fileName);
-    }
-
-    void marshal(Object object) {
-        createDirForReport();
+    static void marshal(File reportFile, Object object) {
         try {
             JAXBContext context = JAXBContext.newInstance(object.getClass());
             javax.xml.bind.Marshaller m = context.createMarshaller();
             m.setProperty(javax.xml.bind.Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
 
-            m.marshal(object, getPathForReportFile().toFile());
+            m.marshal(object, reportFile);
         } catch (JAXBException e) {
             throw new IllegalStateException("Error during marshaling execution", e);
         }
-    }
-
-    private void createDirForReport() {
-        try {
-            Files.createDirectories(Paths.get(reportDir));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private Path getPathForReportFile() {
-        return Paths.get(reportDir, fileName);
-    }
-
-    private String getReportDir(String reportDir) {
-        return String.join(File.separator, baseDir, reportDir);
-    }
-
-    private String getFileName(String fileName) {
-       return fileName.endsWith(".xml") ? fileName : fileName + ".xml";
     }
 }

--- a/core/src/test/java/org/arquillian/smart/testing/report/ExecutionReporterTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/report/ExecutionReporterTest.java
@@ -1,11 +1,15 @@
 package org.arquillian.smart.testing.report;
 
-import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.arquillian.smart.testing.Configuration;
 import org.arquillian.smart.testing.TestSelection;
 import org.junit.Test;
 
 import static java.util.Arrays.asList;
+import static org.arquillian.smart.testing.hub.storage.local.AfterExecutionLocalStorage.REPORTING_SUBDIRECTORY;
+import static org.arquillian.smart.testing.hub.storage.local.AfterExecutionLocalStorage.SMART_TESTING_TARGET_DIRECTORY_NAME;
+import static org.arquillian.smart.testing.report.SmartTestingReportGenerator.REPORT_FILE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ExecutionReporterTest {
@@ -22,6 +26,7 @@ public class ExecutionReporterTest {
         smartTestingReportGenerator.generateReport();
 
         // then
-        assertThat(new File("target/smart-testing-report.xml")).exists();
+        Path report = Paths.get("target", SMART_TESTING_TARGET_DIRECTORY_NAME, REPORTING_SUBDIRECTORY, REPORT_FILE_NAME);
+        assertThat(report).exists();
     }
 }

--- a/core/src/test/java/org/arquillian/smart/testing/report/ExecutionReporterUsingPropertyTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/report/ExecutionReporterUsingPropertyTest.java
@@ -1,6 +1,7 @@
 package org.arquillian.smart.testing.report;
 
-import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Properties;
 import net.jcip.annotations.NotThreadSafe;
 import org.arquillian.smart.testing.Configuration;
@@ -14,15 +15,15 @@ import org.junit.experimental.categories.Category;
 import static java.util.Arrays.asList;
 import static org.arquillian.smart.testing.Configuration.SMART_TESTING;
 import static org.arquillian.smart.testing.Configuration.SMART_TESTING_MODE;
-import static org.arquillian.smart.testing.Configuration.SMART_TESTING_REPORT_DIR;
-import static org.arquillian.smart.testing.Configuration.SMART_TESTING_REPORT_NAME;
+import static org.arquillian.smart.testing.hub.storage.local.AfterExecutionLocalStorage.REPORTING_SUBDIRECTORY;
+import static org.arquillian.smart.testing.hub.storage.local.AfterExecutionLocalStorage.SMART_TESTING_TARGET_DIRECTORY_NAME;
+import static org.arquillian.smart.testing.report.SmartTestingReportGenerator.REPORT_FILE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Category(NotThreadSafe.class)
 public class ExecutionReporterUsingPropertyTest {
     
     private static final String REPORT_TO_VERIFY_PATH = "src/test/resources/sample-report.xml";
-    private static final String REPORT_PATH = "target/smart-testing-report/report.xml";
 
     @Rule
     public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
@@ -35,8 +36,6 @@ public class ExecutionReporterUsingPropertyTest {
     @Test
     public void should_generate_report_in_report_dir_with_given_name() {
         // given
-        System.setProperty(SMART_TESTING_REPORT_DIR, "target/smart-testing-report");
-        System.setProperty(SMART_TESTING_REPORT_NAME, "report");
         System.setProperty(SMART_TESTING, "new,changed");
         System.setProperty(SMART_TESTING_MODE, "selecting");
         final TestSelection newChangedTestSelection = new TestSelection(ExecutionReporterTest.class.getName(), "new", "changed");
@@ -47,9 +46,10 @@ public class ExecutionReporterUsingPropertyTest {
         smartTestingReportGenerator.generateReport();
 
         // then
-        assertThat(new File(REPORT_PATH))
+        Path report = Paths.get("target", SMART_TESTING_TARGET_DIRECTORY_NAME, REPORTING_SUBDIRECTORY, REPORT_FILE_NAME);
+        assertThat(report)
             .exists()
-            .hasSameContentAs(new File(REPORT_TO_VERIFY_PATH));
+            .hasSameContentAs(Paths.get(REPORT_TO_VERIFY_PATH));
     }
 
     private static String[] getSmartTestingProperties() {

--- a/core/src/test/resources/sample-report.xml
+++ b/core/src/test/resources/sample-report.xml
@@ -10,8 +10,6 @@
         <properties>
             <property name="smart.testing" value="new,changed"/>
             <property name="smart.testing.mode" value="selecting"/>
-            <property name="smart.testing.report.dir" value="target/smart-testing-report"/>
-            <property name="smart.testing.report.name" value="report"/>
         </properties>
     </executionConfiguration>
     <selection>

--- a/docs/reports.adoc
+++ b/docs/reports.adoc
@@ -21,12 +21,5 @@ include::../core/src/test/resources/sample-report.xml[]
 === Configuration
 
 By default this feature is disabled. You can enable it by setting property `const:core/src/main/java/org/arquillian/smart/testing/Configuration.java[name="ENABLE_REPORT_PROPERTY"]` to `true`.
-
-You will get generated reports in `target/smart-testing-report.xml` by default.
-
-To change the location of the generated output report, following properties
-should be set to the desired alternative location.
-
-`const:core/src/main/java/org/arquillian/smart/testing/Configuration.java[name="SMART_TESTING_REPORT_DIR"]`:: To configure directory where generated reports should be stored.
-`const:core/src/main/java/org/arquillian/smart/testing/Configuration.java[name="SMART_TESTING_REPORT_NAME"]`:: To configure the file name of the generated report.
+If you use the property, then you get the generated reports in `target/const:core/src/main/java/org/arquillian/smart/testing/hub/storage/local/AfterExecutionLocalStorage.java[name="SMART_TESTING_TARGET_DIRECTORY_NAME"]/const:core/src/main/java/org/arquillian/smart/testing/hub/storage/local/AfterExecutionLocalStorage.java[name="REPORTING_SUBDIRECTORY"]/const:core/src/main/java/org/arquillian/smart/testing/Configuration.java[name="REPORT_FILE_NAME"]` for every module separately.
 

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/SurefireForksConfigurationTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/SurefireForksConfigurationTest.java
@@ -12,13 +12,13 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static org.arquillian.smart.testing.Configuration.DEFAULT_REPORT_FILE_NAME;
 import static org.arquillian.smart.testing.Configuration.ENABLE_REPORT_PROPERTY;
-import static org.arquillian.smart.testing.ftest.testbed.TestRepository.testRepository;
 import static org.arquillian.smart.testing.ftest.configuration.CustomAssertions.assertThatAllBuiltSubmodulesContainBuildArtifact;
+import static org.arquillian.smart.testing.ftest.testbed.TestRepository.testRepository;
 import static org.arquillian.smart.testing.ftest.testbed.configuration.Mode.SELECTING;
 import static org.arquillian.smart.testing.ftest.testbed.configuration.Strategy.AFFECTED;
 import static org.arquillian.smart.testing.ftest.testbed.configuration.Strategy.NEW;
+import static org.arquillian.smart.testing.report.SmartTestingReportGenerator.REPORT_FILE_NAME;
 
 public class SurefireForksConfigurationTest {
 
@@ -83,6 +83,6 @@ public class SurefireForksConfigurationTest {
             .run();
         // then
         softly.assertThat(actualTestResults.accumulatedPerTestClass()).containsAll(expectedTestResults).hasSameSizeAs(expectedTestResults);
-        assertThatAllBuiltSubmodulesContainBuildArtifact(projectBuilder.getBuiltProject(), DEFAULT_REPORT_FILE_NAME);
+        assertThatAllBuiltSubmodulesContainBuildArtifact(projectBuilder.getBuiltProject(), REPORT_FILE_NAME);
     }
 }


### PR DESCRIPTION
Changes:
* changed storage directory to: `target/smart-testing/reporting/`
* changed report name to: `report.xml` - IMHO the original `smart-testing-report.xml` had duplicated information that is contained in the directory where the report is stored.
* for storing the report file, I'm using `LocalStorage` logic proposed by: https://github.com/arquillian/smart-testing/pull/159
* removed properties: `smart.testing.report.dir` & `smart.testing.report.name`

Changes proposed by this PR is contained in the commit: https://github.com/arquillian/smart-testing/pull/161/commits/253fb4cd3fce1ac987911b35f8c8076124345cb1

fixes: https://github.com/arquillian/smart-testing/issues/158