### PR TITLE
Suggests closest matching strategy when mistyped

### DIFF
--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/configuration/Strategy.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/configuration/Strategy.java
@@ -1,13 +1,19 @@
 package org.arquillian.smart.testing.ftest.testbed.configuration;
 
-public enum Strategy {
-    AFFECTED,
-    NEW,
-    CHANGED,
-    FAILED;
+public class Strategy {
+    public static final Strategy AFFECTED = new Strategy("affected");
+    public static final Strategy NEW = new Strategy("new");
+    public static final Strategy CHANGED = new Strategy("changed");
+    public static final Strategy FAILED = new Strategy("failed");
+
+    private final String name;
+
+    public Strategy(String name) {
+        this.name = name;
+    }
 
     public String getName() {
-        return this.name().toLowerCase();
+        return this.name.toLowerCase();
     }
 
 }

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/Project.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/Project.java
@@ -32,6 +32,10 @@ public class Project implements AutoCloseable {
         return projectBuilder.getMavenLog();
     }
 
+    public boolean failed() {
+        return projectBuilder.getBuiltProject().getMavenBuildExitCode() != 0;
+    }
+
     public ProjectConfigurator configureSmartTesting() {
         return new ProjectConfigurator(this, root);
     }

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/MisspelledStrategiesFunctionalTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/MisspelledStrategiesFunctionalTest.java
@@ -1,0 +1,53 @@
+package org.arquillian.smart.testing.ftest.configuration;
+
+import org.arquillian.smart.testing.ftest.testbed.configuration.Strategy;
+import org.arquillian.smart.testing.ftest.testbed.project.Project;
+import org.arquillian.smart.testing.rules.TestBed;
+import org.arquillian.smart.testing.rules.git.GitClone;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.arquillian.smart.testing.Configuration.SMART_TESTING_DEBUG;
+import static org.arquillian.smart.testing.ftest.testbed.TestRepository.testRepository;
+import static org.arquillian.smart.testing.ftest.testbed.configuration.Mode.ORDERING;
+import static org.arquillian.smart.testing.scm.ScmRunnerProperties.COMMIT;
+import static org.arquillian.smart.testing.scm.ScmRunnerProperties.PREVIOUS_COMMIT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MisspelledStrategiesFunctionalTest {
+
+    @ClassRule
+    public static final GitClone GIT_CLONE = new GitClone(testRepository());
+
+    @Rule
+    public TestBed testBed = new TestBed(GIT_CLONE);
+
+    @Test
+    public void should_fail_and_log_suggestion_for_misspelled_strategies() throws Exception {
+        // given
+        final Strategy misspelledNew = new Strategy("neew");
+        final Strategy misspelledAffected = new Strategy("affffected");
+
+        final Project project = testBed.getProject();
+        project.configureSmartTesting()
+                .executionOrder(misspelledAffected, misspelledNew)
+                .inMode(ORDERING)
+            .enable();
+
+        // when
+        project.build("config/impl-base")
+                .options()
+                    .ignoreBuildFailure()
+                    .withSystemProperties(COMMIT, "HEAD", PREVIOUS_COMMIT, "HEAD~", SMART_TESTING_DEBUG, "true")
+                .configure()
+            .run();
+
+        // then
+        String projectMavenLog = project.getMavenLog();
+        assertThat(project.failed()).isTrue();
+        assertThat(projectMavenLog).contains("Unable to find strategy [" + misspelledAffected.getName() + "]. Did you mean [affected]?");
+        assertThat(projectMavenLog).contains("Unable to find strategy [" + misspelledNew.getName() + "]. Did you mean [new]?");
+    }
+
+}

--- a/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/dependencies/DependencyResolver.java
+++ b/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/dependencies/DependencyResolver.java
@@ -1,16 +1,20 @@
 package org.arquillian.smart.testing.mvn.ext.dependencies;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
 import org.arquillian.smart.testing.Configuration;
+import org.arquillian.smart.testing.Logger;
 import org.arquillian.smart.testing.mvn.ext.ApplicablePlugins;
 
 public class DependencyResolver {
 
+    private static Logger LOGGER = Logger.getLogger();
     private final Configuration configuration;
+    private final StringSimilarityCalculator stringSimilarityCalculator = new StringSimilarityCalculator();
 
     public DependencyResolver(Configuration configuration) {
         this.configuration = configuration;
@@ -26,9 +30,20 @@ public class DependencyResolver {
         final StrategyDependencyResolver strategyDependencyResolver = new StrategyDependencyResolver();
         model.addDependency(smartTestingProviderDependency());
         final Map<String, Dependency> dependencies = strategyDependencyResolver.resolveDependencies();
-        for (final String strategy : strategies) {
-            final Dependency dependency = dependencies.get(strategy);
-            model.addDependency(dependency);
+        final Map<String, String> strategyMismatch = new HashMap<>();
+        for (final String definedStrategy : strategies) {
+            if (!dependencies.containsKey(definedStrategy)) {
+                final String closestMatch = stringSimilarityCalculator.findClosestMatch(definedStrategy, dependencies.keySet());
+                strategyMismatch.put(definedStrategy, closestMatch);
+            } else {
+                final Dependency dependency = dependencies.get(definedStrategy);
+                model.addDependency(dependency);
+            }
+        }
+        strategyMismatch.forEach((selection, match) -> LOGGER.error("Unable to find strategy [%s]. Did you mean [%s]?", selection, match));
+        if (!strategyMismatch.isEmpty()) {
+            throw new IllegalStateException("Unknown strategies (see above). Please refer to http://arquillian.org/smart-testing/#_strategies "
+                + "for the list of available strategies.");
         }
     }
 

--- a/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/dependencies/StringSimilarityCalculator.java
+++ b/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/dependencies/StringSimilarityCalculator.java
@@ -1,0 +1,58 @@
+package org.arquillian.smart.testing.mvn.ext.dependencies;
+
+import java.util.Collection;
+
+import static java.lang.Math.min;
+
+class StringSimilarityCalculator {
+
+    /**
+     * Finds closest matching string from targets comparing to passed sample using
+     * <a href="https://en.wikipedia.org/wiki/Levenshtein_distance">Levenshtein distance</a> method.
+     *
+     * @param sample string for which the closest matching one will be found
+     * @param targets targets to compare against
+     * @return
+     */
+    String findClosestMatch(String sample, Collection<String> targets) {
+        int distance = sample.length();
+        String closestMatch = "";
+        for (final String target : targets) {
+            final int currentDistance = calculateLevenshteinDistance(sample, target);
+            if (currentDistance < distance) {
+                distance = currentDistance;
+                closestMatch = target;
+            }
+        }
+        return closestMatch;
+    }
+
+    private int calculateLevenshteinDistance(String s, String t) {
+        final int[] previousDistances = new int[t.length() + 1];
+        final int[] currentDistances = new int[t.length() + 1];
+        for (int i = 0; i < previousDistances.length; i++) {
+            previousDistances[i] = i;
+        }
+
+        final char[] source = s.toCharArray();
+        final char[] target = t.toCharArray();
+
+        for (int i = 0; i < source.length; i++) {
+            currentDistances[0] = i + 1;
+            for (int j = 0; j < target.length; j++) {
+                int cost = 1;
+                if (source[i] == target[j]) {
+                    cost = 0;
+                }
+                final int costOfInsertion = currentDistances[j] + 1;
+                final int costOfRemoval = previousDistances[j + 1] + 1;
+                final int costOfSubstitution = previousDistances[j] + cost;
+                currentDistances[j + 1] = min(costOfInsertion, min(costOfRemoval, costOfSubstitution));
+            }
+            System.arraycopy(currentDistances, 0, previousDistances, 0, currentDistances.length);
+        }
+        return currentDistances[target.length];
+    }
+
+
+}

--- a/mvn-extension/src/test/java/org/arquillian/smart/testing/mvn/ext/dependencies/StringSimilarityCalculatorTest.java
+++ b/mvn-extension/src/test/java/org/arquillian/smart/testing/mvn/ext/dependencies/StringSimilarityCalculatorTest.java
@@ -1,0 +1,38 @@
+package org.arquillian.smart.testing.mvn.ext.dependencies;
+
+import java.util.Arrays;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StringSimilarityCalculatorTest {
+
+    @Test
+    public void should_find_exact_match() throws Exception {
+        // given
+        final String sample = "sample";
+
+        // when
+        final String closestMatch =
+            new StringSimilarityCalculator().findClosestMatch(sample, Arrays.asList("smaple", "sapmle", "", "sample"));
+
+        // then
+        assertThat(closestMatch).isEqualTo(sample);
+    }
+
+    @Test
+    public void should_find_match_for_misspelled_strategy() throws Exception {
+        // given
+        final String misspelled = "cahnged";
+        final String expectedWord = "changed";
+
+        // when
+        final String closestMatch =
+            new StringSimilarityCalculator().findClosestMatch(misspelled, Arrays.asList("failed", "affected", "changed", "new"));
+
+        // then
+        assertThat(closestMatch).isEqualTo(expectedWord);
+    }
+
+
+}


### PR DESCRIPTION
#### Short description of what this resolves:

With #171 we introduced an exception informing about not existing strategy. This PR brings a suggestion which one could have been the intended one by still failing the build early, but hinting the user with

```
[ERROR] [Smart Testing Extension] Unable to find strategy [chaenged]. Did you mean [changed]?                                                                                                                                                                                              
[ERROR] [Smart Testing Extension] Unable to find strategy [neew]. Did you mean [new]?                                                                                                                                                                                                      
[ERROR] Internal error: java.lang.IllegalStateException: Unknown strategies (see above). Please refer to http://arquillian.org/smart-testing/#
_strategies for the list of available strategies. -> [Help 1]                                                                                 
org.apache.maven.InternalErrorException: Internal error: java.lang.IllegalStateException: Unknown strategies (see above). Please refer to http
://arquillian.org/smart-testing/#_strategies for the list of available strategies.                                                            
        at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:122)                                                                       
        at org.apache.maven.cli.MavenCli.execute(MavenCli.java:993)    
        at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:345)     
        at org.apache.maven.cli.MavenCli.main(MavenCli.java:191)       
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) 
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)                                                      
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)                                              
        at java.lang.reflect.Method.invoke(Method.java:498)            
        at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)                                                
        at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)                                                        
        at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)                                              
        at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)            
```

Fixes #170 
