### PR TITLE
feat(#166): Adds flag to enable/disable transitivity on affected 

### DIFF
--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -99,6 +99,8 @@ exclusions=org.springframework.*, org.apache.commons.*
 
 IMPORTANT: Exclusions has precedence over inclusions.
 
+You can also disable transitivity by setting `-Dconst:strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/AffectedRunnerProperties.java[name="SMART_TESTING_AFFECTED_TRANSITIVITY"] to `false`.
+
 ****
 
 IMPORTANT: This strategy is currently only applicable for _white box_ testing approach. At this point our approach is to

--- a/docs/refcard.adoc
+++ b/docs/refcard.adoc
@@ -72,6 +72,10 @@ a|`const:strategies/affected/src/main/java/org/arquillian/smart/testing/strategi
 a|
 a|`affected`
 
+a| `const:strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/AffectedRunnerProperties.java[name="SMART_TESTING_AFFECTED_TRANSITIVITY"]`
+|Set transitivity enabled
+a|const:strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/AffectedRunnerProperties.java[name="DEFAULT_SMART_TESTING_AFFECTED_TRANSITIVITY_VALUE"]
+a|`affected`
 |===
 
 === Getting insights of the execution

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/AffectedRunnerProperties.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/AffectedRunnerProperties.java
@@ -11,6 +11,9 @@ class AffectedRunnerProperties {
 
     private static final String SMART_TESTING_AFFECTED_CONFIG = "smart.testing.affected.config";
 
+    static final String SMART_TESTING_AFFECTED_TRANSITIVITY = "smart.testing.affected.transitivity";
+    static final String DEFAULT_SMART_TESTING_AFFECTED_TRANSITIVITY_VALUE = "true";
+
     static final String SMART_TESTING_AFFECTED_EXCLUSIONS = "smart.testing.affected.exclusions";
     static final String SMART_TESTING_AFFECTED_INCLUSIONS = "smart.testing.affected.inclusions";
     static final String INCLUSIONS = "inclusions";
@@ -33,6 +36,11 @@ class AffectedRunnerProperties {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    static boolean getSmartTestingAffectedTransitivity() {
+        return Boolean.parseBoolean(System.getProperty(SMART_TESTING_AFFECTED_TRANSITIVITY,
+            DEFAULT_SMART_TESTING_AFFECTED_TRANSITIVITY_VALUE));
     }
 
     static String getSmartTestingAffectedExclusions() {

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ClassDependenciesGraph.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ClassDependenciesGraph.java
@@ -50,12 +50,14 @@ public class ClassDependenciesGraph {
     private final DirectedGraph<JavaElement, DefaultEdge> graph;
     private final Filter filter;
     private final TestVerifier testVerifier;
+    private final boolean enableTransitivity;
 
     ClassDependenciesGraph(TestVerifier testVerifier) {
         this.builder = new JavaClassBuilder();
         this.graph = new DefaultDirectedGraph<>(DefaultEdge.class);
         this.filter = new Filter(AffectedRunnerProperties.getSmartTestingAffectedInclusions(), AffectedRunnerProperties.getSmartTestingAffectedExclusions());
         this.testVerifier = testVerifier;
+        this.enableTransitivity = AffectedRunnerProperties.getSmartTestingAffectedTransitivity();
     }
 
     void buildTestDependencyGraph(Collection<File> testJavaFiles) {
@@ -102,7 +104,7 @@ public class ClassDependenciesGraph {
 
         for (String importz : imports) {
 
-            if (addImport(javaElementParentClass, importz) && filter.shouldBeIncluded(importz)) {
+            if (addImport(javaElementParentClass, importz) && filter.shouldBeIncluded(importz) && this.enableTransitivity) {
                 JavaClass javaClass = builder.getClassDescription(importz);
                 if (javaClass != null) {
                     updateJavaElementWithImportReferences(javaElementParentClass, javaClass.getImports());

--- a/strategies/affected/src/test/java/org/arquillian/smart/testing/strategies/affected/ClassDependenciesGraphTest.java
+++ b/strategies/affected/src/test/java/org/arquillian/smart/testing/strategies/affected/ClassDependenciesGraphTest.java
@@ -141,6 +141,30 @@ public class ClassDependenciesGraphTest {
     }
 
     @Test
+    public void should_not_detect_all_changes_transitive_if_transitivity_is_disabled() {
+        // given
+        System.setProperty(AffectedRunnerProperties.SMART_TESTING_AFFECTED_TRANSITIVITY, "false");
+        final ClassDependenciesGraph
+            classDependenciesGraph = new ClassDependenciesGraph(new EndingWithTestTestVerifier());
+
+        final String testLocation = ATest.class.getResource("ATest.class").getPath();
+        final String testLocation2 = BTest.class.getResource("BTest.class").getPath();
+        final String testLocation3 = CTest.class.getResource("CTest.class").getPath();
+        classDependenciesGraph.buildTestDependencyGraph(Arrays.asList(new File(testLocation), new File(testLocation2),
+            new File(testLocation3)));
+
+        // when
+        Set<File> mainObjectsChanged = new HashSet<>();
+        mainObjectsChanged.add(new File(D.class.getResource("D.class").getPath()));
+
+        final Set<String> testsDependingOn = classDependenciesGraph.findTestsDependingOn(mainObjectsChanged);
+
+        // then
+        assertThat(testsDependingOn)
+            .isEmpty();
+    }
+
+    @Test
     public void should_exclude_imports_if_property_set() {
         // given
         System.setProperty(AffectedRunnerProperties.SMART_TESTING_AFFECTED_EXCLUSIONS, "org.arquillian.smart.testing.strategies.affected.fakeproject.main.B");


### PR DESCRIPTION
#### Short description of what this resolves:

Adds flag to enable/disable transitivity on affected strategy so in case of big projects containing some "god" classes you can cut the transitivity since affected strategy returns almost all tests to be executed

#### Changes proposed in this pull request:

- Add flag to enable/disable transitivity `smart.testing.affected.transitivity. By default transitivity is enabled.


Fixes: #166
