### PR TITLE
feat(#146): provides installation script

### DIFF
--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -5,7 +5,7 @@
 Ok, just execute following snippet and you are all set:
 
 [[installing]]
-`curl -sS https://git.io/v5jMS | bash` copyToClipboard:installing[]
+`curl -sSL https://git.io/v5jy6 | bash` copyToClipboard:installing[]
 
 You can also add these flags:
 
@@ -15,7 +15,7 @@ You can also add these flags:
 
 For example:
 
-`curl -sS https://git.io/v5jMS | bash -- --latest`
+`curl -sSL https://git.io/v5jy6 | bash -s -- --latest`
 
 This script will automatically do what we described below. If you are curious keep on reading, but you may skip it too.
 

--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -4,8 +4,8 @@
 
 Ok, just execute following snippet and you are all set:
 
-[[installing]]
-`curl -sSL https://git.io/v5jy6 | bash` copyToClipboard:installing[]
+[[installing-release]]
+`curl -sSL https://git.io/v5jy6 | bash` copyToClipboard:installing-release[]
 
 You can also add these flags:
 
@@ -15,7 +15,8 @@ You can also add these flags:
 
 For example:
 
-`curl -sSL https://git.io/v5jy6 | bash -s -- --latest`
+[[installing-latest]]
+`curl -sSL https://git.io/v5jy6 | bash -s +++--+++ --latest` copyToClipboard:installing-latest[]
 
 This script will automatically do what we described below. If you are curious keep on reading, but you may skip it too.
 

--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -9,8 +9,7 @@ Ok, just execute following snippet and you are all set:
 
 You can also add these flags:
 
-  * `-l|--latest` latest published artifact in Maven Central
-  * `-r|--release` latest release (that's the default)
+  * `-l|--latest` latest published artifact in Maven Central (that's the default)
   * `-v|--version=` - specific version to install
 
 For example:

--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -1,14 +1,33 @@
 == Installation
 
+=== Don't make me think
+
+Ok, just execute following snippet and you are all set:
+
+[[installing]]
+`curl -sS https://git.io/v5jMS | bash` copyToClipboard:installing[]
+
+You can also add these flags:
+
+  * `-l|--latest` latest published artifact in Maven Central
+  * `-r|--release` latest release (that's the default)
+  * `-v|--version=` - specific version to install
+
+For example:
+
+`curl -sS https://git.io/v5jMS | bash -- --latest`
+
+This script will automatically do what we described below. If you are curious keep on reading, but you may skip it too.
+
 === Maven Extension
 
-*Smart Testing* is a Maven extension, so needs to be installed as is.
+*Smart Testing* is a Maven extension, so depending on the version of Maven you have to follow slightly different approach of installing it.
 
-==== Maven >= 3.1.X
+==== Maven above 3.1.X
 
-Get Smart Testing _shaded_ copy from https://bintray.com/arquillian/Arquillian/smart-testing[Bintray] and copy it to `M2_HOME/lib/ext`
+Get Smart Testing Extension _shaded jar_ from http://central.maven.org/maven2/org/arquillian/smart/testing/maven-lifecycle-extension/[Maven Central] and copy it to `M2_HOME/lib/ext`.
 
-==== Maven >= 3.3.X
+==== Maven above 3.3.X
 
 You can still use the process described at <<Maven >= 3.1.X>> or use the new _core extension configuration mechanism_ by
 creating folder called `.mvn` in the root of your project and create inside it an `extensions.xml` file

--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -20,6 +20,8 @@ For example:
 
 This script will automatically do what we described below. If you are curious keep on reading, but you may skip it too.
 
+IMPORTANT: This script requires `xmllint`, so make sure you have it installed.
+
 === Maven Extension
 
 *Smart Testing* is a Maven extension, so depending on the version of Maven you have to follow slightly different approach of installing it.

--- a/install.sh
+++ b/install.sh
@@ -2,9 +2,8 @@
 
 MAVEN_METADATA=$(curl -sL http://central.maven.org/maven2/org/arquillian/smart/testing/smart-testing-parent/maven-metadata.xml)
 LATEST=$(echo ${MAVEN_METADATA} | grep -oPm1 "(?<=<latest>)[^<]+")
-RELEASE=$(echo ${MAVEN_METADATA} | grep -oPm1 "(?<=<release>)[^<]+")
 
-VERSION=${RELEASE}
+VERSION=${LATEST}
 INSTALL_SPECIFIC_VERSION="0"
 
 while test $# -gt 0; do
@@ -12,8 +11,7 @@ while test $# -gt 0; do
             -h|--help)
                 echo "Installs Arquillian Smart Testing Extension"
                 echo "options:"
-                echo "-l, --latest                   installs latest version of the extension"
-                echo "-r, --release                  installs latest released version of the extension"
+                echo "-l, --latest                   installs latest version of the extension (default)"
                 echo "-v, --version=VERSION          installs defined version (doesn't check if exists!)"
                 exit 0
                 ;;
@@ -22,18 +20,13 @@ while test $# -gt 0; do
                 VERSION=${LATEST}
                 shift
                 ;;
-            -r|--release)
-                shift
-                VERSION=${RELEASE}
-                shift
-                ;;
             -v)
                 shift
                 if test $# -gt 0; then
                     VERSION=$1
                     INSTALL_SPECIFIC_VERSION="1"
                 else
-                    echo "no version specified"
+                    echo "No version specified."
                     exit 1
                 fi
                 shift

--- a/install.sh
+++ b/install.sh
@@ -122,20 +122,21 @@ function override_version() {
 }
 
 function ignore_smart_testing_artifacts() {
-    read -r -p "Do you want to add Smart Testing execution artifacts to .gitignore? [Y/n] " response
-        case "$response" in
-            [nN][oO]|[nN])
-                ;;
-            *)
-                if [ ! -f .gitignore ]; then
-                    touch ./.gitignore
-                fi
-                cat .gitignore | grep -q '.smart-testing' && EXISTS=1 || EXISTS=0
-                if [ ${EXISTS} == 0 ]; then
-                    echo -e "\n# Smart Testing Exclusions\n.smart-testing/\n" >> ./.gitignore
-                fi
-                ;;
-        esac
+    cat .gitignore | grep -q '.smart-testing' && EXISTS=1 || EXISTS=0
+    if [ ${EXISTS} == 0 ]; then
+        read -r -p "Do you want to add Smart Testing execution artifacts to .gitignore? [Y/n] " response
+            case "$response" in
+                [nN][oO]|[nN])
+                    ;;
+                *)
+                    if [ ! -f .gitignore ]; then
+                        touch ./.gitignore
+                    fi
+
+                        echo -e "\n# Smart Testing Exclusions\n.smart-testing/\n" >> ./.gitignore
+                    ;;
+            esac
+    fi
 }
 
 ## MAIN LOGIC

--- a/install.sh
+++ b/install.sh
@@ -130,7 +130,7 @@ function ignore_smart_testing_artifacts() {
                 fi
                 cat .gitignore | grep -q '.smart-testing' && EXISTS=1 || EXISTS=0
                 if [ ${EXISTS} == 0 ]; then
-                    echo "# Smart Testing Exclusions\n.smart-testing" >> ./.gitignore
+                    echo -e "\n# Smart Testing Exclusions\n.smart-testing/\n" >> ./.gitignore
                 fi
                 ;;
         esac

--- a/install.sh
+++ b/install.sh
@@ -67,7 +67,7 @@ function install_extension() {
     EXTENSION="<extension><groupId>org.arquillian.smart.testing</groupId><artifactId>maven-lifecycle-extension</artifactId><version>${VERSION}</version></extension>"
 
     [ -d .mvn ] || mkdir .mvn
-    
+
     if [ ! -f .mvn/extensions.xml ]; then
         echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
             <extensions>

--- a/install.sh
+++ b/install.sh
@@ -66,6 +66,8 @@ function install_extension() {
     # Needs to be without new lines, otherwise my sed skills below will fail badly :\
     EXTENSION="<extension><groupId>org.arquillian.smart.testing</groupId><artifactId>maven-lifecycle-extension</artifactId><version>${VERSION}</version></extension>"
 
+    [ -d .mvn ] || mkdir .mvn
+    
     if [ ! -f .mvn/extensions.xml ]; then
         echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
             <extensions>

--- a/install.sh
+++ b/install.sh
@@ -137,7 +137,7 @@ function ignore_smart_testing_artifacts() {
                 fi
                 cat .gitignore | grep -q '.smart-testing' && EXISTS=1 || EXISTS=0
                 if [ ${EXISTS} == 0 ]; then
-                    echo "# Smart Testing Exlusions\n.smart-testing" >> ./.gitignore
+                    echo "# Smart Testing Exclusions\n.smart-testing" >> ./.gitignore
                 fi
                 ;;
         esac

--- a/install.sh
+++ b/install.sh
@@ -128,6 +128,9 @@ function override_version() {
 
 ## MAIN LOGIC
 
+command -v mvn >/dev/null 2>&1 || { echo >&2 "Cannot find Maven (mvn). Make sure you have it installed."; exit 1; }
+command -v xmllint >/dev/null 2>&1 || { echo >&2 "This script requires xmllint. Make sure you have it installed."; exit 1; }
+
 MVN_VERSION=$(mvn --version | head -n1 | cut -d' ' -f3)
 
 if [[ $MVN_VERSION =~ ^[3].[3-9].[0-9]$ ]]; then

--- a/install.sh
+++ b/install.sh
@@ -56,6 +56,7 @@ function install_shaded_library() {
         exit 1
     fi
     SHADED_JAR="maven-lifecycle-extension-${VERSION}-shaded.jar"
+    echo "Installing ${SHADED_JAR} into ${M2_HOME}/lib/ext"
     wget http://central.maven.org/maven2/org/arquillian/smart/testing/maven-lifecycle-extension/${VERSION}/${SHADED_JAR}
     read -r -p "We want to move shaded jar to M2_HOME with sudo. Can we? [y/N] " response
     case "$response" in
@@ -83,13 +84,15 @@ function install_extension() {
         if [ ! ${EXTENSION_REGISTERED} ]; then
             EXTENSION=$(echo ${EXTENSION} | sed -e "s#/#\\\/#g");
             sed -i -E 's/(.*<extensions>)(.*)/\1\n'$EXTENSION'\2/g' .mvn/extensions.xml
+            echo "Installed Smart Testing Extension ${VERSION}"
         else
-            echo -e "Extension already registered with version ${EXTENSION_REGISTERED}\c"
+            echo -e "Smart Testing Extension already registered with version ${EXTENSION_REGISTERED}\c"
 
             if [ ${INSTALL_SPECIFIC_VERSION} -eq 1 ]; then
                 if [ "${EXTENSION_REGISTERED}" != "${VERSION}" ]; then
-                    echo -e " - overwritting with ${VERSION}\c"
+                    echo -e " - overwritting with ${VERSION}."
                     override_version $VERSION
+                    echo -e "Updated Smart Testing Extension to ${VERSION}\c"
                 fi
                 echo "."
             elif [ $EXTENSION_REGISTERED != $LATEST ]; then
@@ -97,6 +100,7 @@ function install_extension() {
                 case "$response" in
                     [yY][eE][sS]|[yY])
                           override_version ${LATEST}
+                          echo "Updated Smart Testing Extension to ${LATEST}"
                         ;;
                     *)
 
@@ -125,11 +129,12 @@ function override_version() {
 ## MAIN LOGIC
 
 MVN_VERSION=$(mvn --version | head -n1 | cut -d' ' -f3)
-echo $MVN_VERSION
 
 if [[ $MVN_VERSION =~ ^[3].[3-9].[0-9]$ ]]; then
+    echo "Installing extension in .mvn/extensions.xml"
     install_extension
 elif [[ $MVN_VERSION =~ ^[3].[1-2].[0-9]$ ]]; then
+    echo "Installing extension in M2_HOME/lib/ext"
     install_shaded_library
 else
     echo "Version ${MVN_VERSION} is not supported.";

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+
+MAVEN_METADATA=$(curl -sL http://central.maven.org/maven2/org/arquillian/smart/testing/smart-testing-parent/maven-metadata.xml)
+LATEST=$(echo ${MAVEN_METADATA} | grep -oPm1 "(?<=<latest>)[^<]+")
+RELEASE=$(echo ${MAVEN_METADATA} | grep -oPm1 "(?<=<release>)[^<]+")
+
+VERSION=${RELEASE}
+INSTALL_SPECIFIC_VERSION="0"
+
+while test $# -gt 0; do
+       case "$1" in
+            -h|--help)
+                echo "Installs Arquillian Smart Testing Extension"
+                echo "options:"
+                echo "-l, --latest                   installs latest version of the extension"
+                echo "-r, --release                  installs latest released version of the extension"
+                echo "-v, --version=VERSION          installs defined version (doesn't check if exists!)"
+                exit 0
+                ;;
+            -l|--latest)
+                shift
+                VERSION=${LATEST}
+                shift
+                ;;
+            -r|--release)
+                shift
+                VERSION=${RELEASE}
+                shift
+                ;;
+            -v)
+                shift
+                if test $# -gt 0; then
+                    VERSION=$1
+                    INSTALL_SPECIFIC_VERSION="1"
+                else
+                    echo "no version specified"
+                    exit 1
+                fi
+                shift
+                ;;
+            --version*)
+                VERSION=`echo $1 | sed -e 's/^[^=]*=//g'`
+                INSTALL_SPECIFIC_VERSION="1"
+                shift
+                ;;
+            *)
+               echo "$1 is not a recognized flag!"
+               exit -1
+               ;;
+      esac
+done
+
+function install_shaded_library() {
+    if [ -z "$M2_HOME" ]; then
+        echo "Please set M2_HOME"
+        exit 1
+    fi
+    SHADED_JAR="maven-lifecycle-extension-${VERSION}-shaded.jar"
+    wget http://central.maven.org/maven2/org/arquillian/smart/testing/maven-lifecycle-extension/${VERSION}/${SHADED_JAR}
+    read -r -p "We want to move shaded jar to M2_HOME with sudo. Can we? [y/N] " response
+    case "$response" in
+        [yY][eE][sS]|[yY])
+              sudo mv $SHADED_JAR $M2_HOME/lib/ext
+            ;;
+        *)
+            ;;
+    esac
+}
+
+function install_extension() {
+
+    # Needs to be without new lines, otherwise my sed skills below will fail badly :\
+    EXTENSION="<extension><groupId>org.arquillian.smart.testing</groupId><artifactId>maven-lifecycle-extension</artifactId><version>${VERSION}</version></extension>"
+
+    if [ ! -f .mvn/extensions.xml ]; then
+        echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+            <extensions>
+              ${EXTENSION}
+            </extensions>" > .mvn/extensions.xml
+    else
+        EXTENSION_REGISTERED=$(cat .mvn/extensions.xml | grep 'org.arquillian.smart.testing' -A 2 |  grep -oPm1 "(?<=<version>)[^<]+");
+
+        if [ ! ${EXTENSION_REGISTERED} ]; then
+            EXTENSION=$(echo ${EXTENSION} | sed -e "s#/#\\\/#g");
+            sed -i -E 's/(.*<extensions>)(.*)/\1\n'$EXTENSION'\2/g' .mvn/extensions.xml
+        else
+            echo -e "Extension already registered with version ${EXTENSION_REGISTERED}\c"
+
+            if [ ${INSTALL_SPECIFIC_VERSION} -eq 1 ]; then
+                if [ "${EXTENSION_REGISTERED}" != "${VERSION}" ]; then
+                    echo -e " - overwritting with ${VERSION}\c"
+                    override_version $VERSION
+                fi
+                echo "."
+            elif [ $EXTENSION_REGISTERED != $LATEST ]; then
+                read -r -p ". Do you want to override with latest ${LATEST}? [y/N] " response
+                case "$response" in
+                    [yY][eE][sS]|[yY])
+                          override_version ${LATEST}
+                        ;;
+                    *)
+
+                        ;;
+                esac
+            else
+                echo " which is the latest stable version."
+            fi
+        fi
+    fi
+
+    mv .mvn/extensions.xml .mvn/extensions-unformatted.xml
+    xmllint --format .mvn/extensions-unformatted.xml > .mvn/extensions.xml
+    rm .mvn/extensions-unformatted.xml
+}
+
+function override_version() {
+    cat .mvn/extensions.xml | awk -v groupId="org.arquillian.smart.testing" -v version=$1 -v RS="</extension>" '
+      $0 ~ "<groupId>" groupId "</groupId>" {
+        sub("<version>.*</version>", "<version>" version "</version>")
+      }
+      {printf "%s", $0 RS}' | sed '$ d' > .mvn/extensions-new.xml
+    mv .mvn/extensions-new.xml .mvn/extensions.xml
+}
+
+## MAIN LOGIC
+
+MVN_VERSION=$(mvn --version | head -n1 | cut -d' ' -f3)
+echo $MVN_VERSION
+
+if [[ $MVN_VERSION =~ ^[3].[3-9].[0-9]$ ]]; then
+    install_extension
+elif [[ $MVN_VERSION =~ ^[3].[1-2].[0-9]$ ]]; then
+    install_shaded_library
+else
+    echo "Version ${MVN_VERSION} is not supported.";
+fi
+


### PR DESCRIPTION
#### Short description of what this resolves:

Installation script which simplifies getting started experience with our tool. 

`curl -sSL https://git.io/v5jD6 | bash` 

notice that the `git.io` URL in the docs is different - it points to `master` which will be working only after we merge this PR. See the docs for more options or 

1. Creates  `.mvn/extension.xml` with ST configured to latest (using Maven Central metadata) if the extension file does not exist
2. In case `.mvn/extension.xml` has other extensions defined ours is added to it 
3. If our extension is already defined and has older version we ask to overwrite and do it automatically
4. Detects if we can use extension mechanism, otherwise rollback to [pre Maven `3.3.x` version](http://arquillian.org/smart-testing/#_maven_3_1_x) - before merging we have to decide on #175  (for old way of installation we don't do any of the overwrites/updates as in points above - it's just a simple copy)

Tested only on Fedora, would be good to try on OSX before merging.

#### Changes proposed in this pull request:

- bash installation script
- updated docs

Fixes #146 
