### PR TITLE
fix: made the AffectedRunnerProperties a normal class with constructor

### DIFF
--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/AffectedRunnerProperties.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/AffectedRunnerProperties.java
@@ -19,14 +19,17 @@ class AffectedRunnerProperties {
     static final String INCLUSIONS = "inclusions";
     static final String EXCLUSIONS = "exclusions";
 
-    static final Properties properties = new Properties();
+    private final Properties properties = new Properties();
 
-    // To just read once the configuration file.
-    static {
+    AffectedRunnerProperties(){
         readFile(System.getProperty(SMART_TESTING_AFFECTED_CONFIG));
     }
 
-    static void readFile(String location) {
+    AffectedRunnerProperties(String csvLocation) {
+        readFile(csvLocation);
+    }
+
+    void readFile(String location) {
         if (location == null) {
             return;
         }
@@ -38,26 +41,26 @@ class AffectedRunnerProperties {
         }
     }
 
-    static boolean getSmartTestingAffectedTransitivity() {
+    boolean getSmartTestingAffectedTransitivity() {
         return Boolean.parseBoolean(System.getProperty(SMART_TESTING_AFFECTED_TRANSITIVITY,
             DEFAULT_SMART_TESTING_AFFECTED_TRANSITIVITY_VALUE));
     }
 
-    static String getSmartTestingAffectedExclusions() {
+    String getSmartTestingAffectedExclusions() {
         String exclusions = System.getProperty(SMART_TESTING_AFFECTED_EXCLUSIONS);
         String exclusionsFromFile = properties.getProperty(EXCLUSIONS);
 
         return resolve(exclusions, exclusionsFromFile);
     }
 
-    static String getSmartTestingAffectedInclusions() {
+    String getSmartTestingAffectedInclusions() {
         String inclusions = System.getProperty(SMART_TESTING_AFFECTED_INCLUSIONS);
         String inclusionsFromFile = properties.getProperty(INCLUSIONS);
 
         return resolve(inclusions, inclusionsFromFile);
     }
 
-    static String resolve(String expressions, String fileExpressions) {
+    String resolve(String expressions, String fileExpressions) {
         StringJoiner joiner = new StringJoiner(", ");
         if (expressions != null) {
             joiner.add(expressions);
@@ -68,6 +71,10 @@ class AffectedRunnerProperties {
         }
 
         return joiner.toString().trim();
+    }
+
+    String getProperty(String key){
+        return properties.getProperty(key);
     }
 
 }

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ClassDependenciesGraph.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ClassDependenciesGraph.java
@@ -55,9 +55,10 @@ public class ClassDependenciesGraph {
     ClassDependenciesGraph(TestVerifier testVerifier) {
         this.builder = new JavaClassBuilder();
         this.graph = new DefaultDirectedGraph<>(DefaultEdge.class);
-        this.filter = new Filter(AffectedRunnerProperties.getSmartTestingAffectedInclusions(), AffectedRunnerProperties.getSmartTestingAffectedExclusions());
+        AffectedRunnerProperties affectedRunnerProperties = new AffectedRunnerProperties();
+        this.filter = new Filter(affectedRunnerProperties.getSmartTestingAffectedInclusions(), affectedRunnerProperties.getSmartTestingAffectedExclusions());
         this.testVerifier = testVerifier;
-        this.enableTransitivity = AffectedRunnerProperties.getSmartTestingAffectedTransitivity();
+        this.enableTransitivity = affectedRunnerProperties.getSmartTestingAffectedTransitivity();
     }
 
     void buildTestDependencyGraph(Collection<File> testJavaFiles) {

--- a/strategies/affected/src/test/java/org/arquillian/smart/testing/strategies/affected/AffectedRunnerPropertiesTest.java
+++ b/strategies/affected/src/test/java/org/arquillian/smart/testing/strategies/affected/AffectedRunnerPropertiesTest.java
@@ -12,9 +12,9 @@ public class AffectedRunnerPropertiesTest {
         final String csvLocation = AffectedRunnerProperties.class.getResource("/config.properties").getPath();
 
         // when
-        AffectedRunnerProperties.readFile(csvLocation);
-        final String smartTestingAffectedExclusions = AffectedRunnerProperties.resolve(null,
-            AffectedRunnerProperties.properties.getProperty(AffectedRunnerProperties.EXCLUSIONS));
+        AffectedRunnerProperties affectedRunnerProperties = new AffectedRunnerProperties(csvLocation);
+        final String smartTestingAffectedExclusions = affectedRunnerProperties.resolve(null,
+            affectedRunnerProperties.getProperty(AffectedRunnerProperties.EXCLUSIONS));
 
         // then
         assertThat(smartTestingAffectedExclusions).isEqualTo("a, b, c");
@@ -26,9 +26,10 @@ public class AffectedRunnerPropertiesTest {
         final String csvLocation = AffectedRunnerProperties.class.getResource("/config.properties").getPath();
 
         // when
-        AffectedRunnerProperties.readFile(csvLocation);
-        final String smartTestingAffectedInclusions = AffectedRunnerProperties.resolve(null,
-            AffectedRunnerProperties.properties.getProperty(AffectedRunnerProperties.INCLUSIONS));
+        AffectedRunnerProperties affectedRunnerProperties = new AffectedRunnerProperties(csvLocation);
+        affectedRunnerProperties.readFile(csvLocation);
+        final String smartTestingAffectedInclusions = affectedRunnerProperties.resolve(null,
+            affectedRunnerProperties.getProperty(AffectedRunnerProperties.INCLUSIONS));
 
         // then
         assertThat(smartTestingAffectedInclusions).isEqualTo("d, e");


### PR DESCRIPTION
Made the `AffectedRunnerProperties` a normal class with a constructor to not share its state (the properties variable) between modules in a non-thread-safe way.
And also to make it testable as it was influenced by the test classes executed before `ClassDependenciesGraphTest`

As a side effect the test `ClassDependenciesGraphTest` failed in IDE:
Fixes #179 
