### PR TITLE
fix(#165): TestVerifier is executed only in Java files

### DIFF
--- a/core/src/main/java/org/arquillian/smart/testing/api/TestVerifier.java
+++ b/core/src/main/java/org/arquillian/smart/testing/api/TestVerifier.java
@@ -16,6 +16,11 @@ public interface TestVerifier {
      * @return Whether the given path to a resource represents a test class or not
      */
     default boolean isTest(Path resource) {
+
+        if (!isJavaFile(resource)) {
+            return false;
+        }
+
         final String className = new ClassNameExtractor().extractFullyQualifiedName(resource);
         return isTest(className);
     }
@@ -27,9 +32,15 @@ public interface TestVerifier {
      * @return Whether the given path to a resource represents a non-test class or not
      */
     default boolean isCore(Path resource) {
+        if (!isJavaFile(resource)) {
+            return false;
+        }
         return !isTest(resource);
     }
 
+    default boolean isJavaFile(Path file) {
+        return file.toString().endsWith(".java");
+    }
 
     /**
      * Check whether the given {@link TestSelection} instance represents a test class or not


### PR DESCRIPTION
#### Short description of what this resolves:

TestVerifier is executed only in Java files

#### Changes proposed in this pull request:

- `TestVerifier` methods return false if given path is not a Java file


Fixes #165 
