### PR TITLE
feat(#147): introduces per-pr docs build and tagged versions

### DIFF
--- a/.asciidoctor/generate.sh
+++ b/.asciidoctor/generate.sh
@@ -35,10 +35,6 @@ if [ ! -z "${TRAVIS_TAG}" ]; then
     TARGET_FOLDER="${TRAVIS_TAG}"
 fi
 
-if [ -z "${TARGET_FOLDER// }" ] && [ "${TRAVIS_BRANCH}" != "master" ]; then
-    TARGET_FOLDER="preview/${TRAVIS_COMMIT}"
-fi
-
 echo "Generating doc in $TARGET_FOLDER"
 
 docker run -v ${WORKING_DIR}:/docs/ --name adoc-to-html rochdev/alpine-asciidoctor:mini asciidoctor \

--- a/.asciidoctor/generate.sh
+++ b/.asciidoctor/generate.sh
@@ -25,11 +25,27 @@ done
 
 WORKING_DIR=${TRAVIS_BUILD_DIR:-${PWD}}
 
+TARGET_FOLDER=""
+
+if [ ! -z "${TRAVIS_PULL_REQUEST// }" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+    TARGET_FOLDER="pr/${TRAVIS_PULL_REQUEST}"
+fi
+
+if [ ! -z "${TRAVIS_TAG}" ]; then
+    TARGET_FOLDER="${TRAVIS_TAG}"
+fi
+
+if [ -z "${TARGET_FOLDER// }" ] && [ "${TRAVIS_BRANCH}" != "master" ]; then
+    TARGET_FOLDER="preview/${TRAVIS_COMMIT}"
+fi
+
+echo "Generating doc in $TARGET_FOLDER"
+
 docker run -v ${WORKING_DIR}:/docs/ --name adoc-to-html rochdev/alpine-asciidoctor:mini asciidoctor \
     -r /docs/.asciidoctor/lib/const-inline-macro.rb \
     -r /docs/.asciidoctor/lib/copy-to-clipboard-inline-macro.rb \
     -a generated-doc=true -a asciidoctor-source=/docs/docs \
-    /docs/README.adoc -o /docs/gh-pages/index.html --trace;
+    /docs/README.adoc -o /docs/gh-pages/${TARGET_FOLDER}/index.html --trace;
 
 docker ps -a | grep -q 'Exited (0)' && FAILED=0 || FAILED=1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,7 @@ after_success:
       git add .;
       git commit -m"docs: publishes new documentation";
       git push --quiet "${GH_REF}" gh-pages > /dev/null 2>&1;
+      echo ${TRAVIS_PULL_REQUEST};
       if [ ! -z "${TRAVIS_PULL_REQUEST// }" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
           curl https://api.github.com/repos/arquillian/smart-testing/issues/${TRAVIS_PULL_REQUEST}/comments -H "Authorization:token ${GH_TOKEN}" \
               -X POST -d "{ \"body\": \"Documentation ready for preview at http://arquillian.org/smart-testing/pr/${TRAVIS_PULL_REQUEST}\"}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
   - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
   - MODIFIED_DOCS=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -E 'README.adoc|^docs/.*.adoc$' | wc -l)
   - git describe --tags --exact-match HEAD >/dev/null 2>&1 && TAGGED=0 || TAGGED=1
+  - 'echo $TRAVIS_TAG'
   - '[ $TAGGED -eq 0 ] || [ $(git log --format=%B  $TRAVIS_COMMIT_RANGE | grep -i "\[gen docs\]" | wc -l) -gt 0 ] || [ $MODIFIED_DOCS -ge 1 ] && GENERATE_DOC=0 || GENERATE_DOC=1'
   - 'if [ $GENERATE_DOC -eq 0 ]; then
       git config user.name "${GH_USER}";

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ before_script:
             git commit -m"docs: cleans up closed PR doc preview";
             git push --quiet "${GH_REF}" gh-pages > /dev/null 2>&1;
         fi
-        cd -;
+        cd ..;
       fi
   '
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ after_success:
       cd gh-pages;
       git add .;
       git commit -m"docs: publishes new documentation";
-      git push --quiet "${GH_REF}" gh-pages > /dev/null 2>&1;
+      git push "${GH_REF}" gh-pages > /dev/null 2>&1;
       echo ${TRAVIS_PULL_REQUEST};
       if [ ! -z "${TRAVIS_PULL_REQUEST// }" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
         curl https://api.github.com/repos/arquillian/smart-testing/issues/${TRAVIS_PULL_REQUEST}/comments -H "Authorization:token ${GH_TOKEN}" -X POST -d "{ \"body\": \"Documentation ready for preview at http://arquillian.org/smart-testing/pr/${TRAVIS_PULL_REQUEST}\"}";

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ before_script:
             if [ "${PR_CLOSED}" == "204" ]; then
                 UPDATE_GH_PAGES=1;
                 rm -rf pr/${pr};
+                curl https://api.github.com/repos/arquillian/smart-testing/issues/${pr}/comments -H "Authorization:token ${GH_TOKEN}" -X POST -d "{ \"body\": \"Documentation was merged with master - latest version you can find at http://arquillian.org/smart-testing/.\"}";
             fi
         done;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,8 +75,7 @@ after_success:
       git push --quiet "${GH_REF}" gh-pages > /dev/null 2>&1;
       echo ${TRAVIS_PULL_REQUEST};
       if [ ! -z "${TRAVIS_PULL_REQUEST// }" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
-          curl https://api.github.com/repos/arquillian/smart-testing/issues/${TRAVIS_PULL_REQUEST}/comments -H "Authorization:token ${GH_TOKEN}" \
-              -X POST -d "{ \"body\": \"Documentation ready for preview at http://arquillian.org/smart-testing/pr/${TRAVIS_PULL_REQUEST}\"}"
+          curl https://api.github.com/repos/arquillian/smart-testing/issues/${TRAVIS_PULL_REQUEST}/comments -H "Authorization:token ${GH_TOKEN}" -X POST -d "{ \"body\": \"Documentation ready for preview at http://arquillian.org/smart-testing/pr/${TRAVIS_PULL_REQUEST}\"}"
       fi
     fi'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,15 @@ before_script:
   # Cleanup PR doc previews - until we figure out how to have a webhook on closing the PR
   - 'if [ "${BRANCH}" == "master" ]; then
         cd gh-pages;
+        UPDATE_GH_PAGES=0;
+        for pr in $(ls -1p pr/ >/dev/null 2>&1 | grep "/$" | sed "s/\/$//"); do
+            PR_CLOSED=$(curl https://api.github.com/repos/arquillian/smart-testing/pulls/$pr/merge -H "Authorization:token ${GH_TOKEN}" -I -s -o /dev/null -w "%{http_code}");
+            if [ "${PR_CLOSED}" == "204" ]; then
+                UPDATE_GH_PAGES=1;
+                rm -rf pr/${pr};
+            fi
+        done;
+
         
         cd ..;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,9 +75,7 @@ after_success:
       git commit -m"docs: publishes new documentation";
       git push --quiet "${GH_REF}" gh-pages > /dev/null 2>&1;
       if [ ! -z "${TRAVIS_PULL_REQUEST// }" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
-        curl https://api.github.com/repos/arquillian/smart-testing/issues/${TRAVIS_PULL_REQUEST}/comments \
-        -H "Authorization:token ${GH_TOKEN}" -X POST \
-        -d "{ \"body\": \"Greeting earthlings! Documentation is ready for preview at http://arquillian.org/smart-testing/pr/${TRAVIS_PULL_REQUEST}. Just be patient. It might take a few minutes for the changes to show up.\"}";
+        curl https://api.github.com/repos/arquillian/smart-testing/issues/${TRAVIS_PULL_REQUEST}/comments -H "Authorization:token ${GH_TOKEN}" -X POST -d "{ \"body\": \"Greeting earthlings! Documentation is ready for preview at http://arquillian.org/smart-testing/pr/${TRAVIS_PULL_REQUEST}. Just be patient. It might take a few minutes for the changes to show up.\"}";
       fi;
     fi'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ before_install:
   - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
   - MODIFIED_DOCS=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -E 'README.adoc|^docs/.*.adoc$' | wc -l)
   - '[ $(git log --format=%B  $TRAVIS_COMMIT_RANGE | grep -i "\[gen docs\]" | wc -l) -gt 0 ] && [ $MODIFIED_DOCS -ge 1 ] && GENERATE_DOC=0 || GENERATE_DOC=1'
-  - 'if [ $FORCE_DOC_GEN -eq 0 ] || [ $GENERATE_DOC -eq 0 ]; then
+  - 'echo $GENERATE_DOC'
+  - 'if [ $GENERATE_DOC -eq 0 ]; then
       git config user.name "${GH_USER}";
       git config user.email "${GH_EMAIL}";
       git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*;

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ cache:
 before_install:
   - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
   - MODIFIED_DOCS=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -E 'README.adoc|^docs/.*.adoc$' | wc -l)
+  - 'echo  $(git log --format=%B  $TRAVIS_COMMIT_RANGE | grep -i "\[gen docs\]" | wc -l)'
+  - 'echo $(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -E "README.adoc|^docs/.*.adoc$" | wc -l)'
   - '[ $(git log --format=%B  $TRAVIS_COMMIT_RANGE | grep -i "\[gen docs\]" | wc -l) -gt 0 ] || [ $MODIFIED_DOCS -ge 1 ] && GENERATE_DOC=0 || GENERATE_DOC=1'
   - 'echo $GENERATE_DOC'
   - 'if [ $GENERATE_DOC -eq 0 ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,12 @@ before_script:
             fi
         done;
 
-        
+        if [ $UPDATE_GH_PAGES -eq 1 ]; then
+            git add .;
+            git commit -m"docs: cleans up closed PR doc previews";
+            git push --quiet "${GH_REF}" gh-pages > /dev/null 2>&1;
+        fi;
+
         cd ..;
       fi
   '

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,11 +48,7 @@ before_script:
             fi
         done;
 
-        if [ $UPDATE_GH_PAGES -eq 1 ]; then
-            git add .;
-            git commit -m"docs: cleans up closed PR doc preview";
-            git push --quiet "${GH_REF}" gh-pages > /dev/null 2>&1;
-        fi
+        
         cd ..;
       fi
   '

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,23 +37,24 @@ before_script:
   - wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz -P /home/travis/.arquillian/resolver/maven/download
   - tar -xf /home/travis/.arquillian/resolver/maven/download/apache-maven-3.3.9-bin.tar.gz -C ~/.arquillian/mvn
   # Cleanup PR doc previews - until we figure out how to have a webhook on closing the PR
-  - 'echo $BRANCH'
-  - 'if [ "$BRANCH" == "master" ]; then
-      cd gh-pages;
-      UPDATE_GH_PAGES=0
-      for pr in $(ls -1p pr/ | grep "/$" | sed "s/\/$//"); do
-        CLOSED=$(curl https://api.github.com/repos/arquillian/smart-testing/pulls/$pr/merge -H "Authorization:token ${GH_TOKEN}" -I -s -o /dev/null -w "%{http_code}")
-        if [ "$CLOSED" == "204" ]; then
-          UPDATE_GH_PAGES=1
-          rm -rf pr/${pr}
-        fi
-      done
-      if [ $UPDATE_GH_PAGES -eq 1 ]; then
-        git commit -m"docs: cleans up closed PR doc preview";
-        git push --quiet "${GH_REF}" gh-pages > /dev/null 2>&1;
+  - '
+      if [ "${BRANCH}" == "master" ]; then
+          cd gh-pages
+          UPDATE_GH_PAGES=0
+          for pr in $(ls -1p pr/ | grep "/$" | sed "s/\/$//"); do
+              PR_CLOSED=$(curl https://api.github.com/repos/arquillian/smart-testing/pulls/$pr/merge -H "Authorization:token ${GH_TOKEN}" -I -s -o /dev/null -w "%{http_code}")
+              if [ "${PR_CLOSED}" == "204" ]; then
+                  UPDATE_GH_PAGES=1
+                  rm -rf pr/${pr}
+              fi
+          done
+
+          if [ ${UPDATE_GH_PAGES} -eq 1 ]; then
+              git commit -m"docs: cleans up closed PR doc preview";
+              git push --quiet "${GH_REF}" gh-pages > /dev/null 2>&1;
+          fi
+          cd -
       fi
-      cd -
-     fi
   '
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ cache:
 before_install:
   - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
   - MODIFIED_DOCS=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -E 'README.adoc|^docs/.*.adoc$' | wc -l)
-  - '[ $(git log --format=%B  $TRAVIS_COMMIT_RANGE | grep -i "\[gen docs\]" | wc -l) -gt 0 ] || [ $MODIFIED_DOCS -ge 1 ] && GENERATE_DOC=0 || GENERATE_DOC=1'
-  - 'echo $GENERATE_DOC'
+  - git describe --tags --exact-match HEAD >/dev/null 2>&1 && TAGGED=0 || TAGGED=1
+  - '[ $TAGGED -eq 0 ] || [ $(git log --format=%B  $TRAVIS_COMMIT_RANGE | grep -i "\[gen docs\]" | wc -l) -gt 0 ] || [ $MODIFIED_DOCS -ge 1 ] && GENERATE_DOC=0 || GENERATE_DOC=1'
   - 'if [ $GENERATE_DOC -eq 0 ]; then
       git config user.name "${GH_USER}";
       git config user.email "${GH_EMAIL}";

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,19 +39,7 @@ before_script:
   # Cleanup PR doc previews - until we figure out how to have a webhook on closing the PR
   - 'if [ "${BRANCH}" == "master" ]; then
         cd gh-pages;
-        UPDATE_GH_PAGES=0;
-        for pr in $(ls -1p pr/ >/dev/null 2>&1 | grep "/$" | sed "s/\/$//"); do
-            PR_CLOSED=$(curl https://api.github.com/repos/arquillian/smart-testing/pulls/$pr/merge -H "Authorization:token ${GH_TOKEN}" -I -s -o /dev/null -w "%{http_code}");
-            if [ "${PR_CLOSED}" == "204" ]; then
-                UPDATE_GH_PAGES=1;
-                rm -rf pr/${pr};
-            fi
-        done;
-
-        if [ $UPDATE_GH_PAGES -eq 1 ]; then
-            git commit -m"docs: cleans up closed PR doc preview";
-            git push --quiet "${GH_REF}" gh-pages > /dev/null 2>&1;
-        fi
+        
         cd ..;
       fi
   '

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_script:
   - wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz -P /home/travis/.arquillian/resolver/maven/download
   - tar -xf /home/travis/.arquillian/resolver/maven/download/apache-maven-3.3.9-bin.tar.gz -C ~/.arquillian/mvn
   # Cleanup PR doc previews - until we figure out how to have a webhook on closing the PR
+  - 'echo $BRANCH'
   - 'if [ "$BRANCH" == "master" ]; then
       cd gh-pages;
       UPDATE_GH_PAGES=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_script:
   - wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz -P /home/travis/.arquillian/resolver/maven/download
   - tar -xf /home/travis/.arquillian/resolver/maven/download/apache-maven-3.3.9-bin.tar.gz -C ~/.arquillian/mvn
   # Cleanup PR doc previews - until we figure out how to have a webhook on closing the PR
-  - '
+  - ' echo $(ls -1p pr/ >/dev/null 2>&1 | grep "/$" | sed "s/\/$//")
       if [ "${BRANCH}" == "master" ]; then
           cd gh-pages
           UPDATE_GH_PAGES=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_script:
   - wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz -P /home/travis/.arquillian/resolver/maven/download
   - tar -xf /home/travis/.arquillian/resolver/maven/download/apache-maven-3.3.9-bin.tar.gz -C ~/.arquillian/mvn
   # Cleanup PR doc previews - until we figure out how to have a webhook on closing the PR
-  - 'if [ "${BRANCH}" == "master" ]; then
+  - 'if [ "${BRANCH}" == "master" ] && [ $GENERATE_DOC -eq 0 ]; then
         cd gh-pages;
         UPDATE_GH_PAGES=0;
         for pr in $(ls -1p pr/ >/dev/null 2>&1 | grep "/$" | sed "s/\/$//"); do
@@ -48,7 +48,11 @@ before_script:
             fi
         done;
 
-        
+        if [ $UPDATE_GH_PAGES -eq 1 ]; then
+            git add .;
+            git commit -m"docs: cleans up closed PR doc preview";
+            git push --quiet "${GH_REF}" gh-pages > /dev/null 2>&1;
+        fi
         cd ..;
       fi
   '

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,9 @@ cache:
     - $HOME/.m2
 
 before_install:
-  - 'echo $TRAVIS_PULL_REQUEST_BRANCH'
-  - 'echo $TRAVIS_BRANCH'
-  - 'echo $TRAVIS_COMMIT_RANGE'
   - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
-  - '[ $(git log --format=%B  $TRAVIS_COMMIT_RANGE | grep -i "\[gen docs\]" | wc -l) -gt 0 ] && FORCE_DOC_GEN=0 || FORCE_DOC_GEN=1'
   - MODIFIED_DOCS=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -E 'README.adoc|^docs/.*.adoc$' | wc -l)
-  - '[ $BRANCH == "master" ] && [ $MODIFIED_DOCS -ge 1 ] && GENERATE_DOC=0 || GENERATE_DOC=1'
+  - '[ $(git log --format=%B  $TRAVIS_COMMIT_RANGE | grep -i "\[gen docs\]" | wc -l) -gt 0 ] && [ $MODIFIED_DOCS -ge 1 ] && GENERATE_DOC=0 || GENERATE_DOC=1'
   - 'if [ $FORCE_DOC_GEN -eq 0 ] || [ $GENERATE_DOC -eq 0 ]; then
       git config user.name "${GH_USER}";
       git config user.email "${GH_EMAIL}";
@@ -44,13 +40,13 @@ env:
   - TEST_BED_M2_HOME=/home/travis/.arquillian/mvn/apache-maven-3.3.9
 
 script:
-  - ./mvnw clean verify -P travis -DJAVA_OPTS="-XX:-UseLoopPredicate"
-  - 'if [ $FORCE_DOC_GEN -eq 0 ] || [ $GENERATE_DOC -eq 0 ]; then
+  # - ./mvnw clean verify -P travis -DJAVA_OPTS="-XX:-UseLoopPredicate"
+  - 'if [ $GENERATE_DOC -eq 0 ]; then
         ./.asciidoctor/generate.sh --keep;
      fi'
 
 after_success:
-  - 'if [ $FORCE_DOC_GEN -eq 0 ] || [ $GENERATE_DOC -eq 0 ]; then
+  - 'if [ $GENERATE_DOC -eq 0 ]; then
       cd gh-pages;
       git add .;
       git commit -m"docs: publishes new documentation";
@@ -58,11 +54,11 @@ after_success:
     fi'
 
 after_error:
-  - 'if [ $FORCE_DOC_GEN -eq 0 ] || [ $GENERATE_DOC -eq 0 ]; then
+  - 'if [ $GENERATE_DOC -eq 0 ]; then
       docker logs adoc-to-html;
     fi'
 
 after_failure:
-  - 'if [ $FORCE_DOC_GEN -eq 0 ] || [ $GENERATE_DOC -eq 0 ]; then
+  - 'if [ $GENERATE_DOC -eq 0 ]; then
       docker logs adoc-to-html;
     fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - COMMITS_WITH_FORCED_GEN=$(git log --format=%B  $TRAVIS_COMMIT_RANGE | grep -i "\[gen docs\]" | wc -l)
   - git describe --tags --exact-match HEAD >/dev/null 2>&1 && TAGGED=0 || TAGGED=1
   - '[ $TAGGED -eq 0 ] || [ $COMMITS_WITH_FORCED_GEN -gt 0 ] || [ $MODIFIED_DOCS -ge 1 ] && GENERATE_DOC=0 || GENERATE_DOC=1'
-  - '[ "${BRANCH}" == "master" ] || [ ! -z "${TRAVIS_PULL_REQUEST// }"  -a "${TRAVIS_PULL_REQUEST}" != "false" ] && GENERATE_DOC=0 || GENERATE_DOC=1
+  - '[ "${BRANCH}" == "master" ] || [ ! -z "${TRAVIS_PULL_REQUEST// }"  -a "${TRAVIS_PULL_REQUEST}" != "false" ] && GENERATE_DOC=0 || GENERATE_DOC=1'
   - 'if [ $GENERATE_DOC -eq 0 ]; then
       git config user.name "${GH_USER}";
       git config user.email "${GH_EMAIL}";

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,8 +75,8 @@ after_success:
       git push --quiet "${GH_REF}" gh-pages > /dev/null 2>&1;
       echo ${TRAVIS_PULL_REQUEST};
       if [ ! -z "${TRAVIS_PULL_REQUEST// }" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
-          curl https://api.github.com/repos/arquillian/smart-testing/issues/${TRAVIS_PULL_REQUEST}/comments -H "Authorization:token ${GH_TOKEN}" -X POST -d "{ \"body\": \"Documentation ready for preview at http://arquillian.org/smart-testing/pr/${TRAVIS_PULL_REQUEST}\"}"
-      fi
+        curl https://api.github.com/repos/arquillian/smart-testing/issues/${TRAVIS_PULL_REQUEST}/comments -H "Authorization:token ${GH_TOKEN}" -X POST -d "{ \"body\": \"Documentation ready for preview at http://arquillian.org/smart-testing/pr/${TRAVIS_PULL_REQUEST}\"}";
+      fi;
     fi'
 
 after_error:

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,6 @@ before_script:
             git commit -m"docs: cleans up closed PR doc previews";
             git push --quiet "${GH_REF}" gh-pages > /dev/null 2>&1;
         fi;
-
         cd ..;
       fi
   '
@@ -76,7 +75,9 @@ after_success:
       git commit -m"docs: publishes new documentation";
       git push --quiet "${GH_REF}" gh-pages > /dev/null 2>&1;
       if [ ! -z "${TRAVIS_PULL_REQUEST// }" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
-        curl https://api.github.com/repos/arquillian/smart-testing/issues/${TRAVIS_PULL_REQUEST}/comments -H "Authorization:token ${GH_TOKEN}" -X POST -d "{ \"body\": \"Documentation ready for preview at http://arquillian.org/smart-testing/pr/${TRAVIS_PULL_REQUEST}\"}";
+        curl https://api.github.com/repos/arquillian/smart-testing/issues/${TRAVIS_PULL_REQUEST}/comments \
+        -H "Authorization:token ${GH_TOKEN}" -X POST \
+        -d "{ \"body\": \"Greeting earthlings! Documentation is ready for preview at http://arquillian.org/smart-testing/pr/${TRAVIS_PULL_REQUEST}. Just be patient. It might take a few minutes for the changes to show up.\"}";
       fi;
     fi'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,23 +37,22 @@ before_script:
   - wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz -P /home/travis/.arquillian/resolver/maven/download
   - tar -xf /home/travis/.arquillian/resolver/maven/download/apache-maven-3.3.9-bin.tar.gz -C ~/.arquillian/mvn
   # Cleanup PR doc previews - until we figure out how to have a webhook on closing the PR
-  - ' echo $(ls -1p pr/ >/dev/null 2>&1 | grep "/$" | sed "s/\/$//")
-      if [ "${BRANCH}" == "master" ]; then
-          cd gh-pages
-          UPDATE_GH_PAGES=0
-          for pr in $(ls -1p pr/ | grep "/$" | sed "s/\/$//"); do
-              PR_CLOSED=$(curl https://api.github.com/repos/arquillian/smart-testing/pulls/$pr/merge -H "Authorization:token ${GH_TOKEN}" -I -s -o /dev/null -w "%{http_code}")
-              if [ "${PR_CLOSED}" == "204" ]; then
-                  UPDATE_GH_PAGES=1
-                  rm -rf pr/${pr}
-              fi
-          done
+  - 'if [ "${BRANCH}" == "master" ]; then
+        cd gh-pages;
+        UPDATE_GH_PAGES=0;
+        for pr in $(ls -1p pr/ >/dev/null 2>&1 | grep "/$" | sed "s/\/$//"); do
+            PR_CLOSED=$(curl https://api.github.com/repos/arquillian/smart-testing/pulls/$pr/merge -H "Authorization:token ${GH_TOKEN}" -I -s -o /dev/null -w "%{http_code}");
+            if [ "${PR_CLOSED}" == "204" ]; then
+                UPDATE_GH_PAGES=1;
+                rm -rf pr/${pr};
+            fi
+        done;
 
-          if [ ${UPDATE_GH_PAGES} -eq 1 ]; then
-              git commit -m"docs: cleans up closed PR doc preview";
-              git push --quiet "${GH_REF}" gh-pages > /dev/null 2>&1;
-          fi
-          cd -
+        if [ $UPDATE_GH_PAGES -eq 1 ]; then
+            git commit -m"docs: cleans up closed PR doc preview";
+            git push --quiet "${GH_REF}" gh-pages > /dev/null 2>&1;
+        fi
+        cd -;
       fi
   '
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ before_script:
         if [ $UPDATE_GH_PAGES -eq 1 ]; then
             git add .;
             git commit -m"docs: cleans up closed PR doc previews";
-            git push --quiet "${GH_REF}" gh-pages > /dev/null 2>&1;
+            git push --quiet "${GH_REF}" gh-pages;
         fi;
 
         cd ..;
@@ -72,7 +72,7 @@ after_success:
       cd gh-pages;
       git add .;
       git commit -m"docs: publishes new documentation";
-      git push "${GH_REF}" gh-pages;
+      git push --quiet "${GH_REF}" gh-pages;
       if [ ! -z "${TRAVIS_PULL_REQUEST// }" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
         curl https://api.github.com/repos/arquillian/smart-testing/issues/${TRAVIS_PULL_REQUEST}/comments -H "Authorization:token ${GH_TOKEN}" -X POST -d "{ \"body\": \"Documentation ready for preview at http://arquillian.org/smart-testing/pr/${TRAVIS_PULL_REQUEST}\"}";
       fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ cache:
     - $HOME/.m2
 
 before_install:
+  - 'echo $TRAVIS_PULL_REQUEST_BRANCH'
+  - 'echo $TRAVIS_BRANCH'
+  - 'echo $TRAVIS_COMMIT_RANGE'
   - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
   - '[ $(git log --format=%B  $TRAVIS_COMMIT_RANGE | grep -i "\[gen docs\]" | wc -l) -gt 0 ] && FORCE_DOC_GEN=0 || FORCE_DOC_GEN=1'
   - MODIFIED_DOCS=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -E 'README.adoc|^docs/.*.adoc$' | wc -l)

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,8 +72,7 @@ after_success:
       cd gh-pages;
       git add .;
       git commit -m"docs: publishes new documentation";
-      git push "${GH_REF}" gh-pages > /dev/null 2>&1;
-      echo ${TRAVIS_PULL_REQUEST};
+      git push "${GH_REF}" gh-pages;
       if [ ! -z "${TRAVIS_PULL_REQUEST// }" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
         curl https://api.github.com/repos/arquillian/smart-testing/issues/${TRAVIS_PULL_REQUEST}/comments -H "Authorization:token ${GH_TOKEN}" -X POST -d "{ \"body\": \"Documentation ready for preview at http://arquillian.org/smart-testing/pr/${TRAVIS_PULL_REQUEST}\"}";
       fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,10 @@ cache:
 before_install:
   - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
   - MODIFIED_DOCS=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -E 'README.adoc|^docs/.*.adoc$' | wc -l)
+  - COMMITS_WITH_FORCED_GEN=$(git log --format=%B  $TRAVIS_COMMIT_RANGE | grep -i "\[gen docs\]" | wc -l)
   - git describe --tags --exact-match HEAD >/dev/null 2>&1 && TAGGED=0 || TAGGED=1
-  - '[ $TAGGED -eq 0 ] || [ $(git log --format=%B  $TRAVIS_COMMIT_RANGE | grep -i "\[gen docs\]" | wc -l) -gt 0 ] || [ $MODIFIED_DOCS -ge 1 ] && GENERATE_DOC=0 || GENERATE_DOC=1'
+  - '[ $TAGGED -eq 0 ] || [ $COMMITS_WITH_FORCED_GEN -gt 0 ] || [ $MODIFIED_DOCS -ge 1 ] && GENERATE_DOC=0 || GENERATE_DOC=1'
+  - '[ "${BRANCH}" == "master" ] || [ ! -z "${TRAVIS_PULL_REQUEST// }"  -a "${TRAVIS_PULL_REQUEST}" != "false" ] && GENERATE_DOC=0 || GENERATE_DOC=1
   - 'if [ $GENERATE_DOC -eq 0 ]; then
       git config user.name "${GH_USER}";
       git config user.email "${GH_EMAIL}";
@@ -51,7 +53,7 @@ before_script:
         if [ $UPDATE_GH_PAGES -eq 1 ]; then
             git add .;
             git commit -m"docs: cleans up closed PR doc previews";
-            git push --quiet "${GH_REF}" gh-pages;
+            git push --quiet "${GH_REF}" gh-pages > /dev/null 2>&1;
         fi;
 
         cd ..;
@@ -72,7 +74,7 @@ after_success:
       cd gh-pages;
       git add .;
       git commit -m"docs: publishes new documentation";
-      git push --quiet "${GH_REF}" gh-pages;
+      git push --quiet "${GH_REF}" gh-pages > /dev/null 2>&1;
       if [ ! -z "${TRAVIS_PULL_REQUEST// }" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
         curl https://api.github.com/repos/arquillian/smart-testing/issues/${TRAVIS_PULL_REQUEST}/comments -H "Authorization:token ${GH_TOKEN}" -X POST -d "{ \"body\": \"Documentation ready for preview at http://arquillian.org/smart-testing/pr/${TRAVIS_PULL_REQUEST}\"}";
       fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ env:
   - TEST_BED_M2_HOME=/home/travis/.arquillian/mvn/apache-maven-3.3.9
 
 script:
-  # - ./mvnw clean verify -P travis -DJAVA_OPTS="-XX:-UseLoopPredicate"
+  - ./mvnw clean verify -P travis -DJAVA_OPTS="-XX:-UseLoopPredicate"
   - 'if [ $GENERATE_DOC -eq 0 ]; then
         ./.asciidoctor/generate.sh --keep;
      fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ cache:
 before_install:
   - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
   - MODIFIED_DOCS=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -E 'README.adoc|^docs/.*.adoc$' | wc -l)
-  - 'echo  $(git log --format=%B  $TRAVIS_COMMIT_RANGE | grep -i "\[gen docs\]" | wc -l)'
-  - 'echo $(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -E "README.adoc|^docs/.*.adoc$" | wc -l)'
   - '[ $(git log --format=%B  $TRAVIS_COMMIT_RANGE | grep -i "\[gen docs\]" | wc -l) -gt 0 ] || [ $MODIFIED_DOCS -ge 1 ] && GENERATE_DOC=0 || GENERATE_DOC=1'
   - 'echo $GENERATE_DOC'
   - 'if [ $GENERATE_DOC -eq 0 ]; then
@@ -38,6 +36,25 @@ before_script:
   - mkdir -p /home/travis/.arquillian/mvn
   - wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz -P /home/travis/.arquillian/resolver/maven/download
   - tar -xf /home/travis/.arquillian/resolver/maven/download/apache-maven-3.3.9-bin.tar.gz -C ~/.arquillian/mvn
+  # Cleanup PR doc previews - until we figure out how to have a webhook on closing the PR
+  - 'if [ "$BRANCH" == "master" ]; then
+      cd gh-pages;
+      UPDATE_GH_PAGES=0
+      for pr in $(ls -1p pr/ | grep "/$" | sed "s/\/$//"); do
+        CLOSED=$(curl https://api.github.com/repos/arquillian/smart-testing/pulls/$pr/merge -H "Authorization:token ${GH_TOKEN}" -I -s -o /dev/null -w "%{http_code}")
+        if [ "$CLOSED" == "204" ]; then
+          UPDATE_GH_PAGES=1
+          rm -rf pr/${pr}
+        fi
+      done
+      if [ $UPDATE_GH_PAGES -eq 1 ]; then
+        git commit -m"docs: cleans up closed PR doc preview";
+        git push --quiet "${GH_REF}" gh-pages > /dev/null 2>&1;
+      fi
+      cd -
+     fi
+  '
+
 
 env:
   - TEST_BED_M2_HOME=/home/travis/.arquillian/mvn/apache-maven-3.3.9
@@ -54,6 +71,11 @@ after_success:
       git add .;
       git commit -m"docs: publishes new documentation";
       git push --quiet "${GH_REF}" gh-pages > /dev/null 2>&1;
+      if [ ! -z "${TRAVIS_PULL_REQUEST// }" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+          curl https://api.github.com/repos/arquillian/smart-testing/issues/${TRAVIS_PULL_REQUEST}/comments -H "Authorization:token ${GH_TOKEN}" \
+              -X POST -d "{ \"body\": \"Documentation ready for preview at http://arquillian.org/smart-testing/pr/${TRAVIS_PULL_REQUEST}\"}"
+
+      fi
     fi'
 
 after_error:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
 before_install:
   - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
   - MODIFIED_DOCS=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -E 'README.adoc|^docs/.*.adoc$' | wc -l)
-  - '[ $(git log --format=%B  $TRAVIS_COMMIT_RANGE | grep -i "\[gen docs\]" | wc -l) -gt 0 ] && [ $MODIFIED_DOCS -ge 1 ] && GENERATE_DOC=0 || GENERATE_DOC=1'
+  - '[ $(git log --format=%B  $TRAVIS_COMMIT_RANGE | grep -i "\[gen docs\]" | wc -l) -gt 0 ] || [ $MODIFIED_DOCS -ge 1 ] && GENERATE_DOC=0 || GENERATE_DOC=1'
   - 'echo $GENERATE_DOC'
   - 'if [ $GENERATE_DOC -eq 0 ]; then
       git config user.name "${GH_USER}";

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ before_install:
   - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
   - MODIFIED_DOCS=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -E 'README.adoc|^docs/.*.adoc$' | wc -l)
   - git describe --tags --exact-match HEAD >/dev/null 2>&1 && TAGGED=0 || TAGGED=1
-  - 'echo $TRAVIS_TAG'
   - '[ $TAGGED -eq 0 ] || [ $(git log --format=%B  $TRAVIS_COMMIT_RANGE | grep -i "\[gen docs\]" | wc -l) -gt 0 ] || [ $MODIFIED_DOCS -ge 1 ] && GENERATE_DOC=0 || GENERATE_DOC=1'
   - 'if [ $GENERATE_DOC -eq 0 ]; then
       git config user.name "${GH_USER}";
@@ -59,7 +58,6 @@ before_script:
       fi
   '
 
-
 env:
   - TEST_BED_M2_HOME=/home/travis/.arquillian/mvn/apache-maven-3.3.9
 
@@ -78,7 +76,6 @@ after_success:
       if [ ! -z "${TRAVIS_PULL_REQUEST// }" ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
           curl https://api.github.com/repos/arquillian/smart-testing/issues/${TRAVIS_PULL_REQUEST}/comments -H "Authorization:token ${GH_TOKEN}" \
               -X POST -d "{ \"body\": \"Documentation ready for preview at http://arquillian.org/smart-testing/pr/${TRAVIS_PULL_REQUEST}\"}"
-
       fi
     fi'
 


### PR DESCRIPTION
### Features

- builds PR version of the documentation under `arquillian.org/smart-testing/pr/${PR}` and shares the link in the PR comment
- builds tagged doc when tag present on the commit
- cleans up closed PR documentation when on master **and** building the doc (so not every time, but frequently enough)

Documentation generation process is triggered if
- in the range of commits any `.adoc` file was changes
- if the commit is tagged (so we can have for the release commit)
- if commit message contains `[gen docs]` directive

Fixes #147

This crazy amount of commits was for testing travis build... next time I will try with [the local image](https://docs.travis-ci.com/user/common-build-problems/#Troubleshooting-Locally-in-a-Docker-Image). 

