### PR TITLE
fix(#192): Check existence of commit object id 

### DIFF
--- a/core/src/main/java/org/arquillian/smart/testing/scm/git/GitChangeResolver.java
+++ b/core/src/main/java/org/arquillian/smart/testing/scm/git/GitChangeResolver.java
@@ -94,8 +94,12 @@ public class GitChangeResolver implements ChangeResolver {
     private Set<Change> retrieveCommitsChanges() {
         final Repository repository = git.getRepository();
         try (ObjectReader reader = repository.newObjectReader()) {
-            final ObjectId oldHead = repository.resolve(previous + ENSURE_TREE);
-            final ObjectId newHead = repository.resolve(head + ENSURE_TREE);
+
+            final ObjectId oldHead = repository.resolve(this.previous + ENSURE_TREE);
+            checkObjectIdExistence(oldHead, this.previous, repository.getDirectory().getAbsolutePath());
+
+            final ObjectId newHead = repository.resolve(this.head + ENSURE_TREE);
+            checkObjectIdExistence(newHead, this.head, repository.getDirectory().getAbsolutePath());
 
             final CanonicalTreeParser oldTree = new CanonicalTreeParser();
             oldTree.reset(reader, oldHead);
@@ -109,6 +113,12 @@ public class GitChangeResolver implements ChangeResolver {
             return transformToChangeSet(reduceToRenames(commitDiffs), repoRoot);
         } catch (IOException | GitAPIException e) {
             throw new IllegalStateException(e);
+        }
+    }
+
+    private void checkObjectIdExistence(ObjectId retrievedId, String id, String repoLocation) {
+        if (retrievedId == null) {
+            throw new IllegalArgumentException(String.format("Commit id %s is not found into %s Git repository", id, repoLocation));
         }
     }
 

--- a/core/src/test/java/org/arquillian/smart/testing/scm/git/GitChangeResolverTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/scm/git/GitChangeResolverTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.tuple;
 
 public class GitChangeResolverTest {
@@ -106,6 +107,17 @@ public class GitChangeResolverTest {
             relative("README.adoc"), ChangeType.MODIFY));
     }
 
+    @Test
+    public void should_return_meanful_exception_when_incorrect_commit_provided() throws Exception {
+        // given
+        this.gitChangeResolver = new GitChangeResolver(gitFolder.getRoot(), "null", "07b181b");
+
+        // when
+        final Throwable throwable = catchThrowable(() -> gitChangeResolver.diff());
+
+        // then
+        assertThat(throwable).isInstanceOf(IllegalArgumentException.class).hasMessageStartingWith("Commit id null is not found into");
+    }
 
     private Path relative(String path) {
         return Paths.get(gitFolder.getRoot().getAbsolutePath(), path);


### PR DESCRIPTION
#### Short description of what this resolves:

Check existence of commit object id and provide meanful exception

#### Changes proposed in this pull request:

- Checks if ObjectId is null or not

Fixes #192 
