### PR TITLE
fix(ext) Excluding jar signatures from shaded jar

### DIFF
--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/BuildConfigurator.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/BuildConfigurator.java
@@ -38,6 +38,8 @@ public class BuildConfigurator {
     private boolean skipTests = false;
     private File workingDirectory;
     private String mavenOpts = "-Xms512m -Xmx1024m";
+    private String mavenVersion;
+    private Using usingInstallation;
 
     BuildConfigurator(ProjectBuilder projectBuilder) {
         systemProperties.put("surefire.exitTimeout", "-1"); // see http://bit.ly/2vARQ5p
@@ -181,6 +183,11 @@ public class BuildConfigurator {
         return this;
     }
 
+    public BuildConfigurator useMavenVersion(String mavenVersion){
+        this.mavenVersion = mavenVersion;
+        return this;
+    }
+
     void enableDebugOptions() {
         if (isRemoteDebugEnabled()) {
             final String debugOptions = String.format(MVN_DEBUG_AGENT, shouldSuspend(), getRemotePort());
@@ -256,7 +263,11 @@ public class BuildConfigurator {
     boolean isIgnoreBuildFailure() {
         return ignoreBuildFailure;
     }
-    
+
+    String getMavenVersion() {
+        return mavenVersion;
+    }
+
     private int getAvailableLocalPort() {
         ServerSocket socket = null;
         try {
@@ -275,4 +286,11 @@ public class BuildConfigurator {
         }
     }
 
+    Using getUsingInstallation() {
+        return usingInstallation;
+    }
+
+    void setUsingInstallation(Using usingInstallation) {
+        this.usingInstallation = usingInstallation;
+    }
 }

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ChangeApplier.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ChangeApplier.java
@@ -111,6 +111,9 @@ class ChangeApplier {
         // So we create temporary commits to overcome this issue
         // and reset softly on the way to have it all as local changes
         for (final RevCommit stash : stashesToApply) {
+            if (stash == null){
+                continue;
+            }
             git.stashApply().setStashRef(stash.getName()).call();
             if (tmpCommit != null) {
                 git.reset().setRef(ONE_BACK).setMode(SOFT).call();

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/MavenExtensionFileRegisterer.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/MavenExtensionFileRegisterer.java
@@ -8,21 +8,22 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Collectors;
 
-class MavenExtensionRegisterer {
+class MavenExtensionFileRegisterer {
 
-    private static final String EXTENSIONS_XML = "extensions.xml";
+    public static final String MVN_CONFIG_DIR = ".mvn";
+    public static final String EXTENSIONS_XML = "extensions.xml";
     private static final String VERSION_PLACEHOLDER = "${version}";
 
     private final Path rootPom;
 
-    MavenExtensionRegisterer(Path rootPom) {
+    MavenExtensionFileRegisterer(Path rootPom) {
         this.rootPom = rootPom;
     }
 
     void addSmartTestingExtension(String version) {
         final Path projectRoot = rootPom.getParent();
         try {
-            final Path extensionFolder = Files.createDirectories(projectRoot.resolve(".mvn"));
+            final Path extensionFolder = Files.createDirectories(projectRoot.resolve(MVN_CONFIG_DIR));
             final InputStream extensionFile =
                 Thread.currentThread().getContextClassLoader().getResourceAsStream(EXTENSIONS_XML);
 
@@ -35,5 +36,4 @@ class MavenExtensionRegisterer {
             throw new RuntimeException("Failed registering smart-testing extension locally in .mvn folder", e);
         }
     }
-
 }

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/MavenExtensionShadedJarRegisterer.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/MavenExtensionShadedJarRegisterer.java
@@ -1,0 +1,59 @@
+package org.arquillian.smart.testing.ftest.testbed.project;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+
+class MavenExtensionShadedJarRegisterer {
+
+    void addSmartTestingExtension(String stVersion, String mavenVersion) {
+        try {
+            Path libExtDir = getMvnLibExtDirectory(mavenVersion);
+            File shadedJar = retrieveShadedExtensionJar(stVersion);
+            Files.copy(shadedJar.toPath(), libExtDir.resolve(shadedJar.getName()));
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private Path getMvnLibExtDirectory(String mavenVersion) throws IOException {
+        Path libExtDir = getMvnHome(mavenVersion).resolve("lib").resolve("ext");
+        if (!libExtDir.toFile().exists()) {
+            Files.createDirectories(libExtDir);
+        }
+        File[] libExtFiles = libExtDir.toFile().listFiles();
+        Arrays.stream(libExtFiles)
+            .filter(File::isFile).forEach(file -> {
+            try {
+                Files.delete(file.toPath());
+            } catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
+        });
+        return libExtDir;
+    }
+
+    private Path getMvnHome(String mavenVersion) throws IOException {
+        String mvnHomeName = "apache-maven-" + mavenVersion;
+        Path resolverMaven = Paths.get("target","resolver-maven").toAbsolutePath();
+
+        Path mvnHome = Files.walk(resolverMaven)
+            .filter(path -> path.toFile().isDirectory() && (mvnHomeName).equals(path.toFile().getName()))
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException(String.format(
+                "There is no %s directory present inside of the %s directory. The extension cannot be installed.",
+                mvnHomeName, resolverMaven)));
+        return mvnHome;
+    }
+
+    private File retrieveShadedExtensionJar(String stVersion){
+        return Maven.configureResolver().workOffline()
+            .resolve("org.arquillian.smart.testing:maven-lifecycle-extension:jar:shaded:" + stVersion)
+            .withoutTransitivity()
+            .asSingleFile();
+    }
+}

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
@@ -15,6 +15,7 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.stream.Collectors;
 import org.arquillian.smart.testing.logger.Logger;
+import org.arquillian.smart.testing.configuration.Configuration;
 import org.arquillian.smart.testing.ftest.testbed.testresults.TestResult;
 import org.arquillian.smart.testing.logger.Log;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.BuiltProject;
@@ -114,9 +115,22 @@ public class ProjectBuilder {
     }
 
     private void setCustomMavenInstallation(PomEquippedEmbeddedMaven embeddedMaven) {
-        final String mvnInstallation = System.getenv("TEST_BED_M2_HOME");
-        if (mvnInstallation != null) {
-            embeddedMaven.useInstallation(new File(mvnInstallation));
+        if (buildConfigurator.getMavenVersion() != null && !buildConfigurator.getMavenVersion().isEmpty()) {
+            setMavenVersion(embeddedMaven);
+        } else {
+            final String mvnInstallation = System.getenv("TEST_BED_M2_HOME");
+            if (mvnInstallation != null) {
+                embeddedMaven.useInstallation(new File(mvnInstallation));
+            }
+        }
+    }
+
+    private void setMavenVersion(PomEquippedEmbeddedMaven embeddedMaven) {
+        String mavenVersion = buildConfigurator.getMavenVersion();
+        embeddedMaven.useMaven3Version(mavenVersion);
+        if (buildConfigurator.getUsingInstallation() == Using.SHADED_JAR) {
+            String stVersion = buildConfigurator.getSystemProperties().get(Configuration.SMART_TESTING_VERSION);
+            new MavenExtensionShadedJarRegisterer().addSmartTestingExtension(stVersion, mavenVersion);
         }
     }
 

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectConfigurator.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectConfigurator.java
@@ -74,27 +74,39 @@ public class ProjectConfigurator {
         return this;
     }
 
+    /**
+     * Enables using extension file {@link Using#EXTENSION_FILE}
+     *
+     * @return A modified instance of {@link Project}
+     */
     public Project enable() {
-        final Path rootPom = Paths.get(root.toString(), "pom.xml");
-        final MavenExtensionRegisterer mavenExtensionRegisterer = new MavenExtensionRegisterer(rootPom);
-        String currentVersion = resolveVersion();
-        mavenExtensionRegisterer.addSmartTestingExtension(currentVersion);
-            if (!createConfigFile) {
-                this.project.build().options()
-                        .withSystemProperties(SMART_TESTING, strategies(), SMART_TESTING_MODE, getMode().getName(), SMART_TESTING_VERSION, currentVersion)
-                    .configure();
-            } else {
-                if (configuration == null) {
-                    this.configuration = new ConfigurationBuilder()
-                            .strategies(strategies().split("\\s*,\\s*"))
-                            .mode(RunMode.valueOf(getMode().getName().toUpperCase()))
-                        .build();
-                }
+        return enable(Using.EXTENSION_FILE);
+    }
 
-                this.project.configureSmartTesting()
-                        .withConfiguration(configuration)
-                    .createConfigFile();
+    public Project enable(Using usingInstallation) {
+        project.build().options().setUsingInstallation(usingInstallation);
+        final Path rootPom = Paths.get(root.toString(), "pom.xml");
+        String currentVersion = resolveVersion();
+        if (usingInstallation == Using.EXTENSION_FILE) {
+            new MavenExtensionFileRegisterer(rootPom).addSmartTestingExtension(currentVersion);
+        }
+        if (!createConfigFile) {
+            this.project.build().options()
+                .withSystemProperties(SMART_TESTING, strategies(), SMART_TESTING_MODE, getMode().getName(),
+                    SMART_TESTING_VERSION, currentVersion)
+                .configure();
+        } else {
+            if (configuration == null) {
+                this.configuration = new ConfigurationBuilder()
+                    .strategies(strategies().split("\\s*,\\s*"))
+                    .mode(RunMode.valueOf(getMode().getName().toUpperCase()))
+                    .build();
             }
+
+            this.project.configureSmartTesting()
+                .withConfiguration(configuration)
+                .createConfigFile();
+        }
         return this.project;
     }
 

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/Using.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/Using.java
@@ -1,0 +1,6 @@
+package org.arquillian.smart.testing.ftest.testbed.project;
+
+public enum Using {
+
+    EXTENSION_FILE, SHADED_JAR;
+}

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/DebugModeAndMaven325FunctionalTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/DebugModeAndMaven325FunctionalTest.java
@@ -2,9 +2,12 @@ package org.arquillian.smart.testing.ftest.configuration;
 
 import java.io.File;
 import org.arquillian.smart.testing.ftest.customAssertions.SmartTestingSoftAssertions;
+import java.util.Collection;
 import org.arquillian.smart.testing.ftest.testbed.project.Project;
 import org.arquillian.smart.testing.ftest.testbed.project.ProjectBuilder;
 import org.arquillian.smart.testing.ftest.testbed.project.TestResults;
+import org.arquillian.smart.testing.ftest.testbed.project.Using;
+import org.arquillian.smart.testing.ftest.testbed.testresults.TestResult;
 import org.arquillian.smart.testing.rules.TestBed;
 import org.arquillian.smart.testing.rules.git.GitClone;
 import org.junit.ClassRule;
@@ -14,12 +17,14 @@ import org.junit.Test;
 import static org.arquillian.smart.testing.configuration.Configuration.SMART_TESTING_DEBUG;
 import static org.arquillian.smart.testing.ftest.testbed.TestRepository.testRepository;
 import static org.arquillian.smart.testing.ftest.testbed.configuration.Mode.ORDERING;
+import static org.arquillian.smart.testing.ftest.testbed.configuration.Mode.SELECTING;
 import static org.arquillian.smart.testing.ftest.testbed.configuration.Strategy.AFFECTED;
 import static org.arquillian.smart.testing.mvn.ext.ModifiedPomExporter.SMART_TESTING_POM_FILE;
+import static org.arquillian.smart.testing.scm.ScmRunnerProperties.SCM_LAST_CHANGES;
 import static org.arquillian.smart.testing.scm.ScmRunnerProperties.SCM_RANGE_HEAD;
 import static org.arquillian.smart.testing.scm.ScmRunnerProperties.SCM_RANGE_TAIL;
 
-public class DebugModeSmartTestingFunctionalTest {
+public class DebugModeAndMaven325FunctionalTest {
 
     private static final String MAVEN_DEBUG_LOGS = "[DEBUG] Smart Testing Extension -";
     private static final String PROVIDER_DEBUG_LOGS = "DEBUG: Smart Testing Extension -";
@@ -35,30 +40,35 @@ public class DebugModeSmartTestingFunctionalTest {
     public final SmartTestingSoftAssertions softly = new SmartTestingSoftAssertions();
 
     @Test
-    public void should_show_debug_logs_when_smart_testing_is_executed_in_debug_mode() throws Exception {
+    public void should_show_debug_logs_when_smart_testing_is_executed_in_debug_mode_changes_using_325_maven()
+        throws Exception {
         // given
         final Project project = testBed.getProject();
 
         project.configureSmartTesting()
-            .executionOrder(AFFECTED)
-            .inMode(ORDERING)
-            .enable();
+                .executionOrder(AFFECTED)
+                .inMode(SELECTING)
+            .enable(Using.SHADED_JAR);
 
-        project
+        Collection<TestResult> expectedTestResults = project
             .applyAsCommits("Single method body modification - sysout",
                 "Inlined variable in a method");
 
         // when
         ProjectBuilder projectBuilder = project.build("config/impl-base");
         final TestResults actualTestResults = projectBuilder
-            .options()
-            .withSystemProperties(SCM_RANGE_HEAD, "HEAD", SCM_RANGE_TAIL, "HEAD~", SMART_TESTING_DEBUG, "true")
-            .configure()
+                .options()
+                    .withSystemProperties(SCM_LAST_CHANGES, "2", SMART_TESTING_DEBUG, "true")
+                    .useMavenVersion("3.2.5")
+                .configure()
             .run();
 
         // then
-        String projectMavenLog = project.getMavenLog();
+        softly.assertThat(actualTestResults.accumulatedPerTestClass())
+            .containsAll(expectedTestResults)
+            .hasSameSizeAs(expectedTestResults);
 
+        String projectMavenLog = project.getMavenLog();
         softly.assertThat(projectMavenLog)
             .contains(PROVIDER_DEBUG_LOGS)
             .contains(PROVIDER_DEBUG_LOGS + " Applied user properties");

--- a/mvn-extension/pom.xml
+++ b/mvn-extension/pom.xml
@@ -93,7 +93,6 @@
         <version>${version.maven.plugin.shade}</version>
         <configuration>
           <createDependencyReducedPom>false</createDependencyReducedPom>
-          <minimizeJar>true</minimizeJar>
           <shadedArtifactAttached>true</shadedArtifactAttached>
           <shadedClassifierName>shaded</shadedClassifierName>
           <artifactSet>
@@ -101,6 +100,16 @@
               <exclude>org.slf4j:*</exclude>
             </excludes>
           </artifactSet>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/*.SF</exclude>
+                <exclude>META-INF/*.DSA</exclude>
+                <exclude>META-INF/*.RSA</exclude>
+              </excludes>
+            </filter>
+          </filters>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
#### Short description of what this resolves:

Excluding jar signatures:
```
META-INF/*.SF
META-INF/*.DSA
META-INF/*.RSA
```
from the shaded jar that is used for maven extension in older Maven versions. 
If they are present, the shaded jar is not properly loaded and Maven extension doesn't work

Fixes #175 
