### PR TITLE
Initializing git change resolver if dir doesn't contains git folder.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -45,5 +45,18 @@
       <version>${version.snakeyaml}</version>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <java.io.tmpdir>${java.io.tmpdir}</java.io.tmpdir>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/core/src/main/java/org/arquillian/smart/testing/scm/git/GitChangeResolver.java
+++ b/core/src/main/java/org/arquillian/smart/testing/scm/git/GitChangeResolver.java
@@ -81,7 +81,7 @@ public class GitChangeResolver implements ChangeResolver {
         try {
             final FileRepositoryBuilder builder = new FileRepositoryBuilder();
             builder.readEnvironment().findGitDir(projectDir).build();
-        } catch (IOException e) {
+        } catch (IllegalArgumentException | IOException e) {
             logger.warn("Working directory is not git directory. Cause: %s", e.getMessage());
             return false;
         }

--- a/core/src/main/java/org/arquillian/smart/testing/scm/git/GitChangeResolver.java
+++ b/core/src/main/java/org/arquillian/smart/testing/scm/git/GitChangeResolver.java
@@ -89,17 +89,17 @@ public class GitChangeResolver implements ChangeResolver {
 
     @Override
     public boolean isApplicable(File projectDir) {
-        return getFileRepositoryBuilder(projectDir).getGitDir() != null;
+        return fileRepositoryBuilder(projectDir).getGitDir() != null;
     }
 
-    private FileRepositoryBuilder getFileRepositoryBuilder(File currentGitDir) {
+    private FileRepositoryBuilder fileRepositoryBuilder(File currentGitDir) {
         return new FileRepositoryBuilder().readEnvironment().findGitDir(currentGitDir);
     }
 
     private void buildGit(File projectDir){
         closeGitIfExists();
         try {
-            git = new Git(getFileRepositoryBuilder(projectDir).build());
+            git = new Git(fileRepositoryBuilder(projectDir).build());
         } catch (IOException | IllegalArgumentException e) {
             throw new IllegalArgumentException("Unable to find git repository for path " + projectDir.getAbsolutePath(), e);
         }

--- a/core/src/main/java/org/arquillian/smart/testing/scm/git/GitChangeResolver.java
+++ b/core/src/main/java/org/arquillian/smart/testing/scm/git/GitChangeResolver.java
@@ -123,8 +123,7 @@ public class GitChangeResolver implements ChangeResolver {
             final List<DiffEntry> commitDiffs = git.diff().setNewTree(newTree).setOldTree(oldTree).call();
             return transformToChangeSet(reduceToRenames(commitDiffs), repoRoot);
         } catch (MissingObjectException e) {
-            throw new IllegalArgumentException(format(WRONG_COMMIT_ID_EXCEPTION, e.getObjectId().getName(),
-                repository.getDirectory().getAbsolutePath()));
+            throw new IllegalArgumentException(format(WRONG_COMMIT_ID_EXCEPTION, e.getObjectId().getName(), repository.getDirectory().getAbsolutePath()));
         } catch (IOException | GitAPIException e) {
             throw new IllegalStateException(e);
         }
@@ -132,8 +131,7 @@ public class GitChangeResolver implements ChangeResolver {
 
     private void validateCommitExists(ObjectId retrievedId, String id, Repository repository) {
         if (retrievedId == null) {
-            throw new IllegalArgumentException(
-                format(WRONG_COMMIT_ID_EXCEPTION, id, repository.getDirectory().getAbsolutePath()));
+            throw new IllegalArgumentException(format(WRONG_COMMIT_ID_EXCEPTION, id, repository.getDirectory().getAbsolutePath()));
         }
     }
 

--- a/core/src/main/java/org/arquillian/smart/testing/scm/git/GitChangeResolver.java
+++ b/core/src/main/java/org/arquillian/smart/testing/scm/git/GitChangeResolver.java
@@ -123,15 +123,17 @@ public class GitChangeResolver implements ChangeResolver {
             final List<DiffEntry> commitDiffs = git.diff().setNewTree(newTree).setOldTree(oldTree).call();
             return transformToChangeSet(reduceToRenames(commitDiffs), repoRoot);
         } catch (MissingObjectException e) {
-            throw new IllegalArgumentException(format(WRONG_COMMIT_ID_EXCEPTION, e.getObjectId().getName(), repository.getDirectory().getAbsolutePath()));
-        }catch (IOException | GitAPIException e) {
+            throw new IllegalArgumentException(format(WRONG_COMMIT_ID_EXCEPTION, e.getObjectId().getName(),
+                repository.getDirectory().getAbsolutePath()));
+        } catch (IOException | GitAPIException e) {
             throw new IllegalStateException(e);
         }
     }
 
     private void validateCommitExists(ObjectId retrievedId, String id, Repository repository) {
         if (retrievedId == null) {
-            throw new IllegalArgumentException(format(WRONG_COMMIT_ID_EXCEPTION, id, repository.getDirectory().getAbsolutePath()));
+            throw new IllegalArgumentException(
+                format(WRONG_COMMIT_ID_EXCEPTION, id, repository.getDirectory().getAbsolutePath()));
         }
     }
 
@@ -192,5 +194,4 @@ public class GitChangeResolver implements ChangeResolver {
             })
             .collect(Collectors.toSet());
     }
-
 }

--- a/core/src/main/java/org/arquillian/smart/testing/scm/spi/ChangeResolver.java
+++ b/core/src/main/java/org/arquillian/smart/testing/scm/spi/ChangeResolver.java
@@ -9,6 +9,17 @@ public interface ChangeResolver extends AutoCloseable {
 
     Collection<Change> diff(File projectDir, Configuration configuration);
 
+    /**
+     * If projectDir doesn't have scm initialized, then {@link IllegalStateException} is thrown.
+     *
+     * @param projectDir A directory from which you are calculating git diff changes.
+     * @param configuration A configuration used to configure Smart Testing.
+     * @param strategy name of strategy for which you are calculating diff.
+     *
+     * @return Collection of entire diff in projectDir.
+     */
+    Collection<Change> diff(File projectDir, Configuration configuration, String strategy);
+
     boolean isApplicable(File projectDir);
 
 }

--- a/core/src/test/java/org/arquillian/smart/testing/scm/git/GitChangeResolverTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/scm/git/GitChangeResolverTest.java
@@ -66,6 +66,21 @@ public class GitChangeResolverTest {
     }
 
     @Test
+    public void should_not_applicable_when_git_repository_is_not_initialized() throws IOException {
+        // given
+        gitFolder.delete();
+        gitFolder.create();
+
+        this.gitChangeResolver = new GitChangeResolver(gitFolder.getRoot(), "HEAD", "HEAD~0");
+
+        // when
+        final boolean applicable = gitChangeResolver.isApplicable();
+
+        // then
+        assertThat(applicable).isFalse();
+    }
+
+    @Test
     public void should_fetch_all_untracked_files() throws IOException {
         // given
         gitFolder.newFile("untracked.txt");

--- a/core/src/test/java/org/arquillian/smart/testing/scm/git/GitChangeResolverTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/scm/git/GitChangeResolverTest.java
@@ -28,11 +28,6 @@ public class GitChangeResolverTest {
     @Rule
     public final TemporaryFolder gitFolder = new TemporaryFolder(new File("/tmp"));
 
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
-    public static final String CUSTOM = "custom";
-
     private GitChangeResolver gitChangeResolver;
 
     @Before
@@ -69,37 +64,6 @@ public class GitChangeResolverTest {
 
         // then
         assertThat(diff).hasSize(18);
-    }
-
-    @Test
-    public void should_not_applicable_when_git_repository_is_not_initialized() throws IOException {
-        // given
-        gitFolder.delete();
-        gitFolder.create();
-
-        this.gitChangeResolver = new GitChangeResolver();
-
-        // when
-        final boolean applicable = gitChangeResolver.isApplicable(gitFolder.getRoot());
-
-        // then
-        assertThat(applicable).isFalse();
-    }
-
-    @Test
-    public void should_throw_exception_for_fetching_all_changes_when_git_repository_is_not_initialized()
-        throws IOException {
-        // given
-        gitFolder.delete();
-        gitFolder.create();
-
-        this.gitChangeResolver = new GitChangeResolver();
-
-        // then
-        thrown.expect(IllegalStateException.class);
-
-        // when
-        gitChangeResolver.diff(gitFolder.getRoot(), "HEAD", "HEAD~0");
     }
 
     @Test

--- a/core/src/test/java/org/arquillian/smart/testing/scm/git/GitChangeResolverTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/scm/git/GitChangeResolverTest.java
@@ -16,7 +16,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,7 +25,7 @@ import static org.assertj.core.api.Assertions.tuple;
 public class GitChangeResolverTest {
 
     @Rule
-    public final TemporaryFolder gitFolder = new TemporaryFolder(new File("/tmp"));
+    public final TemporaryFolder gitFolder = new TemporaryFolder();
 
     private GitChangeResolver gitChangeResolver;
 

--- a/core/src/test/java/org/arquillian/smart/testing/scm/git/GitChangeResolverWithoutGitTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/scm/git/GitChangeResolverWithoutGitTest.java
@@ -1,38 +1,23 @@
 package org.arquillian.smart.testing.scm.git;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 import org.arquillian.smart.testing.configuration.Configuration;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class GitChangeResolverWithoutGitTest {
 
     @Rule
-    public RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+    public TemporaryFolder  gitFolder = new TemporaryFolder();
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
     private GitChangeResolver gitChangeResolver;
-    private File gitFolder;
-
-    @Before
-    public void createTempFolder() throws IOException {
-        if (System.getProperty("os.name").startsWith("Windows")) {
-            System.setProperty("java.io.tmpdir", "C:\\temp");
-        } else {
-            System.setProperty("java.io.tmpdir", "/tmp");
-        }
-        gitFolder = Files.createTempDirectory(".junit-").toFile();
-    }
 
     @After
     public void closeRepo() throws Exception {
@@ -46,7 +31,7 @@ public class GitChangeResolverWithoutGitTest {
         this.gitChangeResolver = new GitChangeResolver();
 
         // when
-        final boolean applicable = gitChangeResolver.isApplicable(gitFolder);
+        final boolean applicable = gitChangeResolver.isApplicable(gitFolder.getRoot());
 
         // then
         assertThat(applicable).isFalse();
@@ -61,7 +46,7 @@ public class GitChangeResolverWithoutGitTest {
         thrown.expect(IllegalStateException.class);
 
         // when
-        gitChangeResolver.diff(gitFolder, Configuration.load(), "custom");
+        gitChangeResolver.diff(gitFolder.getRoot(), Configuration.load(), "custom");
     }
 
 }

--- a/core/src/test/java/org/arquillian/smart/testing/scm/git/GitChangeResolverWithoutGitTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/scm/git/GitChangeResolverWithoutGitTest.java
@@ -3,17 +3,20 @@ package org.arquillian.smart.testing.scm.git;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import org.arquillian.smart.testing.configuration.Configuration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.rules.ExpectedException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class GitChangeResolverWithoutGitTest {
+
+    @Rule
+    public RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -23,13 +26,17 @@ public class GitChangeResolverWithoutGitTest {
 
     @Before
     public void createTempFolder() throws IOException {
-        gitFolder = Files.createTempDirectory("junit-").toFile();
+        if (System.getProperty("os.name").startsWith("Windows")) {
+            System.setProperty("java.io.tmpdir", "C:\\temp");
+        } else {
+            System.setProperty("java.io.tmpdir", "/tmp");
+        }
+        gitFolder = Files.createTempDirectory(".junit-").toFile();
     }
 
     @After
-    public void closeRepoAndDeleteTempFolder() throws Exception {
+    public void closeRepo() throws Exception {
         this.gitChangeResolver.close();
-        Files.deleteIfExists(Paths.get(gitFolder.toString()));
     }
 
 

--- a/core/src/test/java/org/arquillian/smart/testing/scm/git/GitChangeResolverWithoutGitTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/scm/git/GitChangeResolverWithoutGitTest.java
@@ -1,0 +1,60 @@
+package org.arquillian.smart.testing.scm.git;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.arquillian.smart.testing.configuration.Configuration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GitChangeResolverWithoutGitTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private GitChangeResolver gitChangeResolver;
+    private File gitFolder;
+
+    @Before
+    public void createTempFolder() throws IOException {
+        gitFolder = Files.createTempDirectory("junit-").toFile();
+    }
+
+    @After
+    public void closeRepoAndDeleteTempFolder() throws Exception {
+        this.gitChangeResolver.close();
+        Files.deleteIfExists(Paths.get(gitFolder.toString()));
+    }
+
+
+    @Test
+    public void should_not_applicable_when_git_repository_is_not_initialized()  {
+        // given
+        this.gitChangeResolver = new GitChangeResolver();
+
+        // when
+        final boolean applicable = gitChangeResolver.isApplicable(gitFolder);
+
+        // then
+        assertThat(applicable).isFalse();
+    }
+
+    @Test
+    public void should_throw_exception_for_fetching_all_changes_when_git_repository_is_not_initialized() {
+        // given
+        this.gitChangeResolver = new GitChangeResolver();
+
+        // then
+        thrown.expect(IllegalStateException.class);
+
+        // when
+        gitChangeResolver.diff(gitFolder, Configuration.load(), "custom");
+    }
+
+}

--- a/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/SmartTestingMavenConfigurer.java
+++ b/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/SmartTestingMavenConfigurer.java
@@ -133,7 +133,9 @@ class SmartTestingMavenConfigurer extends AbstractMavenLifecycleParticipant {
             .flatMap(Collection::stream)
             .collect(Collectors.toSet());
 
-        changeStorage.store(changes, projectDirectory);
+        if (!changes.isEmpty()) {
+            changeStorage.store(changes, projectDirectory);
+        }
     }
 
     private void configureExtension(MavenSession session, Configuration configuration) {

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/AffectedTestsDetector.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/AffectedTestsDetector.java
@@ -72,7 +72,7 @@ public class AffectedTestsDetector implements TestExecutionPlanner {
         final Collection<Change> files = changeStorage.read(projectDir)
             .orElseGet(() -> {
                 logger.warn("No cached changes detected... using direct resolution");
-                return changeResolver.diff(projectDir, configuration);
+                return changeResolver.diff(projectDir, configuration, getName());
             });
 
         logger.debug("Time To Build Affected Dependencies Graph %d ms", (System.currentTimeMillis() - beforeDetection));

--- a/strategies/changed/src/main/java/org/arquillian/smart/testing/vcs/git/ChangedTestsDetector.java
+++ b/strategies/changed/src/main/java/org/arquillian/smart/testing/vcs/git/ChangedTestsDetector.java
@@ -55,7 +55,7 @@ public class ChangedTestsDetector implements TestExecutionPlanner {
         final Collection<Change> files = changeStorage.read(projectDir)
             .orElseGet(() -> {
                 logger.warn("No cached changes detected... using direct resolution");
-                return changeResolver.diff(projectDir, configuration);
+                return changeResolver.diff(projectDir, configuration, getName());
             });
 
         return files.stream()

--- a/strategies/changed/src/main/java/org/arquillian/smart/testing/vcs/git/NewTestsDetector.java
+++ b/strategies/changed/src/main/java/org/arquillian/smart/testing/vcs/git/NewTestsDetector.java
@@ -54,7 +54,7 @@ public class NewTestsDetector implements TestExecutionPlanner {
         final Collection<Change> changes = changeStorage.read(projectDir)
             .orElseGet(() -> {
                 logger.warn("No cached changes detected... using direct resolution");
-                return changeResolver.diff(projectDir, configuration);
+                return changeResolver.diff(projectDir, configuration, getName());
         });
 
         return changes.stream()


### PR DESCRIPTION
#### Short description of what this resolves:
We are initializing all implementation of `ChangeResolver` using ServiceLoader. Currently if we tries to initialize `GitChangeResolver` it's failing due to `IllegalArgumentException with gitdir is not present` which we haven't catched in either in constrcutor of `GitChangeResolver` or in `isApplicable` method. 

#### Changes proposed in this pull request:

- Catching IllegalArgumentException in constructor of `GitChangeResolver` & `isApplicable` method to avoid unexpected exception while running tests


Fixes #216 
