### PR TITLE
Adds support for different instances of surefire logger 

### DIFF
--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/BuildConfigurator.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/BuildConfigurator.java
@@ -1,6 +1,8 @@
 package org.arquillian.smart.testing.ftest.testbed.project;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.ServerSocket;
@@ -10,6 +12,10 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
 import static java.lang.System.getProperty;
 import static java.util.Arrays.stream;
@@ -183,8 +189,20 @@ public class BuildConfigurator {
         return this;
     }
 
-    public BuildConfigurator useMavenVersion(String mavenVersion){
+    public BuildConfigurator useMavenVersion(String mavenVersion) {
         this.mavenVersion = mavenVersion;
+        return this;
+    }
+
+    public BuildConfigurator useSurefireVersion(String version) {
+        File pomFile = new File(projectBuilder.getRoot().toAbsolutePath().toString()+ File.separator + "pom.xml");
+        try {
+            Model model = new MavenXpp3Reader().read(new FileInputStream(pomFile));
+            model.getProperties().setProperty("version.surefire.plugin", version);
+            new MavenXpp3Writer().write(new FileOutputStream(pomFile), model);
+        } catch (IOException | XmlPullParserException e) {
+            throw new RuntimeException("Failed setting surefire version in pom.", e);
+        }
         return this;
     }
 
@@ -293,4 +311,5 @@ public class BuildConfigurator {
     void setUsingInstallation(Using usingInstallation) {
         this.usingInstallation = usingInstallation;
     }
+
 }

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectBuilder.java
@@ -54,6 +54,10 @@ public class ProjectBuilder {
         return accumulatedTestResults();
     }
 
+    Path getRoot() {
+        return root;
+    }
+
     private BuiltProject executeGoals(String... goals) {
         final PomEquippedEmbeddedMaven embeddedMaven =
             EmbeddedMaven.forProject(root.toAbsolutePath().toString() + "/pom.xml");

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/affected/LocalChangesAffectedTestsSelectionExecutionFunctionalTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/affected/LocalChangesAffectedTestsSelectionExecutionFunctionalTest.java
@@ -58,7 +58,12 @@ public class LocalChangesAffectedTestsSelectionExecutionFunctionalTest {
             "Inlined variable in a method");
 
         // when
-        final TestResults actualTestResults = project.build("config/impl-base").run();
+        final TestResults actualTestResults = project
+            .build("config/impl-base")
+                .options()
+                    .useSurefireVersion("2.20.1")
+                .configure()
+            .run();
 
         // then
         assertThat(actualTestResults.accumulatedPerTestClass()).containsAll(expectedTestResults).hasSameSizeAs(expectedTestResults);

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/SmartTestingSurefireProvider.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/SmartTestingSurefireProvider.java
@@ -32,7 +32,6 @@ public class SmartTestingSurefireProvider implements SurefireProvider {
     private final ProviderParameters bootParams;
     private final Configuration configuration;
     private SurefireProvider surefireProvider;
-    private Object consoleLogger;
 
     @SuppressWarnings("unused") // Used by Surefire Core
     public SmartTestingSurefireProvider(ProviderParameters bootParams) {
@@ -40,9 +39,8 @@ public class SmartTestingSurefireProvider implements SurefireProvider {
         this.paramParser = new ProviderParametersParser(this.bootParams);
         this.surefireProviderFactory = new SurefireProviderFactory(this.paramParser);
         this.surefireProvider = surefireProviderFactory.createInstance();
-        this.consoleLogger = getConsoleLogger();
         this.configuration = Configuration.loadPrecalculated(getProjectDir());
-        Log.setLoggerFactory(new SurefireProviderLoggerFactory(consoleLogger, isAnyDebugEnabled()));
+        Log.setLoggerFactory(new SurefireProviderLoggerFactory(getConsoleLogger(), isAnyDebugEnabled()));
     }
 
     SmartTestingSurefireProvider(ProviderParameters bootParams, SurefireProviderFactory surefireProviderFactory) {
@@ -50,9 +48,8 @@ public class SmartTestingSurefireProvider implements SurefireProvider {
         this.paramParser = new ProviderParametersParser(this.bootParams);
         this.surefireProviderFactory = surefireProviderFactory;
         this.surefireProvider = surefireProviderFactory.createInstance();
-        this.consoleLogger = getConsoleLogger();
         this.configuration = Configuration.loadPrecalculated(getProjectDir());
-        Log.setLoggerFactory(new SurefireProviderLoggerFactory(consoleLogger, isAnyDebugEnabled()));
+        Log.setLoggerFactory(new SurefireProviderLoggerFactory(getConsoleLogger(), isAnyDebugEnabled()));
     }
 
     public Iterable<Class<?>> getSuites() {

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/logger/SurefireProviderLoggerFactory.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/logger/SurefireProviderLoggerFactory.java
@@ -1,6 +1,11 @@
 package org.arquillian.smart.testing.surefire.provider.logger;
 
-import org.apache.maven.surefire.report.ConsoleLogger;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Optional;
+import org.arquillian.smart.testing.logger.DefaultLoggerFactory;
 import org.arquillian.smart.testing.logger.Logger;
 import org.arquillian.smart.testing.logger.LoggerFactory;
 
@@ -8,10 +13,12 @@ import static java.lang.String.format;
 
 public class SurefireProviderLoggerFactory implements LoggerFactory {
 
-    private ConsoleLogger logger;
+    private Object logger;
     private boolean debugLogEnabled;
+    public static final String NOT_COMPATIBLE_MESSAGE = "The Surefire version that you are using is not fully compatible "
+        + "with the current version of Smart Testing. Please create an issue.";
 
-    public SurefireProviderLoggerFactory(ConsoleLogger consoleLogger, boolean debugLogEnabled) {
+    public SurefireProviderLoggerFactory(Object consoleLogger, boolean debugLogEnabled) {
         this.logger = consoleLogger;
         this.debugLogEnabled = debugLogEnabled;
     }
@@ -25,32 +32,61 @@ public class SurefireProviderLoggerFactory implements LoggerFactory {
 
         private static final String PREFIX = "%s: Smart Testing Extension - ";
 
-        private ConsoleLogger consoleLogger;
+        private Object consoleLogger;
+        private Method logMethod;
 
-        private SurefireProviderLogger(ConsoleLogger consoleLogger) {
+        private SurefireProviderLogger(Object consoleLogger) {
             this.consoleLogger = consoleLogger;
+            Optional<Method> method = Arrays.stream(consoleLogger.getClass().getMethods())
+                .filter(this::isPublicConsoleLogMethod)
+                .findFirst();
+
+            if (method.isPresent()) {
+                logMethod = method.get();
+            } else {
+                new DefaultLoggerFactory()
+                    .getLogger()
+                    .warn(NOT_COMPATIBLE_MESSAGE);
+            }
         }
 
         @Override
         public void info(String msg, Object... args) {
-            consoleLogger.info(getFormattedMsg("INFO", msg, args));
+            logMessage(getFormattedMsg("INFO", msg, args));
         }
 
         @Override
         public void warn(String msg, Object... args) {
-            consoleLogger.info(getFormattedMsg("WARN", msg, args));
+            logMessage(getFormattedMsg("WARN", msg, args));
         }
 
         @Override
         public void debug(String msg, Object... args) {
-            if(debugLogEnabled) {
-                consoleLogger.info(getFormattedMsg("DEBUG", msg, args));
+            if (debugLogEnabled) {
+                logMessage(getFormattedMsg("DEBUG", msg, args));
             }
         }
 
         @Override
         public void error(String msg, Object... args) {
-            consoleLogger.info(getFormattedMsg("ERROR", msg, args));
+            logMessage(getFormattedMsg("ERROR", msg, args));
+        }
+
+        private void logMessage(String message) {
+            if (logMethod != null) {
+                try {
+                    logMethod.invoke(consoleLogger, message);
+                    return;
+                } catch (IllegalAccessException | InvocationTargetException e) {
+                }
+            }
+            System.out.println(message);
+        }
+
+        private boolean isPublicConsoleLogMethod(Method method){
+            return method.getParameterCount() == 1
+                && method.getParameterTypes()[0] == String.class
+                && Arrays.asList(method.getModifiers()).contains(Modifier.PUBLIC);
         }
 
         private String getFormattedMsg(String level, String msg, Object... args) {
@@ -58,7 +94,7 @@ public class SurefireProviderLoggerFactory implements LoggerFactory {
                 msg = format(msg, args);
             }
             StringBuffer formattedMsg = new StringBuffer(format(PREFIX, level)).append(msg);
-            if (consoleLogger.getClass().getName().equals("org.apache.maven.surefire.booter.ForkingRunListener")) {
+            if (consoleLogger != null && consoleLogger.getClass().getName().equals("org.apache.maven.surefire.booter.ForkingRunListener")) {
                 return formattedMsg.append(System.lineSeparator()).toString();
             }
             return formattedMsg.toString();
@@ -68,6 +104,5 @@ public class SurefireProviderLoggerFactory implements LoggerFactory {
         public boolean isDebug() {
             return debugLogEnabled;
         }
-
     }
 }

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/logger/SurefireProviderLoggerFactory.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/logger/SurefireProviderLoggerFactory.java
@@ -37,17 +37,7 @@ public class SurefireProviderLoggerFactory implements LoggerFactory {
 
         private SurefireProviderLogger(Object consoleLogger) {
             this.consoleLogger = consoleLogger;
-            Optional<Method> method = Arrays.stream(consoleLogger.getClass().getMethods())
-                .filter(this::isPublicConsoleLogMethod)
-                .findFirst();
-
-            if (method.isPresent()) {
-                logMethod = method.get();
-            } else {
-                new DefaultLoggerFactory()
-                    .getLogger()
-                    .warn(NOT_COMPATIBLE_MESSAGE);
-            }
+            this.logMethod = getLogMethod();
         }
 
         @Override
@@ -81,6 +71,23 @@ public class SurefireProviderLoggerFactory implements LoggerFactory {
                 }
             }
             System.out.println(message);
+        }
+
+        private Method getLogMethod() {
+            if (consoleLogger != null) {
+                Optional<Method> method = Arrays.stream(consoleLogger.getClass().getMethods())
+                    .filter(this::isPublicConsoleLogMethod)
+                    .findFirst();
+
+                if (method.isPresent()) {
+                    return method.get();
+                } else {
+                    new DefaultLoggerFactory()
+                        .getLogger()
+                        .warn(NOT_COMPATIBLE_MESSAGE);
+                }
+            }
+            return null;
         }
 
         private boolean isPublicConsoleLogMethod(Method method){


### PR DESCRIPTION
<!-- 
Many thanks for contributing to Arquillian! Together we can make the testing world better.

Please tell us what this PR brings following the template we provided. 
And don't forget to link to the issue (or create one if there is none).

If you are still working on the change please prefix this pull request title with "WIP"

YOU CAN DELETE THIS COMMENT :)
-->

#### Short description of what this resolves:
Surefire Loggers returns an instance of `ConsoleLogger` in version 2.19 and an instance of `ConsoleStream` in newer versions from 2.20 on wards.

Support for both the versions is now included with use of reflections.

#### Changes proposed in this pull request:

- Use reflections to identify the correct Logger instance.
- Adds option to configure surefire version in test bed.

Fixes #201 #218 
