### PR TITLE
Fixes typo in usage document example.

### DIFF
--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -35,12 +35,13 @@ You can still use the process described at <<Maven >= 3.1.X>> or use the new _co
 creating folder called `.mvn` in the root of your project and create inside it an `extensions.xml` file
 which registers the smart testing extension:
 
+[[smart-testing-extension]]
 [source, xml,indent=0]
 .${maven.projectBasedir}/.mvn/extensions.xml
 ----
 include::../functional-tests/test-bed/src/main/resources/extensions.xml[]
 ----
-
+copyToClipboard:smart-testing-extension[]
 
 ++++
 <script type="text/javascript" src="https://asciinema.org/a/131840.js" id="asciicast-131840" async></script>

--- a/docs/refcard.adoc
+++ b/docs/refcard.adoc
@@ -2,11 +2,13 @@
 
 === Installation
 
+[[extension]]
 [source, xml,indent=0]
 .${maven.projectBasedir}/.mvn/extensions.xml
 ----
 include::../functional-tests/test-bed/src/main/resources/extensions.xml[]
 ----
+copyToClipboard:extension[]
 
 === Configuration
 
@@ -96,7 +98,9 @@ a|`false`
 
 === Configuration File
 
+[[configuration-file]]
 [source, yaml, indent=0]
 ----
 include::../core/src/test/resources/configuration/smart-testing-with-lastChanges.yml[]
 ----
+copyToClipboard:configuration-file[]

--- a/docs/usage.adoc
+++ b/docs/usage.adoc
@@ -13,7 +13,7 @@ Remember that the default **mode** is `const:core/src/main/java/org/arquillian/s
 *You want to run only tests that you've just added or modified locally*
 
 [[selectingChanged]]
-`mvn clean test -Dconst:core/src/main/java/org/arquillian/smart/testing/configuration/Configuration.java[name="SMART_TESTING"]="new, changed"` `mvn clean test -Dsmart.testing="new, changed"`  copyToClipboard:selectingChanged[]
+`mvn clean test -Dconst:core/src/main/java/org/arquillian/smart/testing/configuration/Configuration.java[name="SMART_TESTING"]="new, changed"`  copyToClipboard:selectingChanged[]
 
 *You want to run all tests but given priority to the latest tests added or modified*
 


### PR DESCRIPTION
<!-- 
Many thanks for contributing to Arquillian! Together we can make the testing world better.

Please tell us what this PR brings following the template we provided. 
And don't forget to link to the issue (or create one if there is none).

If you are still working on the change please prefix this pull request title with "WIP"

YOU CAN DELETE THIS COMMENT :)
-->

#### Short description of what this resolves:
Command duplicated in usage example.

#### Changes proposed in this pull request:

- Deletes duplicate command in usage.
- Adds copy to clipboard option for smart testing extension.


Fixes #
