### PR TITLE
fix(assertions) Finds effective poms recursively

### DIFF
--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/customAssertions/BuiltProjectAssert.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/customAssertions/BuiltProjectAssert.java
@@ -30,7 +30,8 @@ public class BuiltProjectAssert extends AbstractAssert<BuiltProjectAssert, Built
      *     effectivePom file to verify
      **/
     public BuiltProjectAssert allBuiltSubModulesContainEffectivePom(String effectivePom) {
-        actual.getModules().forEach(subModule -> assertThat(subModule).containsEffectivePom(effectivePom));
+        actual.getModules().forEach(subModule -> assertThat(subModule).allBuiltSubModulesContainEffectivePom(effectivePom));
+        containsEffectivePom(effectivePom);
         return this;
     }
 
@@ -41,11 +42,12 @@ public class BuiltProjectAssert extends AbstractAssert<BuiltProjectAssert, Built
      *     report file to verify
      **/
     public BuiltProjectAssert allBuiltSubModulesWithTestExecutionsContainReport(String report) {
-        actual.getModules().forEach(subModule -> assertThat(subModule).hasReportFile(report));
+        actual.getModules().forEach(subModule -> assertThat(subModule).allBuiltSubModulesWithTestExecutionsContainReport(report));
+        hasReportFile(report);
         return this;
     }
 
-    private BuiltProjectAssert containsEffectivePom(String effectivePom) {
+    private void containsEffectivePom(String effectivePom) {
         final String smartTestingExtension = "org.arquillian.smart.testing";
         if (actual.getTargetDirectory().exists() && !actual.getModel().getPackaging().equals("pom")) {
             final File pomFile = new File(actual.getTargetDirectory(), effectivePom);
@@ -53,10 +55,9 @@ public class BuiltProjectAssert extends AbstractAssert<BuiltProjectAssert, Built
             fileAssert.exists();
             Assertions.assertThat(contentOf(pomFile)).contains(smartTestingExtension);
         }
-        return this;
     }
 
-    private BuiltProjectAssert hasReportFile(String report) {
+    private void hasReportFile(String report) {
         final File targetDirectory = actual.getTargetDirectory();
         Path reportPath = Paths.get(targetDirectory.toString(), SMART_TESTING_TARGET_DIRECTORY_NAME, REPORTING_SUBDIRECTORY);
         final FileAssert fileAssert = new FileAssert(new File(reportPath.toString(), report));
@@ -67,10 +68,8 @@ public class BuiltProjectAssert extends AbstractAssert<BuiltProjectAssert, Built
                 fileAssert.doesNotExist();
             }
         } else {
-            allBuiltSubModulesWithTestExecutionsContainReport(report);
             fileAssert.doesNotExist();
         }
-        return this;
     }
 
     private static boolean isJar(BuiltProject subModule) {

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/customAssertions/SmartTestingSoftAssertions.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/customAssertions/SmartTestingSoftAssertions.java
@@ -5,7 +5,6 @@ import org.assertj.core.api.SoftAssertions;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.BuiltProject;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
-import org.junit.runners.model.MultipleFailureException;
 import org.junit.runners.model.Statement;
 
 public class SmartTestingSoftAssertions extends SoftAssertions implements TestRule {
@@ -23,7 +22,7 @@ public class SmartTestingSoftAssertions extends SoftAssertions implements TestRu
         return new Statement() {
             public void evaluate() throws Throwable {
                 base.evaluate();
-                MultipleFailureException.assertEmpty(errorsCollected());
+                assertAll();
             }
         };
     }


### PR DESCRIPTION
Finds effective poms recursively otherwise the test is green when the expected file is not present in one of the submodules.

fixes: #226 