### PR TITLE
fix: ChangeResolver and ChangeStorage are using correct pahts

### DIFF
--- a/core/src/main/java/org/arquillian/smart/testing/configuration/Configuration.java
+++ b/core/src/main/java/org/arquillian/smart/testing/configuration/Configuration.java
@@ -157,8 +157,11 @@ public class Configuration implements ConfigurationSection {
     public static Configuration loadPrecalculated(File projectDir) {
         final File configFile =
             new LocalStorage(projectDir).duringExecution().temporary().file(SMART_TESTING_YML).getFile();
-
-        return loadConfigurationFromFile(configFile);
+        if (configFile.exists()) {
+            return loadConfigurationFromFile(configFile);
+        } else {
+            return load(projectDir);
+        }
     }
 
     static Configuration loadConfigurationFromFile(File configFile) {

--- a/core/src/main/java/org/arquillian/smart/testing/hub/storage/ChangeStorage.java
+++ b/core/src/main/java/org/arquillian/smart/testing/hub/storage/ChangeStorage.java
@@ -1,14 +1,15 @@
 package org.arquillian.smart.testing.hub.storage;
 
+import java.io.File;
 import java.util.Collection;
 import java.util.Optional;
 import org.arquillian.smart.testing.scm.Change;
 
 public interface ChangeStorage {
 
-    void store(Collection<Change> changes);
+    void store(Collection<Change> changes, File projectDir);
 
-    Optional<Collection<Change>> read();
+    Optional<Collection<Change>> read(File projectDir);
 
 
 }

--- a/core/src/main/java/org/arquillian/smart/testing/hub/storage/local/LocalChangeStorage.java
+++ b/core/src/main/java/org/arquillian/smart/testing/hub/storage/local/LocalChangeStorage.java
@@ -19,25 +19,13 @@ public class LocalChangeStorage implements ChangeStorage {
 
     public static final String SMART_TESTING_SCM_CHANGES = "scm-changes";
 
-    private final String currentDirectory;
-
-    // Used by SPI
-    @SuppressWarnings("unused")
-    public LocalChangeStorage() {
-        this.currentDirectory = ".";
-    }
-
-    public LocalChangeStorage(String currentDirectory) {
-        this.currentDirectory = currentDirectory;
-    }
-
     @Override
-    public void store(Collection<Change> changes) {
+    public void store(Collection<Change> changes, File projectDir) {
         StringBuilder fileContent = new StringBuilder();
         changes.forEach(change -> fileContent.append(change.write()).append(System.lineSeparator()));
 
         LocalStorageFileAction scmChangesFile =
-            new LocalStorage(currentDirectory)
+            new LocalStorage(projectDir)
                 .duringExecution()
                 .temporary()
                 .file(SMART_TESTING_SCM_CHANGES);
@@ -49,9 +37,9 @@ public class LocalChangeStorage implements ChangeStorage {
     }
 
     @Override
-    public Optional<Collection<Change>> read() {
+    public Optional<Collection<Change>> read(File projectDir) {
         final Optional<Path> smartTestingScmChangesOptional =
-            findFileInDirectoryOrParents(new File(currentDirectory).getAbsoluteFile(), SMART_TESTING_SCM_CHANGES);
+            findFileInDirectoryOrParents(projectDir.getAbsoluteFile(), SMART_TESTING_SCM_CHANGES);
 
         if (smartTestingScmChangesOptional.isPresent()) {
 

--- a/core/src/main/java/org/arquillian/smart/testing/scm/spi/ChangeResolver.java
+++ b/core/src/main/java/org/arquillian/smart/testing/scm/spi/ChangeResolver.java
@@ -1,12 +1,13 @@
 package org.arquillian.smart.testing.scm.spi;
 
+import java.io.File;
 import java.util.Collection;
 import org.arquillian.smart.testing.scm.Change;
 
 public interface ChangeResolver extends AutoCloseable {
 
-    Collection<Change> diff();
+    Collection<Change> diff(File projectDir);
 
-    boolean isApplicable();
+    boolean isApplicable(File projectDir);
 
 }

--- a/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/SmartTestingMavenConfigurer.java
+++ b/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/SmartTestingMavenConfigurer.java
@@ -50,7 +50,7 @@ class SmartTestingMavenConfigurer extends AbstractMavenLifecycleParticipant {
 
     @Override
     public void afterProjectsRead(MavenSession session) throws MavenExecutionException {
-        File projectDirectory = session.getCurrentProject().getModel().getProjectDirectory();
+        File projectDirectory = session.getTopLevelProject().getModel().getProjectDirectory();
         Log.setLoggerFactory(new MavenExtensionLoggerFactory(mavenLogger));
         configuration = Configuration.load(projectDirectory);
 

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/AffectedChangesDetectorFactory.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/AffectedChangesDetectorFactory.java
@@ -4,7 +4,6 @@ import java.io.File;
 import org.arquillian.smart.testing.api.TestVerifier;
 import org.arquillian.smart.testing.spi.TestExecutionPlanner;
 import org.arquillian.smart.testing.spi.TestExecutionPlannerFactory;
-import org.arquillian.smart.testing.strategies.affected.detector.FileSystemTestClassDetector;
 
 public class AffectedChangesDetectorFactory implements TestExecutionPlannerFactory {
 
@@ -20,7 +19,7 @@ public class AffectedChangesDetectorFactory implements TestExecutionPlannerFacto
 
     @Override
     public TestExecutionPlanner create(File projectDir, TestVerifier verifier) {
-        return new AffectedTestsDetector(new FileSystemTestClassDetector(projectDir, verifier), verifier);
+        return new AffectedTestsDetector(projectDir, verifier);
     }
 
 }

--- a/strategies/affected/src/test/java/org/arquillian/smart/testing/strategies/affected/AffectedTestsDetectorTest.java
+++ b/strategies/affected/src/test/java/org/arquillian/smart/testing/strategies/affected/AffectedTestsDetectorTest.java
@@ -53,10 +53,11 @@ public class AffectedTestsDetectorTest {
         // given
 
         Change change = new Change(getJavaPath(MyBusinessObject.class), ChangeType.ADD);
-        when(changeStorage.read()).thenReturn(Optional.of(Collections.singletonList(change)));
+        when(changeStorage.read(new File("."))).thenReturn(Optional.of(Collections.singletonList(change)));
 
         final AffectedTestsDetector affectedTestsDetector =
-            new AffectedTestsDetector(fileSystemTestClassDetector, changeStorage, changeResolver, new CustomTestVerifier());
+            new AffectedTestsDetector(fileSystemTestClassDetector, changeStorage, changeResolver, new File("."),
+                new CustomTestVerifier());
 
         // when
         final Collection<TestSelection> tests = affectedTestsDetector.getTests();

--- a/strategies/changed/src/test/java/org/arquillian/smart/testing/vcs/git/NoopStorage.java
+++ b/strategies/changed/src/test/java/org/arquillian/smart/testing/vcs/git/NoopStorage.java
@@ -1,5 +1,6 @@
 package org.arquillian.smart.testing.vcs.git;
 
+import java.io.File;
 import java.util.Collection;
 import java.util.Optional;
 import org.arquillian.smart.testing.hub.storage.ChangeStorage;
@@ -7,12 +8,12 @@ import org.arquillian.smart.testing.scm.Change;
 
 public class NoopStorage implements ChangeStorage {
     @Override
-    public void store(Collection<Change> changes) {
+    public void store(Collection<Change> changes, File projectDir) {
 
     }
 
     @Override
-    public Optional<Collection<Change>> read() {
+    public Optional<Collection<Change>> read(File projectDir) {
         return Optional.empty();
     }
 }


### PR DESCRIPTION
#### Short description of what this resolves:

The classes `ChangeResolver` and `ChangeStorage` are using correct paths set using API method `in`. Similar changes have been applied also to some other parts of the code to have consistent behavior.

Fixes: #228 