### PR TITLE
fix: Strategies and related logic use Configuration provided by API

### DIFF
--- a/core/src/main/java/org/arquillian/smart/testing/api/SmartTesting.java
+++ b/core/src/main/java/org/arquillian/smart/testing/api/SmartTesting.java
@@ -1,12 +1,11 @@
 package org.arquillian.smart.testing.api;
 
-import java.nio.file.Paths;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.arquillian.smart.testing.configuration.Configuration;
 import org.arquillian.smart.testing.TestSelection;
+import org.arquillian.smart.testing.configuration.Configuration;
 import org.arquillian.smart.testing.impl.ConfiguredSmartTestingImpl;
 
 /**
@@ -24,7 +23,7 @@ public class SmartTesting {
      * @return An instance of {@link ConfiguredSmartTesting} class
      */
     public static ConfiguredSmartTesting with(TestVerifier testVerifier) {
-        return with(testVerifier, Configuration.loadPrecalculated(Paths.get("").toFile()));
+        return new ConfiguredSmartTestingImpl(testVerifier);
     }
 
     /**

--- a/core/src/main/java/org/arquillian/smart/testing/impl/ConfiguredSmartTestingImpl.java
+++ b/core/src/main/java/org/arquillian/smart/testing/impl/ConfiguredSmartTestingImpl.java
@@ -11,10 +11,14 @@ import org.arquillian.smart.testing.spi.JavaSPILoader;
 
 public class ConfiguredSmartTestingImpl implements ConfiguredSmartTesting {
 
-    private final Configuration configuration;
+    private Configuration configuration;
     private TestExecutionPlannerLoader testExecutionPlannerLoader;
     private TestVerifier testVerifier;
     private File projectDir;
+
+    public ConfiguredSmartTestingImpl(TestVerifier testVerifier) {
+        this.testVerifier = testVerifier;
+    }
 
     public ConfiguredSmartTestingImpl(TestVerifier testVerifier, Configuration configuration) {
         this.testVerifier = testVerifier;
@@ -53,9 +57,12 @@ public class ConfiguredSmartTestingImpl implements ConfiguredSmartTesting {
             String basedir = System.getProperty("basedir");
             projectDir = new File(basedir != null ? basedir : ".");
         }
+        if (configuration == null) {
+            configuration = Configuration.loadPrecalculated(projectDir);
+        }
         if (testExecutionPlannerLoader == null) {
             testExecutionPlannerLoader =
-                new TestExecutionPlannerLoaderImpl(new JavaSPILoader(), testVerifier, projectDir);
+                new TestExecutionPlannerLoaderImpl(new JavaSPILoader(), testVerifier, projectDir, configuration);
         }
         return new TestStrategyApplierImpl(configuration, testExecutionPlannerLoader, projectDir);
     }

--- a/core/src/main/java/org/arquillian/smart/testing/impl/TestExecutionPlannerLoaderImpl.java
+++ b/core/src/main/java/org/arquillian/smart/testing/impl/TestExecutionPlannerLoaderImpl.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import org.arquillian.smart.testing.api.TestVerifier;
+import org.arquillian.smart.testing.configuration.Configuration;
 import org.arquillian.smart.testing.configuration.StringSimilarityCalculator;
 import org.arquillian.smart.testing.spi.JavaSPILoader;
 import org.arquillian.smart.testing.spi.TestExecutionPlanner;
@@ -12,11 +13,14 @@ import org.arquillian.smart.testing.spi.TestExecutionPlannerFactory;
 class TestExecutionPlannerLoaderImpl implements TestExecutionPlannerLoader {
 
     private final Map<String, TestExecutionPlannerFactory> availableStrategies = new HashMap<>();
+    private final Configuration configuration;
     private final JavaSPILoader spiLoader;
     private final TestVerifier verifier;
     private final File projectDir;
 
-    TestExecutionPlannerLoaderImpl(JavaSPILoader spiLoader, TestVerifier verifier, File projectDir) {
+    TestExecutionPlannerLoaderImpl(JavaSPILoader spiLoader, TestVerifier verifier, File projectDir,
+        Configuration configuration) {
+        this.configuration = configuration;
         this.spiLoader = spiLoader;
         this.verifier = verifier;
         this.projectDir = projectDir;
@@ -29,14 +33,14 @@ class TestExecutionPlannerLoaderImpl implements TestExecutionPlannerLoader {
         }
 
         if (availableStrategies.containsKey(strategy)) {
-            return availableStrategies.get(strategy).create(projectDir, verifier);
+            return availableStrategies.get(strategy).create(projectDir, verifier, configuration);
         } else {
             if (autocorrect) {
                 final StringSimilarityCalculator stringSimilarityCalculator = new StringSimilarityCalculator();
                 final String closestMatch =
                     stringSimilarityCalculator.findClosestMatch(strategy, availableStrategies.keySet());
                 if (availableStrategies.containsKey(closestMatch)) {
-                    return availableStrategies.get(closestMatch).create(projectDir, verifier);
+                    return availableStrategies.get(closestMatch).create(projectDir, verifier, configuration);
                 }
             }
         }

--- a/core/src/main/java/org/arquillian/smart/testing/scm/git/GitChangeResolver.java
+++ b/core/src/main/java/org/arquillian/smart/testing/scm/git/GitChangeResolver.java
@@ -52,8 +52,14 @@ public class GitChangeResolver implements ChangeResolver {
     }
 
     @Override
-    public Set<Change> diff(File projectDir) {
-        Scm scm = Configuration.loadPrecalculated(projectDir).getScm();
+    public Set<Change> diff(File projectDir, Configuration configuration) {
+        Scm scm;
+        if (configuration == null){
+            scm = Configuration.loadPrecalculated(projectDir).getScm();
+        } else {
+            scm = configuration.getScm();
+        }
+
         return diff(projectDir, scm.getRange().getTail(), scm.getRange().getHead());
     }
 

--- a/core/src/main/java/org/arquillian/smart/testing/scm/spi/ChangeResolver.java
+++ b/core/src/main/java/org/arquillian/smart/testing/scm/spi/ChangeResolver.java
@@ -2,11 +2,12 @@ package org.arquillian.smart.testing.scm.spi;
 
 import java.io.File;
 import java.util.Collection;
+import org.arquillian.smart.testing.configuration.Configuration;
 import org.arquillian.smart.testing.scm.Change;
 
 public interface ChangeResolver extends AutoCloseable {
 
-    Collection<Change> diff(File projectDir);
+    Collection<Change> diff(File projectDir, Configuration configuration);
 
     boolean isApplicable(File projectDir);
 

--- a/core/src/main/java/org/arquillian/smart/testing/spi/TestExecutionPlannerFactory.java
+++ b/core/src/main/java/org/arquillian/smart/testing/spi/TestExecutionPlannerFactory.java
@@ -2,6 +2,7 @@ package org.arquillian.smart.testing.spi;
 
 import java.io.File;
 import org.arquillian.smart.testing.api.TestVerifier;
+import org.arquillian.smart.testing.configuration.Configuration;
 
 // TODO remove this extra layer in favor of SPI/DI on concrete planners
 public interface TestExecutionPlannerFactory {
@@ -10,6 +11,6 @@ public interface TestExecutionPlannerFactory {
 
     boolean isFor(String name);
 
-    TestExecutionPlanner create(File projectDir, TestVerifier testVerifier);
+    TestExecutionPlanner create(File projectDir, TestVerifier testVerifier, Configuration configuration);
 
 }

--- a/core/src/test/java/org/arquillian/smart/testing/impl/TestExecutionPlannerLoaderTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/impl/TestExecutionPlannerLoaderTest.java
@@ -5,15 +5,13 @@ import java.util.Collection;
 import java.util.Collections;
 import org.arquillian.smart.testing.TestSelection;
 import org.arquillian.smart.testing.api.TestVerifier;
+import org.arquillian.smart.testing.configuration.Configuration;
 import org.arquillian.smart.testing.spi.JavaSPILoader;
 import org.arquillian.smart.testing.spi.TestExecutionPlanner;
 import org.arquillian.smart.testing.spi.TestExecutionPlannerFactory;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -30,7 +28,7 @@ public class TestExecutionPlannerLoaderTest {
         when(mockedSpiLoader.all(eq(TestExecutionPlannerFactory.class))).thenAnswer(i -> Collections.singletonList(
             new DummyTestExecutionPlannerFactory()));
         final TestExecutionPlannerLoaderImpl testExecutionPlannerLoader =
-            new TestExecutionPlannerLoaderImpl(mockedSpiLoader, resource -> true, projectDir);
+            new TestExecutionPlannerLoaderImpl(mockedSpiLoader, resource -> true, projectDir, mock(Configuration.class));
 
         // when
         final TestExecutionPlanner testExecutionPlanner = testExecutionPlannerLoader.getPlannerForStrategy("dummy", false);
@@ -46,7 +44,7 @@ public class TestExecutionPlannerLoaderTest {
         when(mockedSpiLoader.all(eq(TestExecutionPlannerFactory.class))).thenAnswer(i -> Collections.singletonList(
             new DummyTestExecutionPlannerFactory()));
         final TestExecutionPlannerLoaderImpl testExecutionPlannerLoader =
-            new TestExecutionPlannerLoaderImpl(mockedSpiLoader, resource -> true, projectDir);
+            new TestExecutionPlannerLoaderImpl(mockedSpiLoader, resource -> true, projectDir, mock(Configuration.class));
 
         // when
         final TestExecutionPlanner testExecutionPlanner = testExecutionPlannerLoader.getPlannerForStrategy("dumy", true);
@@ -62,7 +60,7 @@ public class TestExecutionPlannerLoaderTest {
         when(mockedSpiLoader.all(eq(TestExecutionPlannerFactory.class))).thenAnswer(i -> Collections.singletonList(
             new DummyTestExecutionPlannerFactory()));
         final TestExecutionPlannerLoaderImpl testExecutionPlannerLoader =
-            new TestExecutionPlannerLoaderImpl(mockedSpiLoader, resource -> true, projectDir);
+            new TestExecutionPlannerLoaderImpl(mockedSpiLoader, resource -> true, projectDir, mock(Configuration.class));
 
         // when
         final Throwable exception = catchThrowable(() -> testExecutionPlannerLoader.getPlannerForStrategy("new", false));
@@ -79,7 +77,7 @@ public class TestExecutionPlannerLoaderTest {
         final JavaSPILoader mockedSpiLoader = mock(JavaSPILoader.class);
         when(mockedSpiLoader.all(eq(TestExecutionPlannerFactory.class))).thenReturn(Collections.emptyList());
         final TestExecutionPlannerLoaderImpl testExecutionPlannerLoader =
-            new TestExecutionPlannerLoaderImpl(mockedSpiLoader, resource -> true, projectDir);
+            new TestExecutionPlannerLoaderImpl(mockedSpiLoader, resource -> true, projectDir, mock(Configuration.class));
 
         // when
         final Throwable exception = catchThrowable(() -> testExecutionPlannerLoader.getPlannerForStrategy("new", false));
@@ -101,7 +99,7 @@ public class TestExecutionPlannerLoaderTest {
         }
 
         @Override
-        public TestExecutionPlanner create(File projectDir, TestVerifier verifier) {
+        public TestExecutionPlanner create(File projectDir, TestVerifier verifier, Configuration configuration) {
             return new TestExecutionPlanner() {
                 @Override
                 public Collection<TestSelection> getTests() {

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/affected/HistoricalChangesAffectedTestsSelectionExecutionFunctionalTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/affected/HistoricalChangesAffectedTestsSelectionExecutionFunctionalTest.java
@@ -1,6 +1,18 @@
 package org.arquillian.smart.testing.ftest.affected;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.arquillian.smart.testing.RunMode;
+import org.arquillian.smart.testing.TestSelection;
+import org.arquillian.smart.testing.api.SmartTesting;
+import org.arquillian.smart.testing.configuration.Configuration;
+import org.arquillian.smart.testing.ftest.customAssertions.SmartTestingSoftAssertions;
+import org.arquillian.smart.testing.ftest.newtests.HistoricalChangesNewTestsSelectionExecutionFunctionalTest;
+import org.arquillian.smart.testing.ftest.testbed.ProjectPersistTest;
+import org.arquillian.smart.testing.ftest.testbed.ProjectPersistUsingPropertyTest;
 import org.arquillian.smart.testing.ftest.testbed.project.Project;
 import org.arquillian.smart.testing.ftest.testbed.project.TestResults;
 import org.arquillian.smart.testing.ftest.testbed.testresults.TestResult;
@@ -22,6 +34,9 @@ public class HistoricalChangesAffectedTestsSelectionExecutionFunctionalTest {
 
     @Rule
     public final TestBed testBed = new TestBed(GIT_CLONE);
+
+    @Rule
+    public final SmartTestingSoftAssertions softly = new SmartTestingSoftAssertions();
 
     @Test
     public void should_only_execute_tests_related_to_single_commit_in_business_logic_when_affected_is_enabled() throws Exception {
@@ -71,7 +86,37 @@ public class HistoricalChangesAffectedTestsSelectionExecutionFunctionalTest {
             .run();
 
         // then
-        assertThat(actualTestResults.accumulatedPerTestClass()).containsAll(expectedTestResults).hasSameSizeAs(expectedTestResults);
+        softly.assertThat(actualTestResults.accumulatedPerTestClass()).containsAll(expectedTestResults).hasSameSizeAs(expectedTestResults);
+
+        // and also
+        verifySmartTestingAPI(expectedTestResults, project);
     }
 
+    private void verifySmartTestingAPI(Collection<TestResult> expectedTestResults, Project project) {
+        // given
+        Configuration configuration = Configuration.load();
+        configuration.setStrategies("affected");
+        configuration.setMode(RunMode.SELECTING);
+        configuration.getScm().setLastChanges("2");
+        List<String> expectedTestClasses = expectedTestResults
+            .stream()
+            .map(TestResult::getClassName)
+            .collect(Collectors.toList());
+
+        ArrayList<String> toOptimize = new ArrayList<>(expectedTestClasses);
+        toOptimize.add(ProjectPersistTest.class.getName());
+        toOptimize.add(ProjectPersistUsingPropertyTest.class.getName());
+        toOptimize.add(HistoricalChangesNewTestsSelectionExecutionFunctionalTest.class.getName());
+
+        // when
+        Set<TestSelection> testSelections = SmartTesting
+            .with(test -> test.endsWith("Test") || test.endsWith("TestCase"), configuration)
+            .in(project.getRoot().toFile())
+            .applyOnNames(toOptimize);
+
+        Set<String> optimizedClassNames = SmartTesting.getNames(testSelections);
+
+        // then
+        softly.assertThat(optimizedClassNames).containsAll(expectedTestClasses).hasSameSizeAs(expectedTestClasses);
+    }
 }

--- a/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/SmartTestingMavenConfigurer.java
+++ b/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/SmartTestingMavenConfigurer.java
@@ -66,7 +66,7 @@ class SmartTestingMavenConfigurer extends AbstractMavenLifecycleParticipant {
 
         if (configuration.areStrategiesDefined()) {
             configureExtension(session, configuration);
-            calculateChanges(projectDirectory);
+            calculateChanges(projectDirectory, configuration);
             Runtime.getRuntime().addShutdownHook(new Thread(() -> purgeLocalStorage(session)));
         } else {
             logStrategiesNotDefined();
@@ -122,11 +122,11 @@ class SmartTestingMavenConfigurer extends AbstractMavenLifecycleParticipant {
         purgeLocalStorage(session);
     }
 
-    private void calculateChanges(File projectDirectory) {
+    private void calculateChanges(File projectDirectory, Configuration configuration) {
         final Iterable<ChangeResolver> changeResolvers =
             new JavaSPILoader().all(ChangeResolver.class, resolver -> resolver.isApplicable(projectDirectory));
         final Collection<Change> changes = stream(changeResolvers.spliterator(), false)
-            .map(changeResolver -> changeResolver.diff(projectDirectory))
+            .map(changeResolver -> changeResolver.diff(projectDirectory, configuration))
             .flatMap(Collection::stream)
             .collect(Collectors.toSet());
 

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/AffectedChangesDetectorFactory.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/AffectedChangesDetectorFactory.java
@@ -2,6 +2,7 @@ package org.arquillian.smart.testing.strategies.affected;
 
 import java.io.File;
 import org.arquillian.smart.testing.api.TestVerifier;
+import org.arquillian.smart.testing.configuration.Configuration;
 import org.arquillian.smart.testing.spi.TestExecutionPlanner;
 import org.arquillian.smart.testing.spi.TestExecutionPlannerFactory;
 
@@ -18,8 +19,8 @@ public class AffectedChangesDetectorFactory implements TestExecutionPlannerFacto
     }
 
     @Override
-    public TestExecutionPlanner create(File projectDir, TestVerifier verifier) {
-        return new AffectedTestsDetector(projectDir, verifier);
+    public TestExecutionPlanner create(File projectDir, TestVerifier verifier, Configuration configuration) {
+        return new AffectedTestsDetector(projectDir, verifier, configuration);
     }
 
 }

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/AffectedTestsDetector.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/AffectedTestsDetector.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.arquillian.smart.testing.configuration.Configuration;
 import org.arquillian.smart.testing.logger.Logger;
 import org.arquillian.smart.testing.TestSelection;
 import org.arquillian.smart.testing.api.TestVerifier;
@@ -29,22 +30,25 @@ public class AffectedTestsDetector implements TestExecutionPlanner {
     private final ChangeStorage changeStorage;
     private final File projectDir;
     private final TestVerifier testVerifier;
+    private final Configuration configuration;
 
-    AffectedTestsDetector(File projectDir, TestVerifier testVerifier) {
+    AffectedTestsDetector(File projectDir, TestVerifier testVerifier, Configuration configuration) {
         this(new FileSystemTestClassDetector(projectDir, testVerifier),
             new JavaSPILoader().onlyOne(ChangeStorage.class).get(),
             new JavaSPILoader().onlyOne(ChangeResolver.class).get(),
             projectDir,
-            testVerifier);
+            testVerifier,
+            configuration);
     }
 
     AffectedTestsDetector(TestClassDetector testClassDetector, ChangeStorage changeStorage, ChangeResolver changeResolver,
-        File projectDir, TestVerifier testVerifier) {
+        File projectDir, TestVerifier testVerifier, Configuration configuration) {
         this.testClassDetector = testClassDetector;
         this.changeStorage = changeStorage;
         this.changeResolver = changeResolver;
         this.projectDir = projectDir;
         this.testVerifier = testVerifier;
+        this.configuration = configuration;
     }
 
     @Override
@@ -68,7 +72,7 @@ public class AffectedTestsDetector implements TestExecutionPlanner {
         final Collection<Change> files = changeStorage.read(projectDir)
             .orElseGet(() -> {
                 logger.warn("No cached changes detected... using direct resolution");
-                return changeResolver.diff(projectDir);
+                return changeResolver.diff(projectDir, configuration);
             });
 
         logger.debug("Time To Build Affected Dependencies Graph %d ms", (System.currentTimeMillis() - beforeDetection));

--- a/strategies/affected/src/test/java/org/arquillian/smart/testing/strategies/affected/AffectedTestsDetectorTest.java
+++ b/strategies/affected/src/test/java/org/arquillian/smart/testing/strategies/affected/AffectedTestsDetectorTest.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import java.util.Set;
 import org.arquillian.smart.testing.TestSelection;
 import org.arquillian.smart.testing.api.TestVerifier;
+import org.arquillian.smart.testing.configuration.Configuration;
 import org.arquillian.smart.testing.hub.storage.ChangeStorage;
 import org.arquillian.smart.testing.scm.Change;
 import org.arquillian.smart.testing.scm.ChangeType;
@@ -23,6 +24,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -57,7 +59,7 @@ public class AffectedTestsDetectorTest {
 
         final AffectedTestsDetector affectedTestsDetector =
             new AffectedTestsDetector(fileSystemTestClassDetector, changeStorage, changeResolver, new File("."),
-                new CustomTestVerifier());
+                new CustomTestVerifier(), mock(Configuration.class));
 
         // when
         final Collection<TestSelection> tests = affectedTestsDetector.getTests();

--- a/strategies/changed/src/main/java/org/arquillian/smart/testing/vcs/git/ChangedFilesDetectorFactory.java
+++ b/strategies/changed/src/main/java/org/arquillian/smart/testing/vcs/git/ChangedFilesDetectorFactory.java
@@ -2,6 +2,7 @@ package org.arquillian.smart.testing.vcs.git;
 
 import java.io.File;
 import org.arquillian.smart.testing.api.TestVerifier;
+import org.arquillian.smart.testing.configuration.Configuration;
 import org.arquillian.smart.testing.spi.TestExecutionPlanner;
 import org.arquillian.smart.testing.spi.TestExecutionPlannerFactory;
 
@@ -18,7 +19,7 @@ public class ChangedFilesDetectorFactory implements TestExecutionPlannerFactory 
     }
 
     @Override
-    public TestExecutionPlanner create(File projectDir, TestVerifier verifier) {
-        return new ChangedTestsDetector(projectDir, verifier);
+    public TestExecutionPlanner create(File projectDir, TestVerifier verifier, Configuration configuration) {
+        return new ChangedTestsDetector(projectDir, verifier, configuration);
     }
 }

--- a/strategies/changed/src/main/java/org/arquillian/smart/testing/vcs/git/ChangedTestsDetector.java
+++ b/strategies/changed/src/main/java/org/arquillian/smart/testing/vcs/git/ChangedTestsDetector.java
@@ -6,6 +6,7 @@ import java.util.EnumSet;
 import java.util.stream.Collectors;
 import org.arquillian.smart.testing.TestSelection;
 import org.arquillian.smart.testing.api.TestVerifier;
+import org.arquillian.smart.testing.configuration.Configuration;
 import org.arquillian.smart.testing.hub.storage.ChangeStorage;
 import org.arquillian.smart.testing.logger.Log;
 import org.arquillian.smart.testing.logger.Logger;
@@ -25,20 +26,23 @@ public class ChangedTestsDetector implements TestExecutionPlanner {
     private final ChangeStorage changeStorage;
     private final File projectDir;
     private final TestVerifier testVerifier;
+    private final Configuration configuration;
 
-    public ChangedTestsDetector(File projectDir, TestVerifier testVerifier) {
+    public ChangedTestsDetector(File projectDir, TestVerifier testVerifier, Configuration configuration) {
         this(new JavaSPILoader().onlyOne(ChangeResolver.class).get(),
             new JavaSPILoader().onlyOne(ChangeStorage.class).get(),
             projectDir,
-            testVerifier);
+            testVerifier,
+            configuration);
     }
 
     public ChangedTestsDetector(ChangeResolver changeResolver, ChangeStorage changeStorage, File projectDir,
-        TestVerifier testVerifier) {
+        TestVerifier testVerifier, Configuration configuration) {
         this.changeResolver = changeResolver;
         this.changeStorage = changeStorage;
         this.projectDir = projectDir;
         this.testVerifier = testVerifier;
+        this.configuration = configuration;
     }
 
     @Override
@@ -51,7 +55,7 @@ public class ChangedTestsDetector implements TestExecutionPlanner {
         final Collection<Change> files = changeStorage.read(projectDir)
             .orElseGet(() -> {
                 logger.warn("No cached changes detected... using direct resolution");
-                return changeResolver.diff(projectDir);
+                return changeResolver.diff(projectDir, configuration);
             });
 
         return files.stream()

--- a/strategies/changed/src/main/java/org/arquillian/smart/testing/vcs/git/NewTestsDetector.java
+++ b/strategies/changed/src/main/java/org/arquillian/smart/testing/vcs/git/NewTestsDetector.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 import org.arquillian.smart.testing.TestSelection;
 import org.arquillian.smart.testing.api.TestVerifier;
+import org.arquillian.smart.testing.configuration.Configuration;
 import org.arquillian.smart.testing.hub.storage.ChangeStorage;
 import org.arquillian.smart.testing.logger.Log;
 import org.arquillian.smart.testing.logger.Logger;
@@ -23,21 +24,24 @@ public class NewTestsDetector implements TestExecutionPlanner {
     private final ChangeStorage changeStorage;
     private final File projectDir;
     private final TestVerifier testVerifier;
+    private final Configuration configuration;
 
     // Temporary before introducing proper DI
-    public NewTestsDetector(File projectDir, TestVerifier testVerifier) {
+    public NewTestsDetector(File projectDir, TestVerifier testVerifier, Configuration configuration) {
         this(new JavaSPILoader().onlyOne(ChangeResolver.class).get(),
             new JavaSPILoader().onlyOne(ChangeStorage.class).get(),
             projectDir,
-            testVerifier);
+            testVerifier,
+            configuration);
     }
 
     public NewTestsDetector(ChangeResolver changeResolver, ChangeStorage changeStorage, File projectDir,
-        TestVerifier testVerifier) {
+        TestVerifier testVerifier, Configuration configuration) {
         this.changeResolver = changeResolver;
         this.changeStorage = changeStorage;
         this.projectDir = projectDir;
         this.testVerifier = testVerifier;
+        this.configuration = configuration;
     }
 
     @Override
@@ -50,7 +54,7 @@ public class NewTestsDetector implements TestExecutionPlanner {
         final Collection<Change> changes = changeStorage.read(projectDir)
             .orElseGet(() -> {
                 logger.warn("No cached changes detected... using direct resolution");
-                return changeResolver.diff(projectDir);
+                return changeResolver.diff(projectDir, configuration);
         });
 
         return changes.stream()

--- a/strategies/changed/src/main/java/org/arquillian/smart/testing/vcs/git/NewTestsDetectorFactory.java
+++ b/strategies/changed/src/main/java/org/arquillian/smart/testing/vcs/git/NewTestsDetectorFactory.java
@@ -2,6 +2,7 @@ package org.arquillian.smart.testing.vcs.git;
 
 import java.io.File;
 import org.arquillian.smart.testing.api.TestVerifier;
+import org.arquillian.smart.testing.configuration.Configuration;
 import org.arquillian.smart.testing.spi.TestExecutionPlanner;
 import org.arquillian.smart.testing.spi.TestExecutionPlannerFactory;
 
@@ -18,7 +19,7 @@ public class NewTestsDetectorFactory implements TestExecutionPlannerFactory {
     }
 
     @Override
-    public TestExecutionPlanner create(File projectDir, TestVerifier verifier) {
-        return new NewTestsDetector(projectDir, verifier);
+    public TestExecutionPlanner create(File projectDir, TestVerifier verifier, Configuration configuration) {
+        return new NewTestsDetector(projectDir, verifier, configuration);
     }
 }

--- a/strategies/changed/src/test/java/org/arquillian/smart/testing/vcs/git/ChangedTestsDetectorTest.java
+++ b/strategies/changed/src/test/java/org/arquillian/smart/testing/vcs/git/ChangedTestsDetectorTest.java
@@ -35,10 +35,10 @@ public class ChangedTestsDetectorTest {
     @Test
     public void should_find_all_modified_tests_in_the_range_of_commits() throws Exception {
         // given
-        createConfiguration("7699c2c", "04d04fe");
+        Configuration configuration = createConfiguration("7699c2c", "04d04fe");
         final ChangedTestsDetector changedTestsDetector =
             new ChangedTestsDetector(new GitChangeResolver(), new NoopStorage(), gitFolder.getRoot(),
-                className -> className.endsWith("Test"));
+                className -> className.endsWith("Test"), configuration);
 
         // when
         final Iterable<TestSelection> changedTests = changedTestsDetector.getTests();
@@ -53,10 +53,10 @@ public class ChangedTestsDetectorTest {
         // given
         // 76b6069 renames test introduced in b4a8a3 - org.arquillian.smart.testing.vcs.git.EvenMoreDummyFilesDetectorTest
         // 6b4a8a3 introduces new test - org.arquillian.smart.testing.vcs.git.DummyFilesDetectorTest
-        createConfiguration("6b4a8a3", "76b6069");
+        Configuration configuration = createConfiguration("6b4a8a3", "76b6069");
         final ChangedTestsDetector changedTestsDetector =
             new ChangedTestsDetector(new GitChangeResolver(), new NoopStorage(), gitFolder.getRoot(),
-                className -> className.endsWith("Test"));
+                className -> className.endsWith("Test"), configuration);
 
         // when
         final Iterable<TestSelection> changedTests = changedTestsDetector.getTests();
@@ -69,14 +69,14 @@ public class ChangedTestsDetectorTest {
     @Test
     public void should_find_all_local_modified_tests_as_changed() throws IOException {
         // given
-        createConfiguration("a4261d5", "1ee4abf");
+        Configuration configuration = createConfiguration("a4261d5", "1ee4abf");
         final Path testFile = Paths.get(gitFolder.getRoot().getAbsolutePath(),
             "core/src/test/java/org/arquillian/smart/testing/FilesTest.java");
         Files.write(testFile, "//This is a test".getBytes(), StandardOpenOption.APPEND);
 
         final ChangedTestsDetector changedTestsDetector =
             new ChangedTestsDetector(new GitChangeResolver(), new NoopStorage(), gitFolder.getRoot(),
-                className -> className.endsWith("Test"));
+                className -> className.endsWith("Test"), configuration);
 
         // when
         final Collection<TestSelection> modifiedTests = changedTestsDetector.getTests();
@@ -89,7 +89,7 @@ public class ChangedTestsDetectorTest {
     @Test
     public void should_find_modified_staged_tests_as_changed() throws IOException, GitAPIException {
         //given
-        createConfiguration("7699c2c", "04d04fe");
+        Configuration configuration = createConfiguration("7699c2c", "04d04fe");
         final Path testFile = Paths.get(gitFolder.getRoot().getAbsolutePath(),
             "core/src/test/java/org/arquillian/smart/testing/FilesTest.java");
         Files.write(testFile, "//This is a test".getBytes(), StandardOpenOption.APPEND);
@@ -97,7 +97,7 @@ public class ChangedTestsDetectorTest {
 
         final ChangedTestsDetector changedTestsDetector =
             new ChangedTestsDetector(new GitChangeResolver(), new NoopStorage(), gitFolder.getRoot(),
-                className -> className.endsWith("Test"));
+                className -> className.endsWith("Test"), configuration);
 
         // when
         final Collection<TestSelection> newTests = changedTestsDetector.getTests();
@@ -111,10 +111,10 @@ public class ChangedTestsDetectorTest {
     @Test
     public void should_not_find_newly_added_tests_in_commit_range_as_changed() throws IOException {
         //given
-        createConfiguration("a4261d5", "1ee4abf");
+        Configuration configuration = createConfiguration("a4261d5", "1ee4abf");
         final ChangedTestsDetector changedTestsDetector =
             new ChangedTestsDetector(new GitChangeResolver(), new NoopStorage(), gitFolder.getRoot(),
-                className -> className.endsWith("Test"));
+                className -> className.endsWith("Test"), configuration);
 
         // when
         final Collection<TestSelection> modifiedTests = changedTestsDetector.getTests();
@@ -127,7 +127,7 @@ public class ChangedTestsDetectorTest {
     @Test
     public void should_not_find_untracked_tests_as_changed() throws IOException {
         //given
-        createConfiguration("7699c2c", "04d04fe");
+        Configuration configuration = createConfiguration("7699c2c", "04d04fe");
         final File testFile = gitFolder.newFile("core.src.test.java.org.arquillian.smart.testing.CalculatorTest.java");
         Files.write(testFile.toPath(), ("package org.arquillian.smart.testing;\n"
             + "\n"
@@ -144,7 +144,7 @@ public class ChangedTestsDetectorTest {
 
         final ChangedTestsDetector changedTestsDetector =
             new ChangedTestsDetector(new GitChangeResolver(), new NoopStorage(), gitFolder.getRoot(),
-                className -> className.endsWith("Test"));
+                className -> className.endsWith("Test"), configuration);
 
         // when
         final Collection<TestSelection> changedTest = changedTestsDetector.getTests();
@@ -155,10 +155,10 @@ public class ChangedTestsDetectorTest {
             .doesNotContain("org.arquillian.smart.testing.CalculatorTest");
     }
 
-    private void createConfiguration(String tail, String head){
+    private Configuration createConfiguration(String tail, String head){
         Configuration configuration = Configuration.load(gitFolder.getRoot());
         configuration.getScm().getRange().setTail(tail);
         configuration.getScm().getRange().setHead(head);
-        configuration.dump(gitFolder.getRoot());
+        return configuration;
     }
 }

--- a/strategies/changed/src/test/java/org/arquillian/smart/testing/vcs/git/NewTestsGitBasedDetectorTest.java
+++ b/strategies/changed/src/test/java/org/arquillian/smart/testing/vcs/git/NewTestsGitBasedDetectorTest.java
@@ -35,9 +35,9 @@ public class NewTestsGitBasedDetectorTest {
     @Test
     public void should_find_all_new_classes_in_the_range_of_commits() throws Exception {
         // given
-        createConfiguration("a4261d5", "1ee4abf");
+        Configuration configuration = createConfiguration("a4261d5", "1ee4abf");
         final NewTestsDetector newTestsDetector =
-            new NewTestsDetector(new GitChangeResolver(), new NoopStorage(), gitFolder.getRoot(), path -> true);
+            new NewTestsDetector(new GitChangeResolver(), new NoopStorage(), gitFolder.getRoot(), path -> true, configuration);
 
         // when
         final Collection<TestSelection> newTests = newTestsDetector.getTests();
@@ -50,12 +50,12 @@ public class NewTestsGitBasedDetectorTest {
     @Test
     public void should_find_local_untracked_files_as_new() throws IOException {
         //given
-        createConfiguration("a4261d5", "1ee4abf");
+        Configuration configuration = createConfiguration("a4261d5", "1ee4abf");
         final File testFile = gitFolder.newFile("core/src/test/java/org/arquillian/smart/testing/CalculatorTest.java");
         Files.write(testFile.toPath(), getContentsOfClass().getBytes(), StandardOpenOption.APPEND);
 
         final NewTestsDetector newTestsDetector =
-            new NewTestsDetector(new GitChangeResolver(), new NoopStorage(), gitFolder.getRoot(), path -> true);
+            new NewTestsDetector(new GitChangeResolver(), new NoopStorage(), gitFolder.getRoot(), path -> true, configuration);
 
         // when
         final Collection<TestSelection> newTests = newTestsDetector.getTests();
@@ -69,14 +69,14 @@ public class NewTestsGitBasedDetectorTest {
     @Test
     public void should_find_local_newly_staged_files_as_new() throws IOException, GitAPIException {
         //given
-        createConfiguration("a4261d5", "1ee4abf");
+        Configuration configuration = createConfiguration("a4261d5", "1ee4abf");
         final File testFile = gitFolder.newFile("core/src/test/java/org/arquillian/smart/testing/CalculatorTest.java");
         Files.write(testFile.toPath(), getContentsOfClass().getBytes(), StandardOpenOption.APPEND);
 
         GitRepositoryOperations.addFile(gitFolder.getRoot(), testFile.getAbsolutePath());
 
         final NewTestsDetector newTestsDetector =
-            new NewTestsDetector(new GitChangeResolver(), new NoopStorage(), gitFolder.getRoot(), path -> true);
+            new NewTestsDetector(new GitChangeResolver(), new NoopStorage(), gitFolder.getRoot(), path -> true, configuration);
 
         // when
         final Collection<TestSelection> newTests = newTestsDetector.getTests();
@@ -90,14 +90,14 @@ public class NewTestsGitBasedDetectorTest {
     @Test
     public void should_not_find_local_modified_file_as_new_when_using_commit_range() throws IOException {
         //given
-        createConfiguration("a4261d5", "1ee4abf");
+        Configuration configuration = createConfiguration("a4261d5", "1ee4abf");
         final Path testFile = Paths.get(gitFolder.getRoot().getAbsolutePath(),
             "core/src/test/java/org/arquillian/smart/testing/FilesTest.java");
 
         Files.write(testFile, "//This is a test".getBytes(), StandardOpenOption.APPEND);
 
         final NewTestsDetector newTestsDetector =
-            new NewTestsDetector(new GitChangeResolver(), new NoopStorage(), gitFolder.getRoot(), path -> true);
+            new NewTestsDetector(new GitChangeResolver(), new NoopStorage(), gitFolder.getRoot(), path -> true, configuration);
 
         // when
         final Collection<TestSelection> newTests = newTestsDetector.getTests();
@@ -121,10 +121,10 @@ public class NewTestsGitBasedDetectorTest {
             + "}";
     }
 
-    private void createConfiguration(String tail, String head){
+    private Configuration createConfiguration(String tail, String head){
         Configuration configuration = Configuration.load(gitFolder.getRoot());
         configuration.getScm().getRange().setTail(tail);
         configuration.getScm().getRange().setHead(head);
-        configuration.dump(gitFolder.getRoot());
+        return configuration;
     }
 }

--- a/strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/FailedTestsDetectorFactory.java
+++ b/strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/FailedTestsDetectorFactory.java
@@ -2,6 +2,7 @@ package org.arquillian.smart.testing.strategies.failed;
 
 import java.io.File;
 import org.arquillian.smart.testing.api.TestVerifier;
+import org.arquillian.smart.testing.configuration.Configuration;
 import org.arquillian.smart.testing.spi.TestExecutionPlanner;
 import org.arquillian.smart.testing.spi.TestExecutionPlannerFactory;
 
@@ -18,7 +19,7 @@ public class FailedTestsDetectorFactory implements TestExecutionPlannerFactory {
     }
 
     @Override
-    public TestExecutionPlanner create(File projectDir, TestVerifier verifier) {
+    public TestExecutionPlanner create(File projectDir, TestVerifier verifier, Configuration configuration) {
         return new FailedTestsDetector();
     }
 


### PR DESCRIPTION
#### Short description of what this resolves:

Strategies and related logic use Configuration provided by SmartTesting API.
In addition, ChangeResolver doesn't load config file if not really necessary.

Modified a ftest to check usage of SmartTesting API from different directory than the project root one (which means also without Configuration)

Fixes #231 
