### PR TITLE
fix(goals) Extension checks goals set for the build if any test will be executed

### DIFF
--- a/core/src/main/java/org/arquillian/smart/testing/hub/storage/local/DuringExecutionLocalStorage.java
+++ b/core/src/main/java/org/arquillian/smart/testing/hub/storage/local/DuringExecutionLocalStorage.java
@@ -1,5 +1,6 @@
 package org.arquillian.smart.testing.hub.storage.local;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -36,15 +37,19 @@ public class DuringExecutionLocalStorage extends AfterExecutionLocalStorage {
     /**
      * Copies all directories that should be stored after the test execution to the given {@code targetDir} directory.
      * If there is some directory with the same name present, then both directories are merged.
+     * If the target directory does not exist or is not provided, then the directories are not moved anywhere.
      * <p>
      * When the directories are copied, then the whole {@link SMART_TESTING_WORKING_DIRECTORY_NAME} is removed
      * </p>
      */
     public void purge(String targetDir) {
-        Arrays.stream(getDirsToStore())
-            .forEach(dirNameToStore -> {
-                storeDirectory(dirNameToStore, targetDir);
-            });
+        if (targetDir != null &&  new File(targetDir).exists()) {
+            Arrays.stream(getDirsToStore())
+                .forEach(dirNameToStore -> {
+                    storeDirectory(dirNameToStore, targetDir);
+                });
+        }
+        FileSystemOperations.deleteDirectory(Paths.get(rootDir, SMART_TESTING_WORKING_DIRECTORY_NAME), true);
     }
 
     private void storeDirectory(String dirNameToStore, String targetDir) {
@@ -56,6 +61,5 @@ public class DuringExecutionLocalStorage extends AfterExecutionLocalStorage {
 
             FileSystemOperations.copyDirectory(dirToCopy, dirToStore, true);
         }
-        FileSystemOperations.deleteDirectory(Paths.get(rootDir, SMART_TESTING_WORKING_DIRECTORY_NAME), true);
     }
 }

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/SkipTestExecutionFunctionalTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configuration/SkipTestExecutionFunctionalTest.java
@@ -1,5 +1,6 @@
 package org.arquillian.smart.testing.ftest.configuration;
 
+import org.arquillian.smart.testing.ftest.customAssertions.SmartTestingSoftAssertions;
 import org.arquillian.smart.testing.ftest.testbed.project.Project;
 import org.arquillian.smart.testing.ftest.testbed.project.TestResults;
 import org.arquillian.smart.testing.rules.TestBed;
@@ -10,8 +11,11 @@ import org.junit.Test;
 
 import static org.arquillian.smart.testing.ftest.testbed.TestRepository.testRepository;
 import static org.arquillian.smart.testing.ftest.testbed.configuration.Mode.ORDERING;
+import static org.arquillian.smart.testing.ftest.testbed.configuration.Mode.SELECTING;
 import static org.arquillian.smart.testing.ftest.testbed.configuration.Strategy.AFFECTED;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.arquillian.smart.testing.ftest.testbed.configuration.Strategy.NEW;
+import static org.arquillian.smart.testing.hub.storage.local.DuringExecutionLocalStorage.SMART_TESTING_WORKING_DIRECTORY_NAME;
+import static org.arquillian.smart.testing.hub.storage.local.LocalChangeStorage.SMART_TESTING_SCM_CHANGES;
 
 public class SkipTestExecutionFunctionalTest {
 
@@ -24,6 +28,9 @@ public class SkipTestExecutionFunctionalTest {
 
     @Rule
     public final TestBed testBed = new TestBed(GIT_CLONE);
+
+    @Rule
+    public final SmartTestingSoftAssertions softly = new SmartTestingSoftAssertions();
 
     @Test
     public void should_execute_all_unit_tests_when_integration_test_execution_is_skipped() throws Exception {
@@ -45,8 +52,8 @@ public class SkipTestExecutionFunctionalTest {
 
         // then
         String capturedMavenLog = project.getMavenLog();
-        assertThat(capturedMavenLog).contains(SMART_TESTING_EXTENSION_ENABLED);
-        assertThat(actualTestResults.accumulatedPerTestClass()).size().isEqualTo(20);
+        softly.assertThat(capturedMavenLog).contains(SMART_TESTING_EXTENSION_ENABLED);
+        softly.assertThat(actualTestResults.accumulatedPerTestClass()).size().isEqualTo(20);
     }
 
     @Test
@@ -69,7 +76,29 @@ public class SkipTestExecutionFunctionalTest {
 
         // then
         String capturedMavenLog = project.getMavenLog();
-        assertThat(capturedMavenLog).contains(SMART_TESTING_EXTENSION_DISABLED);
-        assertThat(actualTestResults.accumulatedPerTestClass()).size().isEqualTo(0);
+        softly.assertThat(capturedMavenLog).contains(SMART_TESTING_EXTENSION_DISABLED);
+        softly.assertThat(actualTestResults.accumulatedPerTestClass()).size().isEqualTo(0);
+    }
+
+    @Test
+    public void should_not_install_extension_when_only_clean_goal_is_used() throws Exception {
+        // given
+        final Project project = testBed.getProject();
+
+        project.configureSmartTesting()
+            .executionOrder(NEW, AFFECTED)
+            .inMode(SELECTING)
+            .enable();
+
+        // when
+        project.build("config/impl-base").run("clean");
+
+        // then
+        softly.assertThat(project.getMavenLog()).contains(SMART_TESTING_EXTENSION_DISABLED);
+
+        softly.assertThat(project)
+            .doesNotContainDirectory(SMART_TESTING_SCM_CHANGES)
+            .doesNotContainDirectory(SMART_TESTING_WORKING_DIRECTORY_NAME)
+            .doesNotContainDirectory("target");
     }
 }

--- a/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/SkipInstallationChecker.java
+++ b/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/SkipInstallationChecker.java
@@ -2,6 +2,7 @@ package org.arquillian.smart.testing.mvn.ext;
 
 import java.util.Arrays;
 import java.util.List;
+import org.apache.maven.execution.MavenSession;
 
 import static org.arquillian.smart.testing.mvn.ext.MavenPropertyResolver.isSkipTestExecutionSet;
 import static org.arquillian.smart.testing.mvn.ext.MavenPropertyResolver.isSpecificTestClassSet;
@@ -11,31 +12,40 @@ class SkipInstallationChecker {
     private static final List<String> EXPECTED_GOALS = Arrays.asList(
         new String[] {"test", "prepare-package", "package", "pre-integration-test", "integration-test",
             "post-integration-test", "verify", "install", "deploy", "pre-site", "site", "post-site", "site-deploy"});
-    private final List<String> goals;
+
+    static final String NO_GOAL_REASON = "No goals have been specified for the build.";
+    static final String NO_TEST_GOAL_REASON =
+        "None of the goals specified for the build will invoke the tests. Any of the following goals are expected: ";
+    static final String TEST_SKIPPED_REASON = "Test Execution has been skipped.";
+    static final String SPECIFIC_CLASSES_REASON = "Specific Test Class execution is set.";
+
+    private final MavenSession session;
     private String reason;
 
-    SkipInstallationChecker(List<String> goals) {
-
-        this.goals = goals;
+    SkipInstallationChecker(MavenSession session) {
+        this.session = session;
     }
 
     boolean shouldSkip() {
-        if (goals.size() == 0) {
-            reason = "No goals have been specified for the build.";
+        List<String> goals = session.getGoals();
+        String defaultGoal = session.getTopLevelProject().getBuild().getDefaultGoal();
+        if (goals.isEmpty() && (defaultGoal == null || defaultGoal.isEmpty())) {
+            reason = NO_GOAL_REASON;
 
         } else {
+            if (goals.isEmpty()) {
+                goals = Arrays.asList(defaultGoal.split(" "));
+            }
             boolean isAnyGoalInvokingTest = goals.stream()
-                .anyMatch(goal -> EXPECTED_GOALS.contains(goal) || isGoalSpecification(goal));
+                .anyMatch(goal -> EXPECTED_GOALS.contains(goal) || isPluginGoal(goal));
             if (!isAnyGoalInvokingTest) {
-                reason =
-                    "None of the goals specified for the build will invoke the tests. Any of the following goals are expected: "
-                        + EXPECTED_GOALS;
+                reason = NO_TEST_GOAL_REASON + EXPECTED_GOALS;
 
             } else if (isSkipTestExecutionSet()) {
-                reason = "Test Execution has been skipped.";
+                reason = TEST_SKIPPED_REASON;
 
             } else if (isSpecificTestClassSet()) {
-                reason = "Single Test Class execution is set.";
+                reason = SPECIFIC_CLASSES_REASON;
             }
         }
 
@@ -46,7 +56,8 @@ class SkipInstallationChecker {
         return reason;
     }
 
-    private boolean isGoalSpecification(String goal) {
-        return goal.indexOf(':') >= 0;
+    // TODO needs additional investigation of using plugin goals such as org.apache.maven.plugins:maven-surefire-plugin:2.20.1:test
+    private boolean isPluginGoal(String goal) {
+        return goal.contains(":");
     }
 }

--- a/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/SkipInstallationChecker.java
+++ b/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/SkipInstallationChecker.java
@@ -1,0 +1,52 @@
+package org.arquillian.smart.testing.mvn.ext;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.arquillian.smart.testing.mvn.ext.MavenPropertyResolver.isSkipTestExecutionSet;
+import static org.arquillian.smart.testing.mvn.ext.MavenPropertyResolver.isSpecificTestClassSet;
+
+class SkipInstallationChecker {
+
+    private static final List<String> EXPECTED_GOALS = Arrays.asList(
+        new String[] {"test", "prepare-package", "package", "pre-integration-test", "integration-test",
+            "post-integration-test", "verify", "install", "deploy", "pre-site", "site", "post-site", "site-deploy"});
+    private final List<String> goals;
+    private String reason;
+
+    SkipInstallationChecker(List<String> goals) {
+
+        this.goals = goals;
+    }
+
+    boolean shouldSkip() {
+        if (goals.size() == 0) {
+            reason = "No goals have been specified for the build.";
+
+        } else {
+            boolean isAnyGoalInvokingTest = goals.stream()
+                .anyMatch(goal -> EXPECTED_GOALS.contains(goal) || isGoalSpecification(goal));
+            if (!isAnyGoalInvokingTest) {
+                reason =
+                    "None of the goals specified for the build will invoke the tests. Any of the following goals are expected: "
+                        + EXPECTED_GOALS;
+
+            } else if (isSkipTestExecutionSet()) {
+                reason = "Test Execution has been skipped.";
+
+            } else if (isSpecificTestClassSet()) {
+                reason = "Single Test Class execution is set.";
+            }
+        }
+
+        return reason != null;
+    }
+
+    String getReason(){
+        return reason;
+    }
+
+    private boolean isGoalSpecification(String goal) {
+        return goal.indexOf(':') >= 0;
+    }
+}

--- a/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/SmartTestingMavenConfigurer.java
+++ b/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/SmartTestingMavenConfigurer.java
@@ -69,7 +69,7 @@ class SmartTestingMavenConfigurer extends AbstractMavenLifecycleParticipant {
     }
 
     private void loadConfigAndCheckIfInstallationShouldBeSkipped(MavenSession session){
-        SkipInstallationChecker skipInstallationChecker = new SkipInstallationChecker(session.getGoals());
+        SkipInstallationChecker skipInstallationChecker = new SkipInstallationChecker(session);
         skipExtensionInstallation = skipInstallationChecker.shouldSkip();
         if (skipExtensionInstallation) {
             logExtensionDisableReason(Log.getLogger(), skipInstallationChecker.getReason());

--- a/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/SmartTestingMavenConfigurer.java
+++ b/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/SmartTestingMavenConfigurer.java
@@ -28,8 +28,6 @@ import org.codehaus.plexus.component.annotations.Requirement;
 
 import static java.util.stream.StreamSupport.stream;
 import static org.arquillian.smart.testing.configuration.Configuration.SMART_TESTING_DISABLE;
-import static org.arquillian.smart.testing.mvn.ext.MavenPropertyResolver.isSkipTestExecutionSet;
-import static org.arquillian.smart.testing.mvn.ext.MavenPropertyResolver.isSpecificTestClassSet;
 
 @Component(role = AbstractMavenLifecycleParticipant.class,
     description = "Entry point to install and manage Smart-Testing extension. Takes care of adding needed dependencies and "
@@ -46,28 +44,39 @@ class SmartTestingMavenConfigurer extends AbstractMavenLifecycleParticipant {
 
     private Configuration configuration;
 
-    private Boolean skipExtensionInstallation;
+    private boolean skipExtensionInstallation;
 
     @Override
     public void afterProjectsRead(MavenSession session) throws MavenExecutionException {
-        File projectDirectory = session.getTopLevelProject().getModel().getProjectDirectory();
         Log.setLoggerFactory(new MavenExtensionLoggerFactory(mavenLogger));
+
+        SkipInstallationChecker skipInstallationChecker = new SkipInstallationChecker(session.getGoals());
+        skipExtensionInstallation = skipInstallationChecker.shouldSkip();
+        if (skipExtensionInstallation) {
+            logExtensionDisableReason(Log.getLogger(), skipInstallationChecker.getReason());
+            return;
+        }
+
+        File projectDirectory = session.getTopLevelProject().getModel().getProjectDirectory();
         configuration = Configuration.load(projectDirectory);
 
         Log.setLoggerFactory(new MavenExtensionLoggerFactory(mavenLogger, configuration));
         logger = Log.getLogger();
 
+        logger.debug("Version: %s", ExtensionVersion.version().toString());
         logger.debug("Applied user properties: %s", session.getUserProperties());
 
-        if (shouldSkipExtensionInstallation()) {
-            logExtensionDisableReason();
+
+        if (configuration.isDisable()) {
+            skipExtensionInstallation = true;
+            logExtensionDisableReason(logger, "System Property " + SMART_TESTING_DISABLE + " is set.");
             return;
         }
 
         if (configuration.areStrategiesDefined()) {
             configureExtension(session, configuration);
             calculateChanges(projectDirectory, configuration);
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> purgeLocalStorage(session)));
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> purgeLocalStorageAndExportPom(session)));
         } else {
             logStrategiesNotDefined();
         }
@@ -88,18 +97,12 @@ class SmartTestingMavenConfigurer extends AbstractMavenLifecycleParticipant {
         }
     }
 
-    private void logExtensionDisableReason() {
+    private void logExtensionDisableReason(Logger customLogger, String customReason) {
         String reason = "Not Defined";
-
-        if (configuration.isDisable()) {
-            reason = "System Property " + SMART_TESTING_DISABLE + " is set.";
-        } else if (isSkipTestExecutionSet()) {
-            reason = "Test Execution has been skipped.";
-        } else if (isSpecificTestClassSet()) {
-            reason = "Single Test Class execution is set.";
+        if (customReason != null && !customReason.isEmpty()){
+            reason = customReason;
         }
-
-        logger.info("Smart Testing is disabled. Reason: %s", reason);
+        customLogger.info("Smart Testing is disabled. Reason: %s", reason);
     }
 
     @Override
@@ -109,17 +112,11 @@ class SmartTestingMavenConfigurer extends AbstractMavenLifecycleParticipant {
             return;
         }
 
-        if (configuration.isDebug() || mavenLogger.isDebugEnabled()) {
-            logger.debug("Version: %s", ExtensionVersion.version().toString());
-            session.getAllProjects().forEach(mavenProject ->
-                ModifiedPomExporter.exportModifiedPom(mavenProject.getModel()));
-        }
-
         if (!configuration.areStrategiesDefined()) {
             logStrategiesNotDefined();
         }
 
-        purgeLocalStorage(session);
+        purgeLocalStorageAndExportPom(session);
     }
 
     private void calculateChanges(File projectDirectory, Configuration configuration) {
@@ -156,18 +153,16 @@ class SmartTestingMavenConfigurer extends AbstractMavenLifecycleParticipant {
                 + "For details on how to configure it head over to http://bit.ly/st-config");
     }
 
-    private boolean shouldSkipExtensionInstallation() {
-        if (skipExtensionInstallation == null) {
-            skipExtensionInstallation = configuration.isDisable() || isSkipTestExecutionSet() || isSpecificTestClassSet();
-        }
-        return skipExtensionInstallation;
-    }
-
-    private void purgeLocalStorage(MavenSession session) {
+    private void purgeLocalStorageAndExportPom(MavenSession session) {
         session.getAllProjects().forEach(mavenProject -> {
             Model model = mavenProject.getModel();
+            boolean isDebug = configuration.isDebug() || mavenLogger.isDebugEnabled();
             String target = model.getBuild() != null ? model.getBuild().getDirectory() : null;
+
             new LocalStorage(model.getProjectDirectory()).duringExecution().purge(target);
+            if (isDebug && new File(target).exists()) {
+                ModifiedPomExporter.exportModifiedPom(mavenProject.getModel());
+            }
         });
     }
 }

--- a/mvn-extension/src/test/java/org/arquillian/smart/testing/mvn/ext/SkipInstallationCheckerTest.java
+++ b/mvn-extension/src/test/java/org/arquillian/smart/testing/mvn/ext/SkipInstallationCheckerTest.java
@@ -1,0 +1,186 @@
+package org.arquillian.smart.testing.mvn.ext;
+
+import java.util.Arrays;
+import java.util.List;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Build;
+import org.apache.maven.project.MavenProject;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.mockito.Mockito;
+
+import static org.arquillian.smart.testing.mvn.ext.SkipInstallationChecker.NO_GOAL_REASON;
+import static org.arquillian.smart.testing.mvn.ext.SkipInstallationChecker.NO_TEST_GOAL_REASON;
+import static org.arquillian.smart.testing.mvn.ext.SkipInstallationChecker.SPECIFIC_CLASSES_REASON;
+import static org.arquillian.smart.testing.mvn.ext.SkipInstallationChecker.TEST_SKIPPED_REASON;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SkipInstallationCheckerTest {
+
+    @Rule
+    public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
+    private MavenSession setUpMavenSession(List<String> goals, String defaultGoal) {
+        Build build = Mockito.mock(Build.class);
+        Mockito.when(build.getDefaultGoal()).thenReturn(defaultGoal);
+
+        MavenProject topLevelProject = Mockito.mock(MavenProject.class);
+        Mockito.when(topLevelProject.getBuild()).thenReturn(build);
+
+        MavenSession mavenSession = Mockito.mock(MavenSession.class);
+        Mockito.when(mavenSession.getGoals()).thenReturn(goals);
+        Mockito.when(mavenSession.getTopLevelProject()).thenReturn(topLevelProject);
+
+        return mavenSession;
+    }
+
+    @Test
+    public void checker_should_return_true_when_validate_is_set_regardless_default_goal() {
+        // given
+        MavenSession mavenSession = setUpMavenSession(Arrays.asList(new String[] {"clean"}), "clean package");
+
+        // when
+        SkipInstallationChecker skipInstallationChecker = new SkipInstallationChecker(mavenSession);
+
+        // then
+        assertThat(skipInstallationChecker.shouldSkip()).isTrue();
+        assertThat(skipInstallationChecker.getReason()).contains(NO_TEST_GOAL_REASON);
+    }
+
+    @Test
+    public void checker_should_return_false_when_package_in_default_goal_is_set_set() {
+        // given
+        MavenSession mavenSession = setUpMavenSession(Arrays.asList(new String[] {}), "clean package");
+
+        // when
+        SkipInstallationChecker skipInstallationChecker = new SkipInstallationChecker(mavenSession);
+
+        // then
+        assertThat(skipInstallationChecker.shouldSkip()).isFalse();
+    }
+
+    @Test
+    public void checker_should_return_true_when_clean_validate_in_default_goal_is_set() {
+        // given
+        MavenSession mavenSession = setUpMavenSession(Arrays.asList(new String[] {}), "clean validate");
+
+        // when
+        SkipInstallationChecker skipInstallationChecker = new SkipInstallationChecker(mavenSession);
+
+        // then
+        assertThat(skipInstallationChecker.shouldSkip()).isTrue();
+        assertThat(skipInstallationChecker.getReason()).contains(NO_TEST_GOAL_REASON);
+    }
+
+    @Test
+    public void checker_should_return_true_when_no_goal_is_set() {
+        // given
+        MavenSession mavenSession = setUpMavenSession(Arrays.asList(new String[] {}), null);
+
+        // when
+        SkipInstallationChecker skipInstallationChecker = new SkipInstallationChecker(mavenSession);
+
+        // then
+        assertThat(skipInstallationChecker.shouldSkip()).isTrue();
+        assertThat(skipInstallationChecker.getReason()).contains(NO_GOAL_REASON);
+    }
+
+    @Test
+    public void checker_should_return_true_when_clean_goal_is_set() {
+        // given
+        MavenSession mavenSession = setUpMavenSession(Arrays.asList(new String[] {"clean"}), null);
+
+        // when
+        SkipInstallationChecker skipInstallationChecker = new SkipInstallationChecker(mavenSession);
+
+        // then
+        assertThat(skipInstallationChecker.shouldSkip()).isTrue();
+        assertThat(skipInstallationChecker.getReason()).contains(NO_TEST_GOAL_REASON);
+    }
+
+    @Test
+    public void checker_should_return_false_when_package_goal_and_no_skip_property_is_set() {
+        // given
+        MavenSession mavenSession = setUpMavenSession(Arrays.asList(new String[] {"clean", "package"}), null);
+
+        // when
+        SkipInstallationChecker skipInstallationChecker = new SkipInstallationChecker(mavenSession);
+
+        // then
+        assertThat(skipInstallationChecker.shouldSkip()).isFalse();
+    }
+
+    @Test
+    public void checker_should_return_false_when_plugin_goal_set_set() {
+        // given
+        MavenSession mavenSession = setUpMavenSession(
+            Arrays.asList(new String[] {"clean", "org.apache.maven.plugins:maven-surefire-plugin:2.20.1:test"}), null);
+
+        // when
+        SkipInstallationChecker skipInstallationChecker = new SkipInstallationChecker(mavenSession);
+
+        // then
+        assertThat(skipInstallationChecker.shouldSkip()).isFalse();
+    }
+
+    @Test
+    public void checker_should_return_true_when_single_test_is_set() {
+        verifySpecificTestClasses("MyCoolTest", true);
+    }
+
+    @Test
+    public void checker_should_return_true_when_two_tests_are_set() {
+        verifySpecificTestClasses("MyCoolTest,MySecondTest", true);
+    }
+
+    @Test
+    public void checker_should_return_false_when_pattern_is_set() {
+        verifySpecificTestClasses("MyCool*Test", false);
+    }
+
+    @Test
+    public void checker_should_return_false_when_classes_and_pattern_are_set() {
+        verifySpecificTestClasses("FirstTest,MyCool*Test,LastTest", false);
+    }
+
+    private void verifySpecificTestClasses(String value, boolean shouldSkip) {
+        // given
+        System.setProperty("test", value);
+        MavenSession mavenSession = setUpMavenSession(Arrays.asList(new String[] {"clean", "package"}), null);
+
+        // when
+        SkipInstallationChecker skipInstallationChecker = new SkipInstallationChecker(mavenSession);
+
+        // then
+        if (shouldSkip) {
+            assertThat(skipInstallationChecker.shouldSkip()).isTrue();
+            assertThat(skipInstallationChecker.getReason()).contains(SPECIFIC_CLASSES_REASON);
+        } else {
+            assertThat(skipInstallationChecker.shouldSkip()).isFalse();
+        }
+    }
+
+    @Test
+    public void checker_should_return_true_when_skip_tests_system_property_set() {
+        verifySkipTestSystemProperty("skipTests");
+    }
+
+    @Test
+    public void checker_should_return_true_when_maven_test_skip_system_property_set() {
+        verifySkipTestSystemProperty("maven.test.skip");
+    }
+
+    private void verifySkipTestSystemProperty(String systemProperty) {
+        // given
+        System.setProperty(systemProperty, "true");
+        MavenSession mavenSession = setUpMavenSession(Arrays.asList(new String[] {"clean", "package"}), null);
+
+        // when
+        SkipInstallationChecker skipInstallationChecker = new SkipInstallationChecker(mavenSession);
+
+        // then
+        assertThat(skipInstallationChecker.shouldSkip()).isTrue();
+        assertThat(skipInstallationChecker.getReason()).contains(TEST_SKIPPED_REASON);
+    }
+}

--- a/mvn-extension/src/test/java/org/arquillian/smart/testing/mvn/ext/SkipInstallationCheckerTest.java
+++ b/mvn-extension/src/test/java/org/arquillian/smart/testing/mvn/ext/SkipInstallationCheckerTest.java
@@ -2,12 +2,15 @@ package org.arquillian.smart.testing.mvn.ext;
 
 import java.util.Arrays;
 import java.util.List;
+import net.jcip.annotations.NotThreadSafe;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Build;
 import org.apache.maven.project.MavenProject;
+import org.assertj.core.api.JUnitSoftAssertions;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
 
 import static org.arquillian.smart.testing.mvn.ext.SkipInstallationChecker.NO_GOAL_REASON;
@@ -16,10 +19,14 @@ import static org.arquillian.smart.testing.mvn.ext.SkipInstallationChecker.SPECI
 import static org.arquillian.smart.testing.mvn.ext.SkipInstallationChecker.TEST_SKIPPED_REASON;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Category(NotThreadSafe.class)
 public class SkipInstallationCheckerTest {
 
     @Rule
     public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
+    @Rule
+    public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
 
     private MavenSession setUpMavenSession(List<String> goals, String defaultGoal) {
         Build build = Mockito.mock(Build.class);
@@ -44,8 +51,8 @@ public class SkipInstallationCheckerTest {
         SkipInstallationChecker skipInstallationChecker = new SkipInstallationChecker(mavenSession);
 
         // then
-        assertThat(skipInstallationChecker.shouldSkip()).isTrue();
-        assertThat(skipInstallationChecker.getReason()).contains(NO_TEST_GOAL_REASON);
+        softly.assertThat(skipInstallationChecker.shouldSkip()).isTrue();
+        softly.assertThat(skipInstallationChecker.getReason()).contains(NO_TEST_GOAL_REASON);
     }
 
     @Test
@@ -69,8 +76,8 @@ public class SkipInstallationCheckerTest {
         SkipInstallationChecker skipInstallationChecker = new SkipInstallationChecker(mavenSession);
 
         // then
-        assertThat(skipInstallationChecker.shouldSkip()).isTrue();
-        assertThat(skipInstallationChecker.getReason()).contains(NO_TEST_GOAL_REASON);
+        softly.assertThat(skipInstallationChecker.shouldSkip()).isTrue();
+        softly.assertThat(skipInstallationChecker.getReason()).contains(NO_TEST_GOAL_REASON);
     }
 
     @Test
@@ -82,8 +89,8 @@ public class SkipInstallationCheckerTest {
         SkipInstallationChecker skipInstallationChecker = new SkipInstallationChecker(mavenSession);
 
         // then
-        assertThat(skipInstallationChecker.shouldSkip()).isTrue();
-        assertThat(skipInstallationChecker.getReason()).contains(NO_GOAL_REASON);
+        softly.assertThat(skipInstallationChecker.shouldSkip()).isTrue();
+        softly.assertThat(skipInstallationChecker.getReason()).contains(NO_GOAL_REASON);
     }
 
     @Test
@@ -95,8 +102,8 @@ public class SkipInstallationCheckerTest {
         SkipInstallationChecker skipInstallationChecker = new SkipInstallationChecker(mavenSession);
 
         // then
-        assertThat(skipInstallationChecker.shouldSkip()).isTrue();
-        assertThat(skipInstallationChecker.getReason()).contains(NO_TEST_GOAL_REASON);
+        softly.assertThat(skipInstallationChecker.shouldSkip()).isTrue();
+        softly.assertThat(skipInstallationChecker.getReason()).contains(NO_TEST_GOAL_REASON);
     }
 
     @Test
@@ -154,10 +161,10 @@ public class SkipInstallationCheckerTest {
 
         // then
         if (shouldSkip) {
-            assertThat(skipInstallationChecker.shouldSkip()).isTrue();
-            assertThat(skipInstallationChecker.getReason()).contains(SPECIFIC_CLASSES_REASON);
+            softly.assertThat(skipInstallationChecker.shouldSkip()).isTrue();
+            softly.assertThat(skipInstallationChecker.getReason()).contains(SPECIFIC_CLASSES_REASON);
         } else {
-            assertThat(skipInstallationChecker.shouldSkip()).isFalse();
+            softly.assertThat(skipInstallationChecker.shouldSkip()).isFalse();
         }
     }
 
@@ -180,7 +187,7 @@ public class SkipInstallationCheckerTest {
         SkipInstallationChecker skipInstallationChecker = new SkipInstallationChecker(mavenSession);
 
         // then
-        assertThat(skipInstallationChecker.shouldSkip()).isTrue();
-        assertThat(skipInstallationChecker.getReason()).contains(TEST_SKIPPED_REASON);
+        softly.assertThat(skipInstallationChecker.shouldSkip()).isTrue();
+        softly.assertThat(skipInstallationChecker.getReason()).contains(TEST_SKIPPED_REASON);
     }
 }


### PR DESCRIPTION
#### Short description of what this resolves:

In the Maven extension, there is verified if any goal invoking test execution is set. Also, if the target is not present (when the session ends) in any of the modules, then it won't be created by ST extension

#### Changes proposed in this pull request:

- Checking if any of the set goals for the build is present in the list:
`{"test", "prepare-package", "package", "pre-integration-test", "integration-test", "post-integration-test", "verify", "install", "deploy", "pre-site", "site", "post-site", "site-deploy"}`
assuming that only these goals can execute a test.
- I'm also checking if any of the provided goals contains colon `:` - for example in the case: 
`org.apache.maven.plugins:maven-surefire-plugin:2.20.1:test`
the check was copied from [Maven internals](https://github.com/apache/maven/blob/master/maven-core/src/main/java/org/apache/maven/lifecycle/internal/DefaultLifecycleTaskSegmentCalculator.java#L150-L153)
- I have refactored the skip installation logic - the system property related code has been moved to one class `SkipInstallationChecker` (that also contains check for the goals) that is executed as the first thing - before the configuration file is loaded
- when the session ends, it is checked if there is any target preset, if not, no modified pom is exported and `reporting` directory from `.smart-testing` is not moved.


Fixes #219 
