### PR TITLE
fix(test): loads resources from classpath not filesystem path

### DIFF
--- a/core/src/test/java/org/arquillian/smart/testing/configuration/ConfigurationTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/configuration/ConfigurationTest.java
@@ -1,18 +1,17 @@
 package org.arquillian.smart.testing.configuration;
 
-import java.io.File;
-import java.nio.file.Paths;
 import org.junit.Test;
 
 import static org.arquillian.smart.testing.RunMode.ORDERING;
 import static org.arquillian.smart.testing.RunMode.SELECTING;
 import static org.arquillian.smart.testing.configuration.Configuration.loadConfigurationFromFile;
+import static org.arquillian.smart.testing.configuration.ResourceLoader.getResourceAsFile;
+import static org.arquillian.smart.testing.configuration.ResourceLoader.getResourceAsPath;
 import static org.arquillian.smart.testing.report.SmartTestingReportGenerator.REPORT_FILE_NAME;
 import static org.arquillian.smart.testing.report.SmartTestingReportGenerator.TARGET;
 import static org.arquillian.smart.testing.scm.ScmRunnerProperties.DEFAULT_LAST_COMMITS;
 import static org.arquillian.smart.testing.scm.ScmRunnerProperties.HEAD;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.contentOf;
 
 public class ConfigurationTest {
 
@@ -43,7 +42,7 @@ public class ConfigurationTest {
 
         // when
         final Configuration actualConfiguration =
-            Configuration.load(Paths.get("src/test/resources/configuration/smart-testing.yml"));
+            Configuration.load(getResourceAsPath("configuration/smart-testing.yml"));
 
         // then
         assertThat(actualConfiguration).isEqualToComparingFieldByFieldRecursively(expectedConfiguration);
@@ -104,9 +103,10 @@ public class ConfigurationTest {
 
         // when
         final Configuration actualConfiguration =
-            loadConfigurationFromFile(new File("src/test/resources/configuration/dumped-smart-testing.yml"));
+            loadConfigurationFromFile(getResourceAsFile("configuration/dumped-smart-testing.yml"));
 
         // then
         assertThat(actualConfiguration).isEqualToComparingFieldByFieldRecursively(expectedConfiguration);
     }
+
 }

--- a/core/src/test/java/org/arquillian/smart/testing/configuration/ConfigurationUsingPropertyTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/configuration/ConfigurationUsingPropertyTest.java
@@ -1,15 +1,16 @@
 package org.arquillian.smart.testing.configuration;
 
-import java.nio.file.Paths;
 import net.jcip.annotations.NotThreadSafe;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.experimental.categories.Category;
 
 import static org.arquillian.smart.testing.RunMode.SELECTING;
 import static org.arquillian.smart.testing.configuration.Configuration.SMART_TESTING;
 import static org.arquillian.smart.testing.configuration.Configuration.SMART_TESTING_MODE;
 import static org.arquillian.smart.testing.configuration.Configuration.SMART_TESTING_REPORT_ENABLE;
+import static org.arquillian.smart.testing.configuration.ResourceLoader.getResourceAsPath;
 import static org.arquillian.smart.testing.report.SmartTestingReportGenerator.REPORT_FILE_NAME;
 import static org.arquillian.smart.testing.report.SmartTestingReportGenerator.TARGET;
 import static org.arquillian.smart.testing.scm.ScmRunnerProperties.HEAD;
@@ -18,7 +19,7 @@ import static org.arquillian.smart.testing.scm.ScmRunnerProperties.SCM_RANGE_HEA
 import static org.arquillian.smart.testing.scm.ScmRunnerProperties.SCM_RANGE_TAIL;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@NotThreadSafe
+@Category(NotThreadSafe.class)
 public class ConfigurationUsingPropertyTest {
 
     @Rule
@@ -31,7 +32,7 @@ public class ConfigurationUsingPropertyTest {
 
         // when
         final Configuration actualConfiguration =
-            Configuration.load(Paths.get("src/test/resources/configuration/smart-testing-with-lastChanges.yml"));
+            Configuration.load(getResourceAsPath("configuration/smart-testing-with-lastChanges.yml"));
 
         // then
         final Range range = actualConfiguration.getScm().getRange();
@@ -42,7 +43,7 @@ public class ConfigurationUsingPropertyTest {
     public void should_load_configuration_for_scmLastChanges_from_config_file() {
         // when
         final Configuration actualConfiguration =
-            Configuration.load(Paths.get("src/test/resources/configuration/smart-testing-with-lastChanges.yml"));
+            Configuration.load(getResourceAsPath("configuration/smart-testing-with-lastChanges.yml"));
 
         // then
         final Range range = actualConfiguration.getScm().getRange();
@@ -53,7 +54,7 @@ public class ConfigurationUsingPropertyTest {
     public void should_load_configuration_for_rangeHead_and_rangeTail_from_config_file() {
         // when
         final Configuration actualConfiguration =
-            Configuration.load(Paths.get("src/test/resources/configuration/smart-testing.yml"));
+            Configuration.load(getResourceAsPath("configuration/smart-testing.yml"));
 
         // then
         final Range range = actualConfiguration.getScm().getRange();
@@ -68,7 +69,7 @@ public class ConfigurationUsingPropertyTest {
 
         // when
         final Configuration actualConfiguration =
-            Configuration.load(Paths.get("src/test/resources/configuration/smart-testing.yml"));
+            Configuration.load(getResourceAsPath("configuration/smart-testing.yml"));
 
         // then
         final Range range = actualConfiguration.getScm().getRange();
@@ -106,7 +107,7 @@ public class ConfigurationUsingPropertyTest {
 
         // when
         final Configuration actualConfiguration =
-            Configuration.load(Paths.get("src/test/resources/configuration/smart-testing.yml"));
+            Configuration.load(getResourceAsPath("configuration/smart-testing.yml"));
 
         // then
         assertThat(actualConfiguration).isEqualToComparingFieldByFieldRecursively(expectedConfiguration);

--- a/core/src/test/java/org/arquillian/smart/testing/configuration/ResourceLoader.java
+++ b/core/src/test/java/org/arquillian/smart/testing/configuration/ResourceLoader.java
@@ -1,0 +1,31 @@
+package org.arquillian.smart.testing.configuration;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+class ResourceLoader {
+
+    static File getResourceAsFile(String resourceName) {
+        final URL resource = getResource(resourceName);
+        return new File(resource.getFile());
+    }
+
+    static Path getResourceAsPath(String resourceName) {
+        try {
+            return Paths.get(getResource(resourceName).toURI());
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static URL getResource(String resourceName) {
+        final URL resource = Thread.currentThread().getContextClassLoader().getResource(resourceName);
+        if (resource == null) {
+            throw new IllegalStateException("Expected " + resourceName + " to be on the classpath");
+        }
+        return resource;
+    }
+}


### PR DESCRIPTION
Small boyscoutting when going through the YAML configuration code. Having files loaded using classloader makes it independent from how we build the project and where we store resources on the actual file system.