### PR TITLE
Fixes plugin selection done via 'apply-to' property.

### DIFF
--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/affected/ChangesOnDifferentModulesAffectedTestsSelectionExecutionFunctionalTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/affected/ChangesOnDifferentModulesAffectedTestsSelectionExecutionFunctionalTest.java
@@ -39,7 +39,7 @@ public class ChangesOnDifferentModulesAffectedTestsSelectionExecutionFunctionalT
         final TestResults actualTestResults = project
             .build("config/impl-base")
                 .options()
-                    .withSystemProperties("scm.range.head", "HEAD", "scm.range.tail", "HEAD~")
+                    .withSystemProperties("scm.range.head", "HEAD", "scm.range.tail", "HEAD~", "smart.testing.apply.to", "surefire")
                 .configure()
             .run();
 

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configurationfile/HistoricalChangesAffectedTestsSelectionExecutionWithConfigFileFunctionalTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configurationfile/HistoricalChangesAffectedTestsSelectionExecutionWithConfigFileFunctionalTest.java
@@ -2,8 +2,6 @@ package org.arquillian.smart.testing.ftest.configurationfile;
 
 import java.util.Collection;
 import org.arquillian.smart.testing.configuration.Configuration;
-import org.arquillian.smart.testing.configuration.Range;
-import org.arquillian.smart.testing.configuration.Scm;
 import org.arquillian.smart.testing.ftest.testbed.configuration.builder.ConfigurationBuilder;
 import org.arquillian.smart.testing.ftest.testbed.project.Project;
 import org.arquillian.smart.testing.ftest.testbed.project.TestResults;

--- a/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/MavenProjectConfigurator.java
+++ b/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/MavenProjectConfigurator.java
@@ -75,7 +75,7 @@ class MavenProjectConfigurator {
             })
             .filter(plugin -> {
                 if (configuration.isApplyToDefined()) {
-                    return configuration.getApplyTo().equals(plugin.getArtifactId());
+                    return plugin.getArtifactId().contains(configuration.getApplyTo());
                 }
                 // If not set the plugin is usable
                 return true;


### PR DESCRIPTION
<!-- 
Many thanks for contributing to Arquillian! Together we can make the testing world better.

Please tell us what this PR brings following the template we provided. 
And don't forget to link to the issue (or create one if there is none).

If you are still working on the change please prefix this pull request title with "WIP"

YOU CAN DELETE THIS COMMENT :)
-->

#### Short description of what this resolves:
Plugin selection done via `apply-to` property throws Illegal State Exception.


#### Changes proposed in this pull request:

- Check for the plugin name `surefire/failsafe` in artifactID.

Fixes #253
