### PR TITLE
Enables setting custom config file.

### DIFF
--- a/core/src/main/java/org/arquillian/smart/testing/configuration/ConfigurationLoader.java
+++ b/core/src/main/java/org/arquillian/smart/testing/configuration/ConfigurationLoader.java
@@ -9,6 +9,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.arquillian.smart.testing.hub.storage.local.LocalStorage;
@@ -31,13 +32,13 @@ public class ConfigurationLoader {
     }
 
     public static Configuration load(File projectDir) {
-        Map<String, Object> yamlConfiguration = new HashMap<>(0);
+        Map<String, Object> yamlConfiguration;
 
         final String customConfigFile = System.getProperty(SMART_TESTING_CONFIG);
         if (customConfigFile != null) {
-            yamlConfiguration = getConfigurationFromCustomConfigFile(customConfigFile, yamlConfiguration);
+            yamlConfiguration = getConfigurationFromCustomConfigFile(customConfigFile);
         } else {
-            yamlConfiguration = getConfigurationFromDefaultConfigFile(projectDir, yamlConfiguration);
+            yamlConfiguration = getConfigurationFromDefaultConfigFile(projectDir);
         }
 
         final Object strategiesConfiguration = yamlConfiguration.get("strategiesConfiguration");
@@ -50,7 +51,7 @@ public class ConfigurationLoader {
         return configuration;
     }
 
-    private static Map<String, Object> getConfigurationFromDefaultConfigFile(File projectDir, Map<String, Object> yamlConfiguration) {
+    private static Map<String, Object> getConfigurationFromDefaultConfigFile(File projectDir) {
         final File[] files =
             projectDir.listFiles((dir, name) -> name.equals(SMART_TESTING_YML) || name.equals(SMART_TESTING_YAML));
 
@@ -62,20 +63,20 @@ public class ConfigurationLoader {
             logger.info("Config file `" + SMART_TESTING_YAML + "` OR `" + SMART_TESTING_YML + "` is not found. "
                 + "Using system properties to load configuration for smart testing.");
         } else {
-            yamlConfiguration = getConfigParametersFromFile(getConfigurationFilePath(files));
+            return getConfigParametersFromFile(getConfigurationFilePath(files));
         }
-        return yamlConfiguration;
+        return Collections.EMPTY_MAP;
     }
 
-    private static Map<String, Object> getConfigurationFromCustomConfigFile(String customConfigFile, Map<String, Object> yamlConfiguration) {
+    private static Map<String, Object> getConfigurationFromCustomConfigFile(String customConfigFile) {
         final File file = Paths.get(customConfigFile).toAbsolutePath().toFile();
         if (!file.exists()) {
-            logger.info("Config file `" + file.getName() + "` is not found. "
-                + "Using system properties to load configuration for smart testing.");
+            logger.warn("Config file `" + file.getName() + "` is not found. "
+                + "Checking for config file `" + SMART_TESTING_YAML + "` OR `" + SMART_TESTING_YML);
         } else {
-            yamlConfiguration = getConfigParametersFromFile(getConfigurationFilePath(file));
+            return getConfigParametersFromFile(getConfigurationFilePath(file));
         }
-        return yamlConfiguration;
+        return Collections.EMPTY_MAP;
     }
 
     private static Map<String, Object> getConfigParametersFromFile(Path filePath) {

--- a/core/src/test/java/org/arquillian/smart/testing/configuration/ConfigurationTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/configuration/ConfigurationTest.java
@@ -2,6 +2,9 @@ package org.arquillian.smart.testing.configuration;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import net.jcip.annotations.NotThreadSafe;
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,6 +47,14 @@ public class ConfigurationTest {
         final Scm scm = new Scm();
         scm.setRange(range);
 
+        Map<String, Object> affectedStrategiesConfig = new HashMap<>();
+        affectedStrategiesConfig.put("exclusions", Arrays.asList("org.package.*", "org.arquillian.package.*"));
+        affectedStrategiesConfig.put("inclusions", Arrays.asList("org.package.exclude.*", "org.arquillian.package.exclude.*"));
+        affectedStrategiesConfig.put("transitivity", true);
+
+        Map<String, Object> strategiesConfig = new HashMap<>();
+        strategiesConfig.put("affected", affectedStrategiesConfig);
+
         final Configuration expectedConfiguration = new Configuration();
         expectedConfiguration.setMode(ORDERING);
         expectedConfiguration.setStrategies("new", "changed", "affected");
@@ -53,6 +64,7 @@ public class ConfigurationTest {
         expectedConfiguration.setScm(scm);
         expectedConfiguration.setReport(report);
         expectedConfiguration.setAutocorrect(true);
+        expectedConfiguration.setStrategiesConfig(strategiesConfig);
         expectedConfiguration.setCustomStrategies(
             new String[] {"smart.testing.strategy.cool=org.arquillian.smart.testing:strategy-cool:1.0.0",
                 "smart.testing.strategy.experimental=org.arquillian.smart.testing:strategy-experimental:1.0.0"});

--- a/core/src/test/java/org/arquillian/smart/testing/configuration/ConfigurationUsingPropertyTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/configuration/ConfigurationUsingPropertyTest.java
@@ -1,18 +1,30 @@
 package org.arquillian.smart.testing.configuration;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import net.jcip.annotations.NotThreadSafe;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.contrib.java.lang.system.SystemErrRule;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
 
+import static org.arquillian.smart.testing.RunMode.ORDERING;
 import static org.arquillian.smart.testing.RunMode.SELECTING;
 import static org.arquillian.smart.testing.configuration.Configuration.SMART_TESTING;
 import static org.arquillian.smart.testing.configuration.Configuration.SMART_TESTING_MODE;
 import static org.arquillian.smart.testing.configuration.Configuration.SMART_TESTING_REPORT_ENABLE;
+import static org.arquillian.smart.testing.configuration.ConfigurationLoader.SMART_TESTING_CONFIG;
+import static org.arquillian.smart.testing.configuration.ResourceLoader.getResourceAsFile;
 import static org.arquillian.smart.testing.configuration.ResourceLoader.getResourceAsPath;
 import static org.arquillian.smart.testing.report.SmartTestingReportGenerator.REPORT_FILE_NAME;
 import static org.arquillian.smart.testing.report.SmartTestingReportGenerator.TARGET;
+import static org.arquillian.smart.testing.scm.ScmRunnerProperties.DEFAULT_LAST_COMMITS;
 import static org.arquillian.smart.testing.scm.ScmRunnerProperties.HEAD;
 import static org.arquillian.smart.testing.scm.ScmRunnerProperties.SCM_LAST_CHANGES;
 import static org.arquillian.smart.testing.scm.ScmRunnerProperties.SCM_RANGE_HEAD;
@@ -24,6 +36,12 @@ public class ConfigurationUsingPropertyTest {
 
     @Rule
     public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Rule
+    public final SystemErrRule systemErrOut = new SystemErrRule().enableLog();
 
     @Test
     public void should_load_configuration_with_overwriting_system_property_for_scmLastChanges_over_values_from_config_file() {
@@ -97,6 +115,15 @@ public class ConfigurationUsingPropertyTest {
         final Scm scm = new Scm();
         scm.setRange(range);
 
+        Map<String, Object> affectedStrategiesConfig = new HashMap<>();
+        affectedStrategiesConfig.put("exclusions", Arrays.asList("org.package.*", "org.arquillian.package.*"));
+        affectedStrategiesConfig.put("inclusions",
+            Arrays.asList("org.package.exclude.*", "org.arquillian.package.exclude.*"));
+        affectedStrategiesConfig.put("transitivity", true);
+
+        Map<String, Object> strategiesConfig = new HashMap<>();
+        strategiesConfig.put("affected", affectedStrategiesConfig);
+
         final Configuration expectedConfiguration = new Configuration();
         expectedConfiguration.setMode(SELECTING);
         expectedConfiguration.setStrategies("changed");
@@ -106,6 +133,7 @@ public class ConfigurationUsingPropertyTest {
         expectedConfiguration.setReport(report);
         expectedConfiguration.setScm(scm);
         expectedConfiguration.setAutocorrect(true);
+        expectedConfiguration.setStrategiesConfig(strategiesConfig);
         expectedConfiguration.setCustomStrategies(
             new String[] {"smart.testing.strategy.experimental=org.arquillian.smart.testing:strategy-experimental:1.0.0",
                 "smart.testing.strategy.my=org.arquillian.smart.testing:strategy-my:1.0.0",
@@ -150,5 +178,96 @@ public class ConfigurationUsingPropertyTest {
 
         // then
         assertThat(actualConfiguration).isEqualToComparingFieldByFieldRecursively(expectedConfiguration);
+    }
+
+    @Test
+    public void should_load_configuration_file_from_a_particular_location() throws IOException {
+        // given
+        final Report report = new Report();
+        report.setEnable(true);
+        report.setDir(TARGET);
+        report.setName(REPORT_FILE_NAME);
+
+        final Range range = new Range();
+        range.setHead(HEAD);
+        range.setTail(HEAD + "~2");
+
+        final Scm scm = new Scm();
+        scm.setRange(range);
+
+        Map<String, Object> affectedStrategiesConfig = new HashMap<>();
+        affectedStrategiesConfig.put("exclusions", Arrays.asList("org.package.*", "org.arquillian.package.*"));
+        affectedStrategiesConfig.put("inclusions",
+            Arrays.asList("org.package.exclude.*", "org.arquillian.package.exclude.*"));
+        affectedStrategiesConfig.put("transitivity", true);
+
+        Map<String, Object> strategiesConfig = new HashMap<>();
+        strategiesConfig.put("affected", affectedStrategiesConfig);
+
+        final Configuration expectedConfiguration = new Configuration();
+        expectedConfiguration.setMode(ORDERING);
+        expectedConfiguration.setStrategies("new", "changed", "affected");
+        expectedConfiguration.setApplyTo("surefire");
+        expectedConfiguration.setDebug(true);
+        expectedConfiguration.setDisable(false);
+        expectedConfiguration.setScm(scm);
+        expectedConfiguration.setReport(report);
+        expectedConfiguration.setAutocorrect(true);
+        expectedConfiguration.setStrategiesConfig(strategiesConfig);
+        expectedConfiguration.setCustomStrategies(
+            new String[] {"smart.testing.strategy.cool=org.arquillian.smart.testing:strategy-cool:1.0.0",
+                "smart.testing.strategy.experimental=org.arquillian.smart.testing:strategy-experimental:1.0.0"});
+
+        final File tempConfigFile = getCustomConfigFile();
+        System.setProperty(SMART_TESTING_CONFIG, tempConfigFile.getAbsolutePath());
+
+        // when
+        final Configuration actualConfiguration = ConfigurationLoader.load();
+
+        // then
+        assertThat(actualConfiguration).isEqualToComparingFieldByFieldRecursively(expectedConfiguration);
+    }
+
+    @Test
+    public void should_log_warning_if_directory_is_passed_as_custom_config_file() throws IOException {
+        // given
+        final Range range = new Range();
+        range.setHead(HEAD);
+        range.setTail(String.join("~", HEAD, DEFAULT_LAST_COMMITS));
+
+        final Scm scm = new Scm();
+        scm.setRange(range);
+
+        final Report report = new Report();
+        report.setEnable(false);
+        report.setDir(TARGET);
+        report.setName(REPORT_FILE_NAME);
+
+        final Configuration expectedConfiguration = new Configuration();
+        expectedConfiguration.setMode(SELECTING);
+        expectedConfiguration.setDebug(false);
+        expectedConfiguration.setDisable(false);
+        expectedConfiguration.setReport(report);
+        expectedConfiguration.setScm(scm);
+        expectedConfiguration.setAutocorrect(false);
+
+        final File tempConfigFile = temporaryFolder.newFolder();
+        System.setProperty(SMART_TESTING_CONFIG, tempConfigFile.getAbsolutePath());
+
+        // when
+        final Configuration actualConfiguration = ConfigurationLoader.load();
+
+        // then
+        assertThat(actualConfiguration).isEqualToComparingFieldByFieldRecursively(expectedConfiguration);
+        assertThat(systemErrOut.getLog())
+            .contains("WARN: Smart Testing Extension - " + tempConfigFile.getName() + " is a directory. Using the default configuration or please specify a `yaml` configuration file.");
+    }
+
+    private File getCustomConfigFile() throws IOException {
+        final File tempConfigFile = temporaryFolder.newFile("custom-config.yml");
+        String content = new String(
+            Files.readAllBytes(getResourceAsFile("configuration/smart-testing.yml").toPath()));
+        Files.write(tempConfigFile.toPath(), content.getBytes());
+        return tempConfigFile;
     }
 }

--- a/core/src/test/java/org/arquillian/smart/testing/configuration/ConfigurationUsingPropertyTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/configuration/ConfigurationUsingPropertyTest.java
@@ -260,7 +260,7 @@ public class ConfigurationUsingPropertyTest {
         // then
         assertThat(actualConfiguration).isEqualToComparingFieldByFieldRecursively(expectedConfiguration);
         assertThat(systemErrOut.getLog())
-            .contains("WARN: Smart Testing Extension - " + tempConfigFile.getName() + " is a directory. Using the default configuration or please specify a `yaml` configuration file.");
+            .contains("WARN: Smart Testing Extension - " + tempConfigFile.getName() + " is a directory. Using the default configuration file resolution.");
     }
 
     private File getCustomConfigFile() throws IOException {

--- a/docs/configfile.adoc
+++ b/docs/configfile.adoc
@@ -2,6 +2,8 @@
 
 You can use smart-testing `YAML` file at `${project.dir}/smart-testing.yml` or at `${project.dir}/smart-testing.yaml`.
 
+You can also point to a custom configuration file from a different project by setting the `const:core/src/main/java/org/arquillian/smart/testing/configuration/ConfigurationLoader.java[name="SMART_TESTING_CONFIG"]` property.
+
 Configuration file looks as follows:
 
 [[config-file]]

--- a/docs/refcard.adoc
+++ b/docs/refcard.adoc
@@ -40,6 +40,11 @@ a|`const:core/src/main/java/org/arquillian/smart/testing/configuration/Configura
 |Enable auto correct of misspelled strategies
 a|`false`
 a|`true`, `false`
+
+a|`const:core/src/main/java/org/arquillian/smart/testing/configuration/ConfigurationLoader.java[name="SMART_TESTING_CONFIG"]`
+|Set custom configuration file
+a| -
+a|custom configuration `yml` file
 |===
 
 === Strategies

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectConfigurator.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectConfigurator.java
@@ -115,15 +115,10 @@ public class ProjectConfigurator {
                     .build();
             }
 
-            if (customConfigFile != null) {
-                this.project.configureSmartTesting()
-                    .withConfiguration(configuration)
-                    .createConfigFile(customConfigFile);
-            } else {
-                this.project.configureSmartTesting()
-                    .withConfiguration(configuration)
-                    .createConfigFile(SMART_TESTING_YML);
-            }
+            this.project.configureSmartTesting()
+                .withConfiguration(configuration)
+                .createConfigFile(customConfigFile != null ? customConfigFile : SMART_TESTING_YML);
+
         }
         return this.project;
     }

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectConfigurator.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectConfigurator.java
@@ -22,6 +22,8 @@ import org.yaml.snakeyaml.nodes.NodeTuple;
 import org.yaml.snakeyaml.nodes.Tag;
 import org.yaml.snakeyaml.representer.Representer;
 
+import static org.arquillian.smart.testing.configuration.ConfigurationLoader.SMART_TESTING_YML;
+
 public class ProjectConfigurator {
 
     private static final String SMART_TESTING = "smart.testing";
@@ -63,7 +65,7 @@ public class ProjectConfigurator {
 
     public ProjectConfigurator createConfigFile() {
         this.createConfigFile = true;
-        createConfigurationFile();
+        createConfigurationFile(SMART_TESTING_YML);
         return this;
     }
 
@@ -120,7 +122,7 @@ public class ProjectConfigurator {
             } else {
                 this.project.configureSmartTesting()
                     .withConfiguration(configuration)
-                    .createConfigFile();
+                    .createConfigFile(SMART_TESTING_YML);
             }
         }
         return this.project;
@@ -128,11 +130,6 @@ public class ProjectConfigurator {
 
     public String strategies() {
        return Arrays.stream(getStrategies()).map(Strategy::getName).collect(Collectors.joining(","));
-    }
-
-    private void createConfigurationFile() {
-        final Path configFilePath = Paths.get(root.toString(), "smart-testing.yml");
-        dumpConfiguration(configFilePath);
     }
 
     private void createConfigurationFile(String customConfigFile) {

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectConfigurator.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/ProjectConfigurator.java
@@ -61,11 +61,15 @@ public class ProjectConfigurator {
         return this;
     }
 
-    public ProjectConfigurator createConfigFile(String... customConfigFile) {
+    public ProjectConfigurator createConfigFile() {
         this.createConfigFile = true;
-        if (customConfigFile.length > 0) {
-            this.customConfigFile = customConfigFile[0];
-        }
+        createConfigurationFile();
+        return this;
+    }
+
+    public ProjectConfigurator createConfigFile(String customConfigFile) {
+        this.createConfigFile = true;
+        this.customConfigFile = customConfigFile;
         createConfigurationFile(customConfigFile);
         return this;
     }
@@ -126,19 +130,19 @@ public class ProjectConfigurator {
        return Arrays.stream(getStrategies()).map(Strategy::getName).collect(Collectors.joining(","));
     }
 
-    private void createConfigurationFile(String... customConfigFile) {
-        Path configFilePath;
-        if (customConfigFile.length > 0) {
-            configFilePath = Paths.get(root.toString(), customConfigFile[0]);
-            if (!Files.exists(configFilePath)) {
-                try {
-                    Files.createFile(configFilePath);
-                } catch (IOException e) {
-                    throw new UncheckedIOException("Failed creating custom configuration file.", e);
-                }
+    private void createConfigurationFile() {
+        final Path configFilePath = Paths.get(root.toString(), "smart-testing.yml");
+        dumpConfiguration(configFilePath);
+    }
+
+    private void createConfigurationFile(String customConfigFile) {
+        Path configFilePath = Paths.get(root.toString(), customConfigFile);
+        if (!Files.exists(configFilePath)) {
+            try {
+                Files.createFile(configFilePath);
+            } catch (IOException e) {
+                throw new UncheckedIOException("Failed creating custom configuration file.", e);
             }
-        } else {
-            configFilePath = Paths.get(root.toString(), "smart-testing.yml");
         }
         dumpConfiguration(configFilePath);
     }

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configurationfile/HistoricalChangesAffectedTestsSelectionExecutionWithConfigFileFunctionalTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/configurationfile/HistoricalChangesAffectedTestsSelectionExecutionWithConfigFileFunctionalTest.java
@@ -29,6 +29,8 @@ public class HistoricalChangesAffectedTestsSelectionExecutionWithConfigFileFunct
         // given
         final Project project = testBed.getProject();
 
+        final String customConfigFile = "core/custom-config-file.yml";
+
         final Configuration configuration = new ConfigurationBuilder()
                 .mode(SELECTING)
                 .strategies(AFFECTED.getName())
@@ -41,14 +43,18 @@ public class HistoricalChangesAffectedTestsSelectionExecutionWithConfigFileFunct
 
         project.configureSmartTesting()
                     .withConfiguration(configuration)
-                .createConfigFile()
+                .createConfigFile(customConfigFile)
             .enable();
 
         final Collection<TestResult> expectedTestResults = project
             .applyAsCommits("Single method body modification - sysout");
 
         // when
-        final TestResults actualTestResults = project.build().run();
+        final TestResults actualTestResults = project.build("config/impl-base")
+                .options()
+                    .withSystemProperties("smart.testing.config", customConfigFile)
+                .configure()
+            .run();
 
         // then
         assertThat(actualTestResults.accumulatedPerTestClass()).containsAll(expectedTestResults).hasSameSizeAs(expectedTestResults);


### PR DESCRIPTION
<!-- 
Many thanks for contributing to Arquillian! Together we can make the testing world better.

Please tell us what this PR brings following the template we provided. 
And don't forget to link to the issue (or create one if there is none).

If you are still working on the change please prefix this pull request title with "WIP"

YOU CAN DELETE THIS COMMENT :)
-->

#### Short description of what this resolves:
Enables use of custom configuration file (eg. file from a different project in multi-module project) using system property `smart.testing.config` for configuring ST.

#### Changes proposed in this pull request:

- Adds system property to specify custom property for configuration file.
- Updates test bed for related changes and tests to verify this feature.

Fixes #242 
