### PR TITLE
Refactors effective plugin filters and error messages.

### DIFF
--- a/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/MavenProjectConfigurator.java
+++ b/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/MavenProjectConfigurator.java
@@ -95,29 +95,23 @@ class MavenProjectConfigurator {
         Version version = Version.from(plugin.getVersion().trim());
         if (!version.isGreaterOrEqualThan(MINIMUM_VERSION)) {
             failBecauseOfPluginVersionMismatch(model);
-            return false;
         }
         return true;
     }
 
     private void failBecauseOfMissingApplicablePlugin(Model model) {
-        String applicablePlugin = (configuration.getApplyTo() != null) ? configuration.getApplyTo()
+        String applicablePlugin = (configuration.isApplyToDefined()) ? configuration.getApplyTo()
             : ApplicablePlugins.ARTIFACT_IDS_LIST.toString();
-        logger.error(
-            "Smart testing must be used with any of %s plugin(s). Please verify <plugins> section in your pom.xml",
-            applicablePlugin, MINIMUM_VERSION);
         logCurrentPlugins(model);
         throw new IllegalStateException(
-            String.format("Smart testing must be used with any of %s plugin(s)", applicablePlugin, MINIMUM_VERSION));
+            String.format("Smart testing must be used with any of %s plugin(s). Please verify <plugins> section in your pom.xml",
+                applicablePlugin));
     }
 
     private void failBecauseOfPluginVersionMismatch(Model model) {
-        logger.error(
-            "Smart testing must be used with any of %s plugins with minimum version %s. Please add or update one of the plugin in <plugins> section in your pom.xml",
-            ApplicablePlugins.ARTIFACT_IDS_LIST, MINIMUM_VERSION);
         logCurrentPlugins(model);
         throw new IllegalStateException(
-            String.format("Smart testing must be used with any of %s plugins with minimum version %s",
+            String.format("Smart testing must be used with any of %s plugins with minimum version %s. Please add or update one of the plugin in <plugins> section in your pom.xml",
                 ApplicablePlugins.ARTIFACT_IDS_LIST, MINIMUM_VERSION));
     }
 


### PR DESCRIPTION
<!-- 
Many thanks for contributing to Arquillian! Together we can make the testing world better.

Please tell us what this PR brings following the template we provided. 
And don't forget to link to the issue (or create one if there is none).

If you are still working on the change please prefix this pull request title with "WIP"

YOU CAN DELETE THIS COMMENT :)
-->

#### Short description of what this resolves:
Fixes ambiguous error message conveying version mismatch despite the correct version used for effective plugin selection.  

#### Changes proposed in this pull request:

- refactors plugin selection filters and error messages. 

Fixes #253 
