### PR TITLE
fix(test-bed): When shaded jar is being resolved,classpath resolution is disabled

### DIFF
--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/MavenExtensionShadedJarRegisterer.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/MavenExtensionShadedJarRegisterer.java
@@ -51,7 +51,8 @@ class MavenExtensionShadedJarRegisterer {
     }
 
     private File retrieveShadedExtensionJar(String stVersion){
-        return Maven.configureResolver().workOffline()
+        return Maven.configureResolver()
+            .withClassPathResolution(false)
             .resolve("org.arquillian.smart.testing:maven-lifecycle-extension:jar:shaded:" + stVersion)
             .withoutTransitivity()
             .asSingleFile();


### PR DESCRIPTION
Otherwise, in IDE it takes the shaded jar from the classpath, where the jar is not complete.

Fixes #259 
