### PR TITLE
chore: Refactored & moved autocorrect functionality to Configuration class

### DIFF
--- a/core/src/main/java/org/arquillian/smart/testing/configuration/Configuration.java
+++ b/core/src/main/java/org/arquillian/smart/testing/configuration/Configuration.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.StreamSupport;
 import org.arquillian.smart.testing.RunMode;
 import org.arquillian.smart.testing.hub.storage.local.LocalStorage;
@@ -223,5 +224,37 @@ public class Configuration implements ConfigurationSection {
                     .orElseThrow(() ->
                         new RuntimeException("The configuration class of strategy " + strategyName
                             + " is not available. Make sure you have correct dependencies on you classpath.")));
+    }
+
+    public void autocorrectStrategies(Set<String> availableStrategies, List<String> errorMessages) {
+        StringSimilarityCalculator stringSimilarityCalculator = new StringSimilarityCalculator();
+        List<String> registeredStrategies = new ArrayList<>();
+
+        for (int i = 0; i < strategies.length; i++) {
+            String definedStrategy = strategies[i];
+
+            if (!availableStrategies.contains(definedStrategy)) {
+                String closestMatch = stringSimilarityCalculator.findClosestMatch(definedStrategy, availableStrategies);
+
+                if (isAutocorrect()) {
+                    if (registeredStrategies.contains(closestMatch)) {
+                        errorMessages.add(
+                            String.format("Autocorrected [%s] strategy to [%s] but it was already registered",
+                                closestMatch, definedStrategy));
+                    }
+                    strategies[i] = closestMatch;
+                    registeredStrategies.add(closestMatch);
+                } else {
+                    errorMessages.add(
+                        String.format("Unable to find strategy [%s]. Did you mean [%s]?", definedStrategy, closestMatch));
+                }
+            } else {
+                if (registeredStrategies.contains(definedStrategy)) {
+                    errorMessages.add(
+                        String.format("Strategy [%s] was already registered or autocorrected", definedStrategy));
+                }
+                registeredStrategies.add(definedStrategy);
+            }
+        }
     }
 }

--- a/core/src/main/java/org/arquillian/smart/testing/impl/TestExecutionPlannerLoader.java
+++ b/core/src/main/java/org/arquillian/smart/testing/impl/TestExecutionPlannerLoader.java
@@ -1,11 +1,14 @@
 package org.arquillian.smart.testing.impl;
 
+import java.util.Set;
 import org.arquillian.smart.testing.api.TestVerifier;
 import org.arquillian.smart.testing.spi.TestExecutionPlanner;
 
 interface TestExecutionPlannerLoader {
 
-    TestExecutionPlanner getPlannerForStrategy(String strategy, boolean autocorrect);
+    TestExecutionPlanner getPlannerForStrategy(String strategy);
 
     TestVerifier getVerifier();
+
+    Set<String> getAvailableStrategyNames();
 }

--- a/core/src/main/java/org/arquillian/smart/testing/impl/TestStrategyApplierImpl.java
+++ b/core/src/main/java/org/arquillian/smart/testing/impl/TestStrategyApplierImpl.java
@@ -57,18 +57,21 @@ class TestStrategyApplierImpl implements TestStrategyApplier {
     }
 
     private Set<TestSelection> selectTests(Configuration configuration) {
-
-        final List<String> strategies = Arrays.asList(configuration.getStrategies());
-        if (strategies.isEmpty()) {
+        if (configuration.getStrategies().length == 0) {
             logger.warn(
                 "Smart Testing Extension is installed but no strategies are provided. It won't influence the way how your tests are executed. "
                     + "For details on how to configure it head over to http://bit.ly/st-config");
             return Collections.emptySet();
         }
 
+        List<String> errorMessages = new ArrayList<>();
+        configuration.autocorrectStrategies(testExecutionPlannerLoader.getAvailableStrategyNames(), errorMessages);
+        errorMessages.forEach(msg -> logger.error(msg));
+
+        List<String> strategies = Arrays.asList(configuration.getStrategies());
         final List<TestSelection> selectedTests = new ArrayList<>();
         for (final String strategy : strategies) {
-            final TestExecutionPlanner plannerForStrategy = testExecutionPlannerLoader.getPlannerForStrategy(strategy, configuration.isAutocorrect());
+            final TestExecutionPlanner plannerForStrategy = testExecutionPlannerLoader.getPlannerForStrategy(strategy);
             selectedTests.addAll(plannerForStrategy.getTests());
         }
         logger.info("Applied strategies: %s", strategies);

--- a/core/src/test/java/org/arquillian/smart/testing/impl/TestExecutionPlannerLoaderTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/impl/TestExecutionPlannerLoaderTest.java
@@ -1,6 +1,7 @@
 package org.arquillian.smart.testing.impl;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import org.arquillian.smart.testing.TestSelection;
@@ -32,7 +33,7 @@ public class TestExecutionPlannerLoaderTest {
             new TestExecutionPlannerLoaderImpl(mockedSpiLoader, resource -> true, projectDir, mock(Configuration.class));
 
         // when
-        final TestExecutionPlanner testExecutionPlanner = testExecutionPlannerLoader.getPlannerForStrategy("dummy", false);
+        final TestExecutionPlanner testExecutionPlanner = testExecutionPlannerLoader.getPlannerForStrategy("dummy");
 
         // then
         assertThat(testExecutionPlanner.getTests()).isEmpty();
@@ -44,11 +45,15 @@ public class TestExecutionPlannerLoaderTest {
         final JavaSPILoader mockedSpiLoader = mock(JavaSPILoader.class);
         when(mockedSpiLoader.all(eq(TestExecutionPlannerFactory.class))).thenAnswer(i -> Collections.singletonList(
             new DummyTestExecutionPlannerFactory()));
+        Configuration configuration = new Configuration();
+        configuration.setAutocorrect(true);
+        configuration.setStrategies("dumy");
         final TestExecutionPlannerLoaderImpl testExecutionPlannerLoader =
-            new TestExecutionPlannerLoaderImpl(mockedSpiLoader, resource -> true, projectDir, mock(Configuration.class));
+            new TestExecutionPlannerLoaderImpl(mockedSpiLoader, resource -> true, projectDir, configuration);
 
         // when
-        final TestExecutionPlanner testExecutionPlanner = testExecutionPlannerLoader.getPlannerForStrategy("dumy", true);
+        configuration.autocorrectStrategies(testExecutionPlannerLoader.getAvailableStrategyNames(), new ArrayList<>());
+        final TestExecutionPlanner testExecutionPlanner = testExecutionPlannerLoader.getPlannerForStrategy(configuration.getStrategies()[0]);
 
         // then
         assertThat(testExecutionPlanner.getTests()).isEmpty();
@@ -64,7 +69,7 @@ public class TestExecutionPlannerLoaderTest {
             new TestExecutionPlannerLoaderImpl(mockedSpiLoader, resource -> true, projectDir, mock(Configuration.class));
 
         // when
-        final Throwable exception = catchThrowable(() -> testExecutionPlannerLoader.getPlannerForStrategy("new", false));
+        final Throwable exception = catchThrowable(() -> testExecutionPlannerLoader.getPlannerForStrategy("new"));
 
         // then
         assertThat(exception).isInstanceOf(IllegalArgumentException.class)
@@ -81,7 +86,7 @@ public class TestExecutionPlannerLoaderTest {
             new TestExecutionPlannerLoaderImpl(mockedSpiLoader, resource -> true, projectDir, mock(Configuration.class));
 
         // when
-        final Throwable exception = catchThrowable(() -> testExecutionPlannerLoader.getPlannerForStrategy("new", false));
+        final Throwable exception = catchThrowable(() -> testExecutionPlannerLoader.getPlannerForStrategy("new"));
 
         // then
         assertThat(exception).isInstanceOf(IllegalStateException.class)

--- a/core/src/test/java/org/arquillian/smart/testing/impl/TestStrategyApplierUsingPropertyTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/impl/TestStrategyApplierUsingPropertyTest.java
@@ -132,7 +132,7 @@ public class TestStrategyApplierUsingPropertyTest {
         when(testExecutionPlanner.getTests()).thenReturn(strategyTests);
 
         TestExecutionPlannerLoader testExecutionPlannerLoader = mock(TestExecutionPlannerLoader.class);
-        when(testExecutionPlannerLoader.getPlannerForStrategy("static", false)).thenReturn(testExecutionPlanner);
+        when(testExecutionPlannerLoader.getPlannerForStrategy("static")).thenReturn(testExecutionPlanner);
         when(testExecutionPlannerLoader.getVerifier())
             .thenReturn(className -> testsToRun.stream().map(Class::getName).anyMatch(name -> name.equals(className)));
 


### PR DESCRIPTION
#### Short description of what this resolves:

The autocorrect functionality has to be available in core to have it accessible (applicable) also in other integration implementations such as in Che

#### Changes proposed in this pull request:

- Moved autocorrect functionality from Maven extension (`DependencyResolver.java`) to Core (`Configuration.java`). The `autocorrectStrategies` method is then called from Smart Testing API

Fixes #269 
