### PR TITLE
fix(#270): when loading test reports it reflects location set by API 

### DIFF
--- a/core/src/main/java/org/arquillian/smart/testing/spi/TestResult.java
+++ b/core/src/main/java/org/arquillian/smart/testing/spi/TestResult.java
@@ -9,11 +9,19 @@ public class TestResult {
     private final Float testDuration;
     private Result result;
 
-    public TestResult(String className, String testMethod, Float testDuration) {
+    public TestResult(String className, String testMethod, Float testDuration, Result result) {
         this.className = className;
         this.testMethod = testMethod;
         this.testDuration = testDuration;
-        this.result = Result.PASSED;
+        this.result = result;
+    }
+
+    public TestResult(String className, Result result) {
+        this(className, "", 0f, result);
+    }
+
+    public TestResult(String className, String testMethod, Float testDuration) {
+        this(className, testMethod, testDuration, Result.PASSED);
     }
 
     public String getClassName() {

--- a/strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/FailedTestsDetector.java
+++ b/strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/FailedTestsDetector.java
@@ -1,5 +1,6 @@
 package org.arquillian.smart.testing.strategies.failed;
 //tag::documentation[]
+import java.io.File;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.stream.Collectors;
@@ -11,10 +12,15 @@ public class FailedTestsDetector implements TestExecutionPlanner {
 
     static final String FAILED = "failed";
 
-    private final TestReportLoader testReportLoader = new InProjectTestReportLoader(new JavaSPILoader());
+    private final File projectDir;
+
+    public FailedTestsDetector(File projectDir) {
+        this.projectDir = projectDir;
+    }
 
     @Override
     public Collection<TestSelection> getTests() { // <1>
+        TestReportLoader testReportLoader = new InProjectTestReportLoader(new JavaSPILoader(), projectDir);
         return testReportLoader.loadTestResults()
             .stream()
             .map(result -> new TestSelection(result, getName())) // <2>

--- a/strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/FailedTestsDetectorFactory.java
+++ b/strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/FailedTestsDetectorFactory.java
@@ -23,7 +23,7 @@ public class FailedTestsDetectorFactory implements TestExecutionPlannerFactory {
 
     @Override
     public TestExecutionPlanner create(File projectDir, TestVerifier verifier, Configuration configuration) {
-        return new FailedTestsDetector();
+        return new FailedTestsDetector(projectDir);
     } // <2>
 
     @Override

--- a/strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/InProjectTestReportLoader.java
+++ b/strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/InProjectTestReportLoader.java
@@ -1,5 +1,6 @@
 package org.arquillian.smart.testing.strategies.failed;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -19,15 +20,15 @@ import static org.arquillian.smart.testing.spi.TestResult.TEMP_REPORT_DIR;
 public class InProjectTestReportLoader implements TestReportLoader {
 
     private final JavaSPILoader javaSPILoader;
-    private String rootDirectory;
+    private File rootDirectory;
 
-    InProjectTestReportLoader(JavaSPILoader javaSPILoader) {
-        this(javaSPILoader, ".");
+    public InProjectTestReportLoader(JavaSPILoader javaSPILoader, File projectDir) {
+        this.javaSPILoader = javaSPILoader;
+        this.rootDirectory = projectDir;
     }
 
     InProjectTestReportLoader(JavaSPILoader javaSPILoader, String rootDirectory) {
-        this.javaSPILoader = javaSPILoader;
-        this.rootDirectory = rootDirectory;
+        this(javaSPILoader, new File(rootDirectory));
     }
 
     @Override


### PR DESCRIPTION
#### Short description of what this resolves:

When the test reports are being loaded it takes into account the location set by API
I have also added some additional constructors to `TestResult` class for easier usage.


Fixes #270
