### PR TITLE
Added -Z flag to work with SELinux

### DIFF
--- a/.asciidoctor/generate.sh
+++ b/.asciidoctor/generate.sh
@@ -37,7 +37,7 @@ fi
 
 echo "Generating doc in $TARGET_FOLDER"
 
-docker run -v ${WORKING_DIR}:/docs/ --name adoc-to-html rochdev/alpine-asciidoctor:mini asciidoctor \
+docker run -v ${WORKING_DIR}:/docs/:Z --name adoc-to-html rochdev/alpine-asciidoctor:mini asciidoctor \
     -r /docs/.asciidoctor/lib/const-inline-macro.rb \
     -r /docs/.asciidoctor/lib/copy-to-clipboard-inline-macro.rb \
     -a generated-doc=true -a asciidoctor-source=/docs/docs \


### PR DESCRIPTION
While generating docs, I have observed that on my host, asciidoc container could not write to shared/mounted private volume.

Maybe you guys are not facing this issue as you are using docker-ce. But in my case I am using fedora distribution of docker installed using `dnf install docker`

Ref - http://www.projectatomic.io/blog/2016/03/dwalsh_selinux_containers/