### PR TITLE
fix(#279): strategy deps are shaded and excluded their transitive deps

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -56,6 +56,61 @@
           </systemPropertyVariables>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${version.maven.plugin.shade}</version>
+        <configuration>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
+          <shadedArtifactAttached>true</shadedArtifactAttached>
+          <shadedClassifierName>shaded</shadedClassifierName>
+          <minimizeJar>true</minimizeJar>
+          <artifactSet>
+            <excludes>
+              <exclude>org.slf4j:*</exclude>
+            </excludes>
+          </artifactSet>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/*.SF</exclude>
+                <exclude>META-INF/*.DSA</exclude>
+                <exclude>META-INF/*.RSA</exclude>
+              </excludes>
+            </filter>
+          </filters>
+          <relocations>
+            <relocation>
+              <pattern>org.yaml.</pattern>
+              <shadedPattern>shaded.org.yaml.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.eclipse.</pattern>
+              <shadedPattern>shaded.org.eclipse.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.</pattern>
+              <shadedPattern>shaded.org.apache.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.jcraft.</pattern>
+              <shadedPattern>shaded.com.jcraft.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>com.googlecode.</pattern>
+              <shadedPattern>shaded.com.googlecode.</shadedPattern>
+            </relocation>
+          </relocations>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/docs/registering-strategies.adoc
+++ b/docs/registering-strategies.adoc
@@ -101,6 +101,8 @@ customStrategies:
 
 It is important to notice that the _key_ part must be prefixed with `const:core/src/main/java/org/arquillian/smart/testing/configuration/Configuration.java[name="SMART_TESTING_CUSTOM_STRATEGIES"].`.
 
+If you need to specify any additional coordinate (such as type or classifier), you have to use the whole coordinates format:
+`groupId:artifactId:packaging:classifier:version:scope`
 
 === Alternative Approach
 

--- a/mvn-extension/pom.xml
+++ b/mvn-extension/pom.xml
@@ -9,10 +9,6 @@
 
   <artifactId>maven-lifecycle-extension</artifactId>
 
-  <properties>
-    <version.maven.plugin.shade>3.0.0</version.maven.plugin.shade>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/dependencies/MavenCoordinatesResolver.java
+++ b/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/dependencies/MavenCoordinatesResolver.java
@@ -1,0 +1,42 @@
+package org.arquillian.smart.testing.mvn.ext.dependencies;
+
+import java.util.Arrays;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Exclusion;
+
+class MavenCoordinatesResolver {
+
+    static Dependency createDependencyFromCoordinates(String coordinatesString, boolean excludeTransitive) {
+        final String[] coordinates = coordinatesString.split(":");
+        int amountOfCoordinates = coordinates.length;
+        if (amountOfCoordinates < 2) {
+            throw new IllegalArgumentException(
+                "Coordinates of the specified strategy [" + coordinatesString + "] doesn't have the correct format.");
+        }
+        final Dependency dependency = new Dependency();
+        dependency.setGroupId(coordinates[0]);
+        dependency.setArtifactId(coordinates[1]);
+        if (amountOfCoordinates == 3) {
+            dependency.setVersion(coordinates[2]);
+        } else if (amountOfCoordinates >= 4) {
+            dependency.setType(coordinates[2].isEmpty() ? "jar" : coordinates[2]);
+            dependency.setClassifier(coordinates[3]);
+        }
+        if (amountOfCoordinates >= 5) {
+            dependency.setVersion(coordinates[4]);
+        }
+        if (amountOfCoordinates == 6) {
+            dependency.setScope(coordinates[5]);
+        }
+        if (dependency.getVersion() == null || dependency.getVersion().isEmpty()) {
+            dependency.setVersion(ExtensionVersion.version().toString());
+        }
+        if (excludeTransitive) {
+            Exclusion exclusion = new Exclusion();
+            exclusion.setGroupId("*");
+            exclusion.setArtifactId("*");
+            dependency.setExclusions(Arrays.asList(exclusion));
+        }
+        return dependency;
+    }
+}

--- a/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/dependencies/StrategyDependencyResolver.java
+++ b/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/dependencies/StrategyDependencyResolver.java
@@ -7,8 +7,9 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 import org.apache.maven.model.Dependency;
-import org.apache.maven.model.Exclusion;
 import org.arquillian.smart.testing.configuration.Configuration;
+
+import static org.arquillian.smart.testing.mvn.ext.dependencies.MavenCoordinatesResolver.createDependencyFromCoordinates;
 
 /**
  * Resolves dependencies for strategies defined by keywords (e.g. new, changed, affected)
@@ -74,39 +75,7 @@ class StrategyDependencyResolver {
             .filter(key -> key.startsWith(SMART_TESTING_STRATEGY_PREFIX))
             .map(String::valueOf)
             .collect(Collectors.toMap(this::filterPrefix,
-                key -> createDependency((String) properties.get(key), excludeTrainsitive)));
-    }
-
-    private Dependency createDependency(String coordinatesString, boolean excludeTrainsitive) {
-        final String[] coordinates = coordinatesString.split(":");
-        int number = coordinates.length;
-        if (number < 2) {
-            throw new IllegalArgumentException(
-                "Coordinates of the specified strategy [" + coordinatesString + "] doesn't have the correct format.");
-        }
-        final Dependency dependency = new Dependency();
-        dependency.setGroupId(coordinates[0]);
-        dependency.setArtifactId(coordinates[1]);
-        if (number == 3) {
-            dependency.setVersion(coordinates[2]);
-        } else if (number > 4) {
-            dependency.setType(coordinates[2].isEmpty() ? "jar" : coordinates[2]);
-            dependency.setClassifier(coordinates[3]);
-            dependency.setVersion(coordinates[4]);
-        }
-        if (number == 6) {
-            dependency.setScope(coordinates[5]);
-        }
-        if (dependency.getVersion() == null || dependency.getVersion().isEmpty()) {
-            dependency.setVersion(ExtensionVersion.version().toString());
-        }
-        if (excludeTrainsitive) {
-            Exclusion exclusion = new Exclusion();
-            exclusion.setGroupId("*");
-            exclusion.setArtifactId("*");
-            dependency.setExclusions(Arrays.asList(exclusion));
-        }
-        return dependency;
+                key -> createDependencyFromCoordinates((String) properties.get(key), excludeTrainsitive)));
     }
 
     private String filterPrefix(String key) {

--- a/mvn-extension/src/main/resources/strategies.properties
+++ b/mvn-extension/src/main/resources/strategies.properties
@@ -1,4 +1,4 @@
-smart.testing.strategy.changed=org.arquillian.smart.testing:strategy-changed
-smart.testing.strategy.new=org.arquillian.smart.testing:strategy-changed
-smart.testing.strategy.affected=org.arquillian.smart.testing:strategy-affected
-smart.testing.strategy.failed=org.arquillian.smart.testing:strategy-failed
+smart.testing.strategy.changed=org.arquillian.smart.testing:strategy-changed::shaded::runtime
+smart.testing.strategy.new=org.arquillian.smart.testing:strategy-changed::shaded::runtime
+smart.testing.strategy.affected=org.arquillian.smart.testing:strategy-affected::shaded::runtime
+smart.testing.strategy.failed=org.arquillian.smart.testing:strategy-failed::shaded::runtime

--- a/mvn-extension/src/test/java/org/arquillian/smart/testing/mvn/ext/dependencies/DependencyAssertion.java
+++ b/mvn-extension/src/test/java/org/arquillian/smart/testing/mvn/ext/dependencies/DependencyAssertion.java
@@ -1,0 +1,74 @@
+package org.arquillian.smart.testing.mvn.ext.dependencies;
+
+import java.util.Objects;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Exclusion;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ListAssert;
+
+public class DependencyAssertion extends AbstractAssert<DependencyAssertion, Dependency> {
+
+    public DependencyAssertion(Dependency actual) {
+        super(actual, DependencyAssertion.class);
+    }
+
+    public static DependencyAssertion assertThat(Dependency actual) {
+        return new DependencyAssertion(actual);
+    }
+
+    public DependencyAssertion hasGroupId(String groupId) {
+        isNotNull();
+        if (!Objects.equals(actual.getGroupId(), groupId)) {
+            failWithMessage("Expected dependency's groupId to be <%s> but was <%s>", groupId, actual.getGroupId());
+        }
+        return this;
+    }
+
+    public DependencyAssertion hasArtifactId(String artifactId) {
+        isNotNull();
+        if (!Objects.equals(actual.getArtifactId(), artifactId)) {
+            failWithMessage("Expected dependency's artifactId to be <%s> but was <%s>", artifactId,
+                actual.getArtifactId());
+        }
+        return this;
+    }
+
+    public DependencyAssertion hasVersion(String version) {
+        isNotNull();
+        if (!Objects.equals(actual.getVersion(), version)) {
+            failWithMessage("Expected dependency's version to be <%s> but was <%s>", version, actual.getVersion());
+        }
+        return this;
+    }
+
+    public DependencyAssertion hasScope(String scope) {
+        isNotNull();
+        if (!Objects.equals(actual.getScope(), scope)) {
+            failWithMessage("Expected dependency's scope to be <%s> but was <%s>", scope, actual.getScope());
+        }
+        return this;
+    }
+
+    public DependencyAssertion hasClassifier(String classifier) {
+        isNotNull();
+        if (!Objects.equals(actual.getClassifier(), classifier)) {
+            failWithMessage("Expected dependency's classifier to be <%s> but was <%s>", classifier,
+                actual.getClassifier());
+        }
+        return this;
+    }
+
+    public DependencyAssertion hasType(String type) {
+        isNotNull();
+        if (!Objects.equals(actual.getType(), type)) {
+            failWithMessage("Expected dependency's type to be <%s> but was <%s>", type, actual.getType());
+        }
+        return this;
+    }
+
+    public ListAssert<Exclusion> exclusions() {
+        isNotNull();
+        return Assertions.assertThat(actual.getExclusions());
+    }
+}

--- a/mvn-extension/src/test/java/org/arquillian/smart/testing/mvn/ext/dependencies/MavenCoordinatesResolverTest.java
+++ b/mvn-extension/src/test/java/org/arquillian/smart/testing/mvn/ext/dependencies/MavenCoordinatesResolverTest.java
@@ -1,0 +1,105 @@
+package org.arquillian.smart.testing.mvn.ext.dependencies;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Exclusion;
+import org.assertj.core.api.Assertions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.arquillian.smart.testing.mvn.ext.dependencies.DependencyAssertion.assertThat;
+
+public class MavenCoordinatesResolverTest {
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    private String groupId = "org.my.group.id";
+    private String artifactId = "my-artifactId";
+    private String version = "my-version";
+    private String classifier = "my-classifier";
+    private String packaging = "my-packaging";
+    private String scope = "my-scope";
+
+    @Test
+    public void should_create_dependency_from_ga_with_st_version_without_exclusions() {
+        // when
+        Dependency dependency =
+            MavenCoordinatesResolver.createDependencyFromCoordinates(groupId + ":" + artifactId, false);
+
+        // then
+        assertThat(dependency)
+            .hasGroupId(groupId)
+            .hasArtifactId(artifactId)
+            .hasVersion(ExtensionVersion.version().toString())
+            .hasType("jar")
+            .hasClassifier(null)
+            .exclusions().isEmpty();
+    }
+
+    @Test
+    public void should_create_dependency_from_gav_with_exclusions() {
+        // when
+        Dependency dependency =
+            MavenCoordinatesResolver.createDependencyFromCoordinates(String.join(":", groupId, artifactId, version),
+                true);
+
+        // then
+        assertThat(dependency)
+            .hasGroupId(groupId)
+            .hasArtifactId(artifactId)
+            .hasVersion(version)
+            .hasType("jar")
+            .hasClassifier(null)
+            .exclusions().hasSize(1);
+        Exclusion exclusion = dependency.getExclusions().get(0);
+        Assertions.assertThat(exclusion.getGroupId()).isEqualTo("*");
+        Assertions.assertThat(exclusion.getArtifactId()).isEqualTo("*");
+    }
+
+    @Test
+    public void should_throw_exception_when_wrong_coordinates_are_set() {
+        // given
+        thrown.expect(IllegalArgumentException.class);
+
+        // when
+        MavenCoordinatesResolver.createDependencyFromCoordinates(groupId + artifactId, false);
+
+        // then exception should be thrown
+    }
+
+    @Test
+    public void should_create_dependency_from_ga_with_st_version_with_shaded_classifier() {
+        // when
+        Dependency dependency =
+            MavenCoordinatesResolver.createDependencyFromCoordinates(
+                String.join(":", groupId, artifactId, "", classifier), false);
+
+        // then
+        assertThat(dependency)
+            .hasGroupId(groupId)
+            .hasArtifactId(artifactId)
+            .hasVersion(ExtensionVersion.version().toString())
+            .hasType("jar")
+            .hasClassifier(classifier)
+            .exclusions().isEmpty();
+    }
+
+    @Test
+    public void should_create_dependency_from_whole_coordinates() {
+        // when
+        Dependency dependency =
+            MavenCoordinatesResolver.createDependencyFromCoordinates(
+                String.join(":", groupId, artifactId, packaging, classifier, version,scope), false);
+
+        // then
+        assertThat(dependency)
+            .hasGroupId(groupId)
+            .hasArtifactId(artifactId)
+            .hasVersion(version)
+            .hasType(packaging)
+            .hasClassifier(classifier)
+            .hasScope(scope)
+            .exclusions().isEmpty();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
     <version.arquillian.spacelift>1.0.2</version.arquillian.spacelift>
     <version.findbugs.annotations>3.0.1</version.findbugs.annotations>
 
+    <version.maven.plugin.shade>3.0.0</version.maven.plugin.shade>
     <version.maven.plugin.deploy>2.8.2</version.maven.plugin.deploy>
 
     <!-- default settings for surefire parallel execution. Overwritten for travis due to JVM crashes -->

--- a/strategies/affected/pom.xml
+++ b/strategies/affected/pom.xml
@@ -14,6 +14,7 @@
     <dependency>
       <groupId>org.arquillian.smart.testing</groupId>
       <artifactId>core</artifactId>
+      <classifier>shaded</classifier>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -79,6 +80,28 @@
               </excludes>
             </filter>
           </filters>
+          <relocations>
+            <relocation>
+              <pattern>org.jgrapht.</pattern>
+              <shadedPattern>shaded.org.jgrapht.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.eclipse.</pattern>
+              <shadedPattern>shaded.org.eclipse.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.</pattern>
+              <shadedPattern>shaded.org.apache.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>javassist.</pattern>
+              <shadedPattern>shaded.javassist.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>io.github.lukehutch.fastclasspathscanner.</pattern>
+              <shadedPattern>shaded.io.github.lukehutch.fastclasspathscanner.</shadedPattern>
+            </relocation>
+          </relocations>
         </configuration>
         <executions>
           <execution>

--- a/strategies/affected/pom.xml
+++ b/strategies/affected/pom.xml
@@ -59,4 +59,36 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${version.maven.plugin.shade}</version>
+        <configuration>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
+          <shadedArtifactAttached>true</shadedArtifactAttached>
+          <shadedClassifierName>shaded</shadedClassifierName>
+          <minimizeJar>true</minimizeJar>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/*.SF</exclude>
+                <exclude>META-INF/*.DSA</exclude>
+                <exclude>META-INF/*.RSA</exclude>
+              </excludes>
+            </filter>
+          </filters>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/strategies/changed/pom.xml
+++ b/strategies/changed/pom.xml
@@ -40,4 +40,36 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${version.maven.plugin.shade}</version>
+        <configuration>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
+          <shadedArtifactAttached>true</shadedArtifactAttached>
+          <shadedClassifierName>shaded</shadedClassifierName>
+          <minimizeJar>true</minimizeJar>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/*.SF</exclude>
+                <exclude>META-INF/*.DSA</exclude>
+                <exclude>META-INF/*.RSA</exclude>
+              </excludes>
+            </filter>
+          </filters>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/strategies/changed/pom.xml
+++ b/strategies/changed/pom.xml
@@ -14,6 +14,7 @@
     <dependency>
       <groupId>org.arquillian.smart.testing</groupId>
       <artifactId>core</artifactId>
+      <classifier>shaded</classifier>
       <version>${project.version}</version>
     </dependency>
 
@@ -60,6 +61,16 @@
               </excludes>
             </filter>
           </filters>
+          <relocations>
+            <relocation>
+              <pattern>org.eclipse.</pattern>
+              <shadedPattern>shaded.org.eclipse.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.</pattern>
+              <shadedPattern>shaded.org.apache.</shadedPattern>
+            </relocation>
+          </relocations>
         </configuration>
         <executions>
           <execution>

--- a/strategies/failed/pom.xml
+++ b/strategies/failed/pom.xml
@@ -14,6 +14,7 @@
     <dependency>
       <groupId>org.arquillian.smart.testing</groupId>
       <artifactId>core</artifactId>
+      <classifier>shaded</classifier>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -58,6 +59,16 @@
               </excludes>
             </filter>
           </filters>
+          <relocations>
+            <relocation>
+              <pattern>org.eclipse.</pattern>
+              <shadedPattern>shaded.org.eclipse.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.</pattern>
+              <shadedPattern>shaded.org.apache.</shadedPattern>
+            </relocation>
+          </relocations>
         </configuration>
         <executions>
           <execution>

--- a/strategies/failed/pom.xml
+++ b/strategies/failed/pom.xml
@@ -38,4 +38,36 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${version.maven.plugin.shade}</version>
+        <configuration>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
+          <shadedArtifactAttached>true</shadedArtifactAttached>
+          <shadedClassifierName>shaded</shadedClassifierName>
+          <minimizeJar>true</minimizeJar>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/*.SF</exclude>
+                <exclude>META-INF/*.DSA</exclude>
+                <exclude>META-INF/*.RSA</exclude>
+              </excludes>
+            </filter>
+          </filters>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
#### Short description of what this resolves:

All strategies are distributed as shaded jars and when they are added to the model, all their transitive dependencies are excluded.

#### Changes proposed in this pull request:

- added shaded plugin configuration to all strategies
- added complete exclusion of transitive deps for all default (shaded) strategy dependencies
- introduced whole coordinate format: `groupId:artifactId:packaging:classifier:version:scope`

- [x]  not added - relocations: https://github.com/arquillian/smart-testing/issues/279#issuecomment-350393260

Fixes #279 
