### PR TITLE
feat(#287): the set of tests-to-run is provided to TestExecutionPlanner implementations

### DIFF
--- a/core/src/main/java/org/arquillian/smart/testing/impl/TestSelector.java
+++ b/core/src/main/java/org/arquillian/smart/testing/impl/TestSelector.java
@@ -1,0 +1,116 @@
+package org.arquillian.smart.testing.impl;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.arquillian.smart.testing.TestSelection;
+import org.arquillian.smart.testing.configuration.Configuration;
+import org.arquillian.smart.testing.logger.Log;
+import org.arquillian.smart.testing.logger.Logger;
+import org.arquillian.smart.testing.report.SmartTestingReportGenerator;
+import org.arquillian.smart.testing.spi.TestExecutionPlanner;
+
+abstract class TestSelector<CLASS_INFO_TYPE> {
+
+    private static final Logger logger = Log.getLogger();
+    private final TestExecutionPlannerLoader testExecutionPlannerLoader;
+    private final File projectDir;
+    private final Configuration configuration;
+
+    TestSelector(Configuration configuration, TestExecutionPlannerLoader testExecutionPlannerLoader, File projectDir) {
+        this.configuration = configuration;
+        this.testExecutionPlannerLoader = testExecutionPlannerLoader;
+        this.projectDir = projectDir;
+    }
+
+    protected abstract Collection<TestSelection> selectTestUsingPlanner(TestExecutionPlanner plannerForStrategy);
+
+    protected abstract Iterable<CLASS_INFO_TYPE> getTestsToRun();
+
+    protected abstract TestSelection createTestSelection(CLASS_INFO_TYPE testClass);
+
+    Set<TestSelection> orderTests() {
+        final Set<TestSelection> orderedTests = new LinkedHashSet<>(selectTests());
+        getTestsToRun()
+            .iterator()
+            .forEachRemaining(testClass -> orderedTests.add(createTestSelection(testClass)));
+        return orderedTests;
+    }
+
+    Set<TestSelection> selectTests() {
+        List<String> strategies = retrieveStrategies();
+        if (strategies.isEmpty()) {
+            logger.warn(
+                "Smart Testing Extension is installed but no strategies are provided. It won't influence the way how your tests are executed. "
+                    + "For details on how to configure it head over to http://bit.ly/st-config");
+            return Collections.emptySet();
+        }
+
+        final List<TestSelection> selectedTests = new ArrayList<>();
+        for (final String strategy : strategies) {
+            final TestExecutionPlanner plannerForStrategy = testExecutionPlannerLoader.getPlannerForStrategy(strategy);
+            selectedTests.addAll(selectTestUsingPlanner(plannerForStrategy));
+        }
+
+        logger.info("Applied strategies: %s", strategies);
+        logger.info("Applied usage: [%s]", configuration.getMode().getName());
+        final Collection<TestSelection> testSelections = filterMergeAndOrderTestSelection(selectedTests, strategies);
+
+        if (testSelections.isEmpty()) {
+            logger.debug("Applied test selections: %s", "No tests selected as per the strategy chosen.");
+        } else {
+            logger.debug("Applied test selections: %s", testSelections.toString());
+        }
+
+        if (isReportEnabled() || logger.isDebug()) {
+            new SmartTestingReportGenerator(testSelections, configuration, projectDir).generateReport();
+        }
+
+        return new LinkedHashSet<>(testSelections);
+    }
+
+    private List<String> retrieveStrategies() {
+        if (configuration.getStrategies().length == 0){
+            return Collections.emptyList();
+        }
+        List<String> errorMessages = new ArrayList<>();
+        configuration.autocorrectStrategies(testExecutionPlannerLoader.getAvailableStrategyNames(), errorMessages);
+        errorMessages.forEach(msg -> logger.error(msg));
+
+        return Arrays.asList(configuration.getStrategies());
+    }
+
+    Collection<TestSelection> filterMergeAndOrderTestSelection(Collection<TestSelection> selectedTests,
+        List<String> strategies) {
+
+        final Collection<TestSelection> testSelections = selectedTests
+            .stream()
+            .filter(testExecutionPlannerLoader.getVerifier()::isTest)
+            .collect(Collectors.toMap(TestSelection::getClassName, Function.identity(), TestSelection::merge,
+                LinkedHashMap::new))
+            .values();
+
+        if (strategies.size() > 1) {
+            final StrategiesComparator byStrategies = new StrategiesComparator(strategies);
+
+            return testSelections.stream()
+                .sorted(Comparator.comparing(TestSelection::getTypes, byStrategies))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        }
+
+        return testSelections;
+    }
+
+    private boolean isReportEnabled() {
+        return configuration.getReport().isEnable();
+    }
+}

--- a/core/src/main/java/org/arquillian/smart/testing/impl/TestSelectorFromClasses.java
+++ b/core/src/main/java/org/arquillian/smart/testing/impl/TestSelectorFromClasses.java
@@ -1,0 +1,33 @@
+package org.arquillian.smart.testing.impl;
+
+import java.io.File;
+import java.util.Collection;
+import org.arquillian.smart.testing.TestSelection;
+import org.arquillian.smart.testing.configuration.Configuration;
+import org.arquillian.smart.testing.spi.TestExecutionPlanner;
+
+class TestSelectorFromClasses extends TestSelector<Class<?>> {
+
+    private final Iterable<Class<?>> testsToRun;
+
+    TestSelectorFromClasses(TestExecutionPlannerLoader testExecutionPlannerLoader, File projectDir,
+        Configuration configuration, Iterable<Class<?>> testsToRun) {
+        super(configuration, testExecutionPlannerLoader, projectDir);
+        this.testsToRun = testsToRun;
+    }
+
+    @Override
+    public Collection<TestSelection> selectTestUsingPlanner(TestExecutionPlanner plannerForStrategy) {
+        return plannerForStrategy.selectTestsFromClasses(testsToRun);
+    }
+
+    @Override
+    protected Iterable<Class<?>> getTestsToRun() {
+        return testsToRun;
+    }
+
+    @Override
+    protected TestSelection createTestSelection(Class<?> testClass) {
+        return new TestSelection(testClass.getName());
+    }
+}

--- a/core/src/main/java/org/arquillian/smart/testing/impl/TestSelectorFromNames.java
+++ b/core/src/main/java/org/arquillian/smart/testing/impl/TestSelectorFromNames.java
@@ -1,0 +1,33 @@
+package org.arquillian.smart.testing.impl;
+
+import java.io.File;
+import java.util.Collection;
+import org.arquillian.smart.testing.TestSelection;
+import org.arquillian.smart.testing.configuration.Configuration;
+import org.arquillian.smart.testing.spi.TestExecutionPlanner;
+
+class TestSelectorFromNames extends TestSelector<String> {
+
+    private final Iterable<String> testsToRun;
+
+    TestSelectorFromNames(TestExecutionPlannerLoader testExecutionPlannerLoader, File projectDir,
+        Configuration configuration, Iterable<String> testsToRun) {
+        super(configuration, testExecutionPlannerLoader, projectDir);
+        this.testsToRun = testsToRun;
+    }
+
+    @Override
+    public Collection<TestSelection> selectTestUsingPlanner(TestExecutionPlanner plannerForStrategy) {
+        return plannerForStrategy.selectTestsFromNames(testsToRun);
+    }
+
+    @Override
+    protected Iterable<String> getTestsToRun() {
+        return testsToRun;
+    }
+
+    @Override
+    protected TestSelection createTestSelection(String testClass) {
+        return new TestSelection(testClass);
+    }
+}

--- a/core/src/main/java/org/arquillian/smart/testing/impl/TestStrategyApplierImpl.java
+++ b/core/src/main/java/org/arquillian/smart/testing/impl/TestStrategyApplierImpl.java
@@ -1,29 +1,13 @@
 package org.arquillian.smart.testing.impl;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import org.arquillian.smart.testing.TestSelection;
 import org.arquillian.smart.testing.api.TestStrategyApplier;
 import org.arquillian.smart.testing.configuration.Configuration;
-import org.arquillian.smart.testing.logger.Log;
-import org.arquillian.smart.testing.logger.Logger;
-import org.arquillian.smart.testing.report.SmartTestingReportGenerator;
-import org.arquillian.smart.testing.spi.TestExecutionPlanner;
 
 class TestStrategyApplierImpl implements TestStrategyApplier {
 
-    private static final Logger logger = Log.getLogger();
     private final TestExecutionPlannerLoader testExecutionPlannerLoader;
     private final File projectDir;
     private final Configuration configuration;
@@ -36,103 +20,28 @@ class TestStrategyApplierImpl implements TestStrategyApplier {
     }
 
     public Set<TestSelection> applyOnNames(Iterable<String> testsToRun) {
-        return apply(testsToRun, className -> className, this::selectTestsFromNames);
+        TestSelectorFromNames testSelector =
+            new TestSelectorFromNames(testExecutionPlannerLoader, projectDir, configuration, testsToRun);
+        return apply(testSelector);
     }
 
-    private Collection<TestSelection> selectTestsFromNames(TestExecutionPlanner testExecutionPlanner,
-        Iterable<String> testsToRun) {
-        return testExecutionPlanner.selectTestsFromNames(testsToRun);
-    }
 
     public Set<TestSelection> applyOnClasses(Iterable<Class<?>> testsToRun) {
-        return apply(testsToRun, Class::getName, this::selectTestsFromClasses);
+        TestSelectorFromClasses testSelector =
+            new TestSelectorFromClasses(testExecutionPlannerLoader, projectDir, configuration, testsToRun);
+        return apply(testSelector);
     }
 
-    private Collection<TestSelection> selectTestsFromClasses(TestExecutionPlanner testExecutionPlanner,
-        Iterable<Class<?>> testsToRun) {
-        return testExecutionPlanner.selectTestsFromClasses(testsToRun);
-    }
+    private Set<TestSelection> apply(TestSelector testSelector) {
 
-    private <TESTCLASS> Set<TestSelection> apply(Iterable<TESTCLASS> testsToRun,
-        Function<TESTCLASS, String> mapperToName,
-        BiFunction<TestExecutionPlanner, Iterable<TESTCLASS>, Collection<TestSelection>> selectionFunction) {
-
-        final Set<TestSelection> selectedTests = selectTests(configuration, testsToRun, selectionFunction);
         if (testSelectionWithAnyStrategyIsChosen(configuration)) {
-            return selectedTests;
+            return testSelector.selectTests();
         } else {
-            final Set<TestSelection> orderedTests = new LinkedHashSet<>(selectedTests);
-            testsToRun
-                .iterator()
-                .forEachRemaining(testclass -> orderedTests.add(new TestSelection(mapperToName.apply(testclass))));
-            return orderedTests;
+            return testSelector.orderTests();
         }
-    }
-
-    private <TESTCLASS> Set<TestSelection> selectTests(Configuration configuration, Iterable<TESTCLASS> testsToRun,
-        BiFunction<TestExecutionPlanner, Iterable<TESTCLASS>, Collection<TestSelection>> selectionFunction) {
-        if (configuration.getStrategies().length == 0) {
-            logger.warn(
-                "Smart Testing Extension is installed but no strategies are provided. It won't influence the way how your tests are executed. "
-                    + "For details on how to configure it head over to http://bit.ly/st-config");
-            return Collections.emptySet();
-        }
-
-        List<String> errorMessages = new ArrayList<>();
-        configuration.autocorrectStrategies(testExecutionPlannerLoader.getAvailableStrategyNames(), errorMessages);
-        errorMessages.forEach(msg -> logger.error(msg));
-
-        List<String> strategies = Arrays.asList(configuration.getStrategies());
-        final List<TestSelection> selectedTests = new ArrayList<>();
-        for (final String strategy : strategies) {
-            final TestExecutionPlanner plannerForStrategy = testExecutionPlannerLoader.getPlannerForStrategy(strategy);
-            selectedTests.addAll(selectionFunction.apply(plannerForStrategy, testsToRun));
-        }
-        logger.info("Applied strategies: %s", strategies);
-        logger.info("Applied usage: [%s]", configuration.getMode().getName());
-        final Collection<TestSelection> testSelections = filterMergeAndOrderTestSelection(selectedTests, strategies);
-
-        if (testSelections.isEmpty()) {
-            logger.debug("Applied test selections: %s", "No tests selected as per the strategy chosen.");
-        } else {
-            logger.debug("Applied test selections: %s", testSelections.toString());
-        }
-
-        if (isReportEnabled() || logger.isDebug()) {
-            final SmartTestingReportGenerator
-                reportGenerator = new SmartTestingReportGenerator(testSelections, configuration, projectDir);
-            reportGenerator.generateReport();
-        }
-
-        return new LinkedHashSet<>(testSelections);
     }
 
     private boolean testSelectionWithAnyStrategyIsChosen(Configuration configuration) {
         return configuration.isSelectingMode() && configuration.getStrategies().length > 0;
-    }
-
-    Collection<TestSelection> filterMergeAndOrderTestSelection(Collection<TestSelection> selectedTests,
-        List<String> strategies) {
-
-        final Collection<TestSelection> testSelections = selectedTests
-            .stream()
-            .filter(testExecutionPlannerLoader.getVerifier()::isTest)
-            .collect(Collectors.toMap(TestSelection::getClassName, Function.identity(), TestSelection::merge,
-                LinkedHashMap::new))
-            .values();
-
-        if (strategies.size() > 1) {
-            final StrategiesComparator byStrategies = new StrategiesComparator(strategies);
-
-            return testSelections.stream()
-                .sorted(Comparator.comparing(TestSelection::getTypes, byStrategies))
-                .collect(Collectors.toCollection(LinkedHashSet::new));
-        }
-
-        return testSelections;
-    }
-
-    private boolean isReportEnabled() {
-        return configuration.getReport().isEnable();
     }
 }

--- a/core/src/main/java/org/arquillian/smart/testing/spi/TestExecutionPlanner.java
+++ b/core/src/main/java/org/arquillian/smart/testing/spi/TestExecutionPlanner.java
@@ -5,7 +5,9 @@ import org.arquillian.smart.testing.TestSelection;
 
 public interface TestExecutionPlanner {
 
-    Collection<TestSelection> getTests();
+    Collection<TestSelection> selectTestsFromNames(Iterable<String> testsToRun);
+
+    Collection<TestSelection> selectTestsFromClasses(Iterable<Class<?>> testsToRun);
 
     String getName();
 

--- a/core/src/main/java/org/arquillian/smart/testing/spi/TestExecutionPlanner.java
+++ b/core/src/main/java/org/arquillian/smart/testing/spi/TestExecutionPlanner.java
@@ -5,9 +5,11 @@ import org.arquillian.smart.testing.TestSelection;
 
 public interface TestExecutionPlanner {
 
+    //tag::documentation[]
     Collection<TestSelection> selectTestsFromNames(Iterable<String> testsToRun);
 
     Collection<TestSelection> selectTestsFromClasses(Iterable<Class<?>> testsToRun);
+    //end::documentation[]
 
     String getName();
 

--- a/core/src/test/java/org/arquillian/smart/testing/impl/TestExecutionPlannerLoaderTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/impl/TestExecutionPlannerLoaderTest.java
@@ -36,7 +36,7 @@ public class TestExecutionPlannerLoaderTest {
         final TestExecutionPlanner testExecutionPlanner = testExecutionPlannerLoader.getPlannerForStrategy("dummy");
 
         // then
-        assertThat(testExecutionPlanner.getTests()).isEmpty();
+        assertThat(testExecutionPlanner.selectTestsFromClasses(Collections.emptyList())).isEmpty();
     }
 
     @Test
@@ -56,7 +56,7 @@ public class TestExecutionPlannerLoaderTest {
         final TestExecutionPlanner testExecutionPlanner = testExecutionPlannerLoader.getPlannerForStrategy(configuration.getStrategies()[0]);
 
         // then
-        assertThat(testExecutionPlanner.getTests()).isEmpty();
+        assertThat(testExecutionPlanner.selectTestsFromClasses(Collections.emptyList())).isEmpty();
     }
 
     @Test
@@ -107,8 +107,14 @@ public class TestExecutionPlannerLoaderTest {
         @Override
         public TestExecutionPlanner create(File projectDir, TestVerifier verifier, Configuration configuration) {
             return new TestExecutionPlanner() {
+
                 @Override
-                public Collection<TestSelection> getTests() {
+                public Collection<TestSelection> selectTestsFromNames(Iterable<String> testsToRun) {
+                    return Collections.emptyList();
+                }
+
+                @Override
+                public Collection<TestSelection> selectTestsFromClasses(Iterable<Class<?>> testsToRun) {
                     return Collections.emptyList();
                 }
 

--- a/core/src/test/java/org/arquillian/smart/testing/impl/TestStrategyApplierUsingPropertyTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/impl/TestStrategyApplierUsingPropertyTest.java
@@ -17,6 +17,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -129,7 +130,7 @@ public class TestStrategyApplierUsingPropertyTest {
 
     private TestExecutionPlannerLoader prepareLoader(final Set<Class<?>> testsToRun, Set<TestSelection> strategyTests) {
         TestExecutionPlanner testExecutionPlanner = mock(TestExecutionPlanner.class);
-        when(testExecutionPlanner.getTests()).thenReturn(strategyTests);
+        when(testExecutionPlanner.selectTestsFromClasses(Mockito.anyCollection())).thenReturn(strategyTests);
 
         TestExecutionPlannerLoader testExecutionPlannerLoader = mock(TestExecutionPlannerLoader.class);
         when(testExecutionPlannerLoader.getPlannerForStrategy("static")).thenReturn(testExecutionPlanner);

--- a/docs/registering-strategies.adoc
+++ b/docs/registering-strategies.adoc
@@ -38,8 +38,7 @@ Apart from the method `getName()` that returns a name of the strategy there are 
 
 [source, java]
 ----
-selectTestsFromNames(Iterable<String> testsToRun)
-selectTestsFromClasses(Iterable<Class<?>> testsToRun)
+include::../core/src/main/java/org/arquillian/smart/testing/spi/TestExecutionPlanner.java[tag=documentation]
 ----
 
 These methods return a collection of the tests that must be executed.

--- a/docs/registering-strategies.adoc
+++ b/docs/registering-strategies.adoc
@@ -33,9 +33,17 @@ include::../strategies/failed/src/main/resources/META-INF/services/org.arquillia
 
 === Implementing TestExecutionPlanner
 
-`TestExecutionPlanner` is the strategy implementation of the strategy.
-The important method there is `getTests()` which returns a collection of the tests that must be executed.
-You also need to set there the strategy name.
+`TestExecutionPlanner` is the implementation of the strategy.
+Apart from the method `getName()` that returns a name of the strategy there are two important methods:
+
+[source, java]
+----
+selectTestsFromNames(Iterable<String> testsToRun)
+selectTestsFromClasses(Iterable<Class<?>> testsToRun)
+----
+
+These methods return a collection of the tests that must be executed.
+There is only one call of one of these two methods - it won't happen that both methods are called at once. The reason for the existence of these two methods is that in some environments there aren't available `Classes` for the tests, but just the names.
 
 For example, failed strategy is implemented as:
 
@@ -44,8 +52,9 @@ For example, failed strategy is implemented as:
 ----
 include::../strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/FailedTestsDetector.java[tag=documentation]
 ----
-<1> Method that returns list of tests to execute
-<2> `TestSelection` requires fully qualified test class name and the strategy where is calculated
+<1> Method that returns list of tests to execute based on the provided set of fully qualified class names of tests that were previously selected to be executed.
+<2> Method that returns list of tests to execute based on the provided set of tests classes that were previously selected to be executed.
+<3> `TestSelection` requires fully qualified test class name and the strategy where is calculated
 
 ==== ChangeStorage, ChangeResolver and TestResultParser
 

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/AffectedTestsDetector.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/AffectedTestsDetector.java
@@ -54,11 +54,20 @@ public class AffectedTestsDetector implements TestExecutionPlanner {
     }
 
     @Override
+    public Collection<TestSelection> selectTestsFromNames(Iterable<String> testsToRun) {
+        return getTests();
+    }
+
+    @Override
+    public Collection<TestSelection> selectTestsFromClasses(Iterable<Class<?>> testsToRun) {
+        return getTests();
+    }
+
+    @Override
     public String getName() {
         return AFFECTED;
     }
 
-    @Override
     public Collection<TestSelection> getTests() {
         ClassDependenciesGraph classDependenciesGraph = configureTestClassDetector();
 

--- a/strategies/changed/src/main/java/org/arquillian/smart/testing/vcs/git/ChangedTestsDetector.java
+++ b/strategies/changed/src/main/java/org/arquillian/smart/testing/vcs/git/ChangedTestsDetector.java
@@ -53,6 +53,15 @@ public class ChangedTestsDetector implements TestExecutionPlanner {
     }
 
     @Override
+    public Collection<TestSelection> selectTestsFromNames(Iterable<String> testsToRun) {
+        return getTests();
+    }
+
+    @Override
+    public Collection<TestSelection> selectTestsFromClasses(Iterable<Class<?>> testsToRun) {
+        return getTests();
+    }
+
     public Collection<TestSelection> getTests() {
         //tag::read_changes[]
         final Collection<Change> files = changeStorage.read(projectDir) // <1>

--- a/strategies/changed/src/main/java/org/arquillian/smart/testing/vcs/git/NewTestsDetector.java
+++ b/strategies/changed/src/main/java/org/arquillian/smart/testing/vcs/git/NewTestsDetector.java
@@ -47,11 +47,20 @@ public class NewTestsDetector implements TestExecutionPlanner {
     }
 
     @Override
+    public Collection<TestSelection> selectTestsFromNames(Iterable<String> testsToRun) {
+        return getTests();
+    }
+
+    @Override
+    public Collection<TestSelection> selectTestsFromClasses(Iterable<Class<?>> testsToRun) {
+        return getTests();
+    }
+
+    @Override
     public String getName() {
         return NEW;
     }
 
-    @Override
     public final Collection<TestSelection> getTests() {
         final Collection<Change> changes = changeStorage.read(projectDir)
             .orElseGet(() -> {

--- a/strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/FailedTestsDetector.java
+++ b/strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/FailedTestsDetector.java
@@ -19,11 +19,20 @@ public class FailedTestsDetector implements TestExecutionPlanner {
     }
 
     @Override
-    public Collection<TestSelection> getTests() { // <1>
+    public Collection<TestSelection> selectTestsFromNames(Iterable<String> testsToRun) { // <1>
+        return getTests();
+    }
+
+    @Override
+    public Collection<TestSelection> selectTestsFromClasses(Iterable<Class<?>> testsToRun) { // <2>
+        return getTests();
+    }
+
+    public Collection<TestSelection> getTests() {
         TestReportLoader testReportLoader = new InProjectTestReportLoader(new JavaSPILoader(), projectDir);
         return testReportLoader.loadTestResults()
             .stream()
-            .map(result -> new TestSelection(result, getName())) // <2>
+            .map(result -> new TestSelection(result, getName())) // <3>
             .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 


### PR DESCRIPTION
#### Short description of what this resolves:

The implementations of the strategies didn't have the information about the set of tests that were selected to be executed. In this PR I'm introducing the changes in `TestExecutionPlanner` API that will provide this kind of information.

#### Changes proposed in this pull request:

- in `TestExecutionPlanner`, instead of one method `getTests()` there are two methods:
```java
Collection<TestSelection> selectTestsFromNames(Iterable<String> testsToRun);
Collection<TestSelection> selectTestsFromClasses(Iterable<Class<?>> testsToRun);
```

Fixes #287 
