### PR TITLE
feat(#283): added categorized strategy

### DIFF
--- a/docs/configfile.adoc
+++ b/docs/configfile.adoc
@@ -197,3 +197,21 @@ a| Sets list of packages to be excluded while applying transitivity.
 a| inclusions
 a| Sets list of packages to be included while applying transitivity.
 |===
+
+==== Categorized Configuration Options
+[cols="2,6", options="header"]
+|===
+|Field | Description
+a| categories
+a| List of categories the strategy should be looking for (can be either whole fully qualified names or only simple class names). If nothing is set, but the strategy is used, then all classes containing the annotation `@Category` are selected.
+
+a| caseSensitive
+a| Sets case sensitivity of the category names. (default is false)
+
+a| matchAll
+a| Sets that the classes should contain all categories specified in the list of the categories. (default is false)
+
+a| reversed
+a| Sets that the selection should be reversed - all classes that don't match the categories will be selected. (default is false)
+|===
+

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -48,7 +48,7 @@ Until now, you've read that smart testing is changing test execution plan runnin
 But how do we know which tests are important and which ones not?
 
 There are several strategies that you can choose from which determine what are the *important* tests.
-Currently we have following strategies in place: `new`, `changed`, `affected` and `failed`.
+Currently we have following strategies in place: `new`, `changed`, `affected`, `failed` and `categorized`.
 
 To set them you need to set Java system property `const:core/src/main/java/org/arquillian/smart/testing/configuration/Configuration.java[name="SMART_TESTING"]` to one or more strategies in comma-separated value form.
 
@@ -179,3 +179,13 @@ If none of the attributes are set, then all production classes with same package
 This strategy uses the _JUnit_ XML https://github.com/apache/maven-surefire/blob/master/maven-surefire-plugin/src/site/resources/xsd/surefire-test-report.xsd[report] for reading past executions.
 All reports from previous local build are automatically copied by the maven extension to a temp directory `${project.directory}/const:core/src/main/java/org/arquillian/smart/testing/hub/storage/local/DuringExecutionLocalStorage.java[name="SMART_TESTING_WORKING_DIRECTORY_NAME"]/const:core/src/main/java/org/arquillian/smart/testing/hub/storage/local/DuringExecutionLocalStorage.java[name="TEMPORARY_SUBDIRECTORY"]/const:core/src/main/java/org/arquillian/smart/testing/hub/storage/local/TemporaryInternalFiles.java[name="TEMP_REPORT_DIR"]` and when the build is finished the directory is removed.
 
+
+==== Categorized
+
+`Categorized` strategy selects tests based in the JUnit 4 annotation `@Category` and the classes specified in it. With this strategy, you can easily set which classes you want to run without any need of changing your `pom.xml` file with complicated profiles.
+
+You can say which categories should be executed by saying either the fully qualified names of the classes or just simple class names (case sensitivity can be set via configuration). For more information about the parameters see <<_categorized_configuration_options, Configuration Options>>.
+
+****
+NOTE: It works on the level of classes, so it doesn't reflect method annotations.
+****

--- a/docs/refcard.adoc
+++ b/docs/refcard.adoc
@@ -24,7 +24,7 @@ a|`ordering`, `selecting`
 a|`const:core/src/main/java/org/arquillian/smart/testing/configuration/Configuration.java[name="SMART_TESTING"]`
 |Set strategies in CSV
 | -
-a|`new`, `changed`, `affected`, `failed`
+a|`new`, `changed`, `affected`, `failed`, `categorized`
 
 a|`const:core/src/main/java/org/arquillian/smart/testing/configuration/Configuration.java[name="SMART_TESTING_DISABLE"]`
 |Disable Smart Testing
@@ -87,6 +87,26 @@ a| `const:core/src/main/java/org/arquillian/smart/testing/configuration/Configur
 |Register custom strategies implementations
 a|
 a|Value is the Maven coordinates of the custom strategy
+
+a| `const:strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategorizedConfiguration.java[name="SMART_TESTING_CATEGORIZED_CATEGORIES"]`
+| List of categories the strategy should be looking for (can be either whole fully qualified names or only simple class names)
+a| -
+a|`categorized`
+
+a| `const:strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategorizedConfiguration.java[name="SMART_TESTING_CATEGORIZED_CASE_SENSITIVE"]`
+| Sets case sensitivity of the category names.
+a| `false`
+a|`categorized`
+
+a| `const:strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategorizedConfiguration.java[name="SMART_TESTING_CATEGORIZED_MATCH_ALL"]`
+| Sets that the classes should contain all categories specified in the list of the categories.
+a| `false`
+a|`categorized`
+
+a| `const:strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategorizedConfiguration.java[name="SMART_TESTING_CATEGORIZED_REVERSED"]`
+| Sets that the selection should be reversed - all classes that don't match the categories will be selected.
+a| `false`
+a|`categorized`
 |===
 
 === Getting insights of the execution

--- a/docs/registering-strategies.adoc
+++ b/docs/registering-strategies.adoc
@@ -1,6 +1,6 @@
 == Registering Custom Strategies
 
-By default *Smart Testing* comes with a set of strategies such as `new`, `changed`, `affected` or `failed`, but you can implement your own strategies and registering them.
+By default *Smart Testing* comes with a set of strategies such as `new`, `changed`, `affected`, `failed` or `categorized`, but you can implement your own strategies and registering them.
 
 To do it you just need to follow next four steps:
 

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/configuration/Strategy.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/configuration/Strategy.java
@@ -5,6 +5,7 @@ public class Strategy {
     public static final Strategy NEW = new Strategy("new");
     public static final Strategy CHANGED = new Strategy("changed");
     public static final Strategy FAILED = new Strategy("failed");
+    public static final Strategy CATEGORIZED = new Strategy("categorized");
 
     private final String name;
 

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/categorized/CategorizedTestSelectionFunctionalTests.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/categorized/CategorizedTestSelectionFunctionalTests.java
@@ -1,0 +1,52 @@
+package org.arquillian.smart.testing.ftest.categorized;
+
+import java.util.Collection;
+import org.arquillian.smart.testing.ftest.testbed.project.Project;
+import org.arquillian.smart.testing.ftest.testbed.project.TestResults;
+import org.arquillian.smart.testing.ftest.testbed.testresults.TestResult;
+import org.arquillian.smart.testing.rules.TestBed;
+import org.arquillian.smart.testing.rules.git.GitClone;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.arquillian.smart.testing.ftest.testbed.TestRepository.testRepository;
+import static org.arquillian.smart.testing.ftest.testbed.configuration.Mode.SELECTING;
+import static org.arquillian.smart.testing.ftest.testbed.configuration.Strategy.CATEGORIZED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CategorizedTestSelectionFunctionalTests {
+
+    @ClassRule
+    public static final GitClone GIT_CLONE = new GitClone(testRepository());
+
+    @Rule
+    public final TestBed testBed = new TestBed(GIT_CLONE);
+
+    @Test
+    public void should_run_test_with_categories_loader_and_service() throws Exception {
+        // given
+        final Project project = testBed.getProject();
+        project
+            .configureSmartTesting()
+            .executionOrder(CATEGORIZED)
+            .inMode(SELECTING)
+            .enable();
+
+        final Collection<TestResult> expectedTestResults =
+            project.applyAsCommits("Added categories to core/impl-base");
+
+        // when
+        final TestResults actualTestResults =
+            project.build("core/impl-base")
+                .options()
+                .withSystemProperties("smart.testing.categorized.categories", "LoaderCategory,serviceCategory",
+                    "smart.testing.categorized.match.all", "true")
+                .configure()
+                .run();
+
+        // then
+        assertThat(actualTestResults.accumulatedPerTestClass()).containsAll(expectedTestResults)
+            .hasSameSizeAs(expectedTestResults);
+    }
+}

--- a/mvn-extension/src/main/resources/strategies.properties
+++ b/mvn-extension/src/main/resources/strategies.properties
@@ -2,3 +2,5 @@ smart.testing.strategy.changed=org.arquillian.smart.testing:strategy-changed::sh
 smart.testing.strategy.new=org.arquillian.smart.testing:strategy-changed::shaded::runtime
 smart.testing.strategy.affected=org.arquillian.smart.testing:strategy-affected::shaded::runtime
 smart.testing.strategy.failed=org.arquillian.smart.testing:strategy-failed::shaded::runtime
+smart.testing.strategy.categorized=org.arquillian.smart.testing:strategy-categorized::shaded::runtime
+

--- a/mvn-extension/src/test/java/org/arquillian/smart/testing/mvn/ext/dependencies/StrategyDependencyResolverTest.java
+++ b/mvn-extension/src/test/java/org/arquillian/smart/testing/mvn/ext/dependencies/StrategyDependencyResolverTest.java
@@ -25,13 +25,14 @@ public class StrategyDependencyResolverTest {
         Map<String, Dependency> dependencies = strategyDependencyResolver.resolveDependencies();
 
         // then
-        assertThat(dependencies.values()).hasSize(4)
+        assertThat(dependencies.values()).hasSize(5)
             .extracting(
                 dependency -> dependency.getGroupId() + ":" + dependency.getArtifactId() + ":" + dependency.getVersion())
             .contains("org.arquillian.smart.testing:strategy-changed:" + ExtensionVersion.version().toString(),
                       "org.arquillian.smart.testing:strategy-failed:" + ExtensionVersion.version().toString(),
                       "org.arquillian.smart.testing:strategy-changed:" + ExtensionVersion.version().toString(),
-                      "org.arquillian.smart.testing:strategy-affected:" + ExtensionVersion.version().toString());
+                      "org.arquillian.smart.testing:strategy-affected:" + ExtensionVersion.version().toString(),
+                      "org.arquillian.smart.testing:strategy-categorized:" + ExtensionVersion.version().toString());
     }
 
     @Test
@@ -64,12 +65,13 @@ public class StrategyDependencyResolverTest {
         Map<String, Dependency> dependencies = strategyDependencyResolver.resolveDependencies();
 
         // then
-        assertThat(dependencies.values()).hasSize(5)
+        assertThat(dependencies.values()).hasSize(6)
             .extracting(
                 dependency -> dependency.getGroupId() + ":" + dependency.getArtifactId() + ":" + dependency.getVersion())
             .contains("org.arquillian.smart.testing:strategy-changed:" + ExtensionVersion.version().toString(),
                 "org.arquillian.smart.testing:strategy-failed:" + ExtensionVersion.version().toString(),
                 "org.arquillian.smart.testing:strategy-affected:" + ExtensionVersion.version().toString(),
+                "org.arquillian.smart.testing:strategy-categorized:" + ExtensionVersion.version().toString(),
                 "org.arquillian.smart.testing:strategy-cool:1.0.0");
     }
 
@@ -85,12 +87,13 @@ public class StrategyDependencyResolverTest {
         Map<String, Dependency> dependencies = strategyDependencyResolver.resolveDependencies();
 
         // then
-        assertThat(dependencies.values()).hasSize(5)
+        assertThat(dependencies.values()).hasSize(6)
             .extracting(
                 dependency -> dependency.getGroupId() + ":" + dependency.getArtifactId() + ":" + dependency.getVersion())
             .contains("org.arquillian.smart.testing:strategy-changed:" + ExtensionVersion.version().toString(),
                 "org.arquillian.smart.testing:strategy-failed:" + ExtensionVersion.version().toString(),
                 "org.arquillian.smart.testing:strategy-affected:" + ExtensionVersion.version().toString(),
+                "org.arquillian.smart.testing:strategy-categorized:" + ExtensionVersion.version().toString(),
                 "org.arquillian.smart.testing:strategy-cool:1.0.1");
     }
 
@@ -105,6 +108,6 @@ public class StrategyDependencyResolverTest {
 
         // then
         assertThat(dependencies.keySet())
-            .containsExactlyInAnyOrder("affected", "changed", "my.cool", "new", "failed");
+            .containsExactlyInAnyOrder("affected", "changed", "my.cool", "new", "failed", "categorized");
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
     <module>strategies/affected</module>
     <module>strategies/changed</module>
     <module>strategies/failed</module>
+    <module>strategies/categorized</module>
     <module>mvn-extension</module>
     <module>functional-tests/git-rules</module>
     <module>functional-tests/test-bed</module>

--- a/strategies/categorized/pom.xml
+++ b/strategies/categorized/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>smart-testing-parent</artifactId>
+    <groupId>org.arquillian.smart.testing</groupId>
+    <version>0.0.6-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>strategy-categorized</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.arquillian.smart.testing</groupId>
+      <artifactId>core</artifactId>
+      <classifier>shaded</classifier>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${version.maven.plugin.shade}</version>
+        <configuration>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
+          <shadedArtifactAttached>true</shadedArtifactAttached>
+          <shadedClassifierName>shaded</shadedClassifierName>
+          <minimizeJar>true</minimizeJar>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/*.SF</exclude>
+                <exclude>META-INF/*.DSA</exclude>
+                <exclude>META-INF/*.RSA</exclude>
+              </excludes>
+            </filter>
+          </filters>
+          <relocations>
+            <relocation>
+              <pattern>org.eclipse.</pattern>
+              <shadedPattern>shaded.org.eclipse.</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>org.apache.</pattern>
+              <shadedPattern>shaded.org.apache.</shadedPattern>
+            </relocation>
+          </relocations>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategoriesParser.java
+++ b/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategoriesParser.java
@@ -1,0 +1,88 @@
+package org.arquillian.smart.testing.strategies.categorized;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.arquillian.smart.testing.logger.Log;
+import org.arquillian.smart.testing.logger.Logger;
+
+class CategoriesParser {
+
+    private final Logger logger = Log.getLogger();
+    private final CategorizedConfiguration strategyConfig;
+    private final List<String> specifiedCategories;
+
+    CategoriesParser(CategorizedConfiguration strategyConfig) {
+        this.strategyConfig = strategyConfig;
+        specifiedCategories = Arrays.stream(strategyConfig.getCategories())
+            .map(this::changeIfNonCaseSensitive)
+            .collect(Collectors.toList());
+    }
+
+    boolean hasCorrectCategories(Class<?> clazz) {
+        List<String> presentCategories = getPresentCategories(clazz);
+
+        if (!presentCategories.isEmpty()) {
+            if (specifiedCategories.size() > 0) {
+
+                List<String> intersection = presentCategories.stream()
+                    .filter(category -> isSpecified(category, specifiedCategories))
+                    .collect(Collectors.toList());
+
+                if (strategyConfig.isMatchAll()) {
+                    return intersection.size() == specifiedCategories.size();
+                } else {
+                    return !intersection.isEmpty();
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private List<String> getPresentCategories(Class<?> clazz) {
+        return Arrays.stream(clazz.getAnnotations())
+            .filter(this::isJUnit4Category)
+            .flatMap(this::retrieveCategoriesFromAnnotation)
+            .map(this::changeIfNonCaseSensitive)
+            .collect(Collectors.toList());
+    }
+
+    private boolean isSpecified(String category, List<String> specifiedCategories) {
+        if (!specifiedCategories.contains(category)) {
+            if (category.contains(".")) {
+                String categoryClassName = category.substring(category.lastIndexOf(".") + 1);
+                return specifiedCategories.contains(categoryClassName);
+            }
+            return false;
+        }
+        return true;
+    }
+
+    private String changeIfNonCaseSensitive(String category) {
+        return strategyConfig.isCaseSensitive() ? category : category.toLowerCase();
+    }
+
+    private Stream<String> retrieveCategoriesFromAnnotation(Annotation categoryAnnotation) {
+        try {
+            Method valueMethod = categoryAnnotation.getClass().getMethod("value");
+            return Arrays.asList((Class[]) valueMethod.invoke(categoryAnnotation))
+                .stream()
+                .map(Class::getName)
+                .collect(Collectors.toList())
+                .stream();
+        } catch (Exception e) {
+            logger.warn("Something wrong happened when the annotation [%s] was being parsed: %s", categoryAnnotation,
+                e.getMessage());
+        }
+        return Stream.empty();
+    }
+
+    private boolean isJUnit4Category(Annotation annotation) {
+        String fgn = annotation.annotationType().getName();
+        return fgn.equals("org.junit.experimental.categories.Category");
+    }
+}

--- a/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategoriesParser.java
+++ b/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategoriesParser.java
@@ -65,8 +65,7 @@ class CategoriesParser {
     private Stream<String> retrieveCategoriesFromAnnotation(Annotation categoryAnnotation) {
         try {
             Method valueMethod = categoryAnnotation.getClass().getMethod("value");
-            return Arrays.asList((Class[]) valueMethod.invoke(categoryAnnotation))
-                .stream()
+            return Arrays.stream((Class[]) valueMethod.invoke(categoryAnnotation))
                 .map(Class::getName)
                 .collect(Collectors.toList())
                 .stream();

--- a/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategoriesParser.java
+++ b/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategoriesParser.java
@@ -23,24 +23,20 @@ class CategoriesParser {
     }
 
     boolean hasCorrectCategories(Class<?> clazz) {
-        List<String> presentCategories = getPresentCategories(clazz);
-
-        if (!presentCategories.isEmpty()) {
-            if (specifiedCategories.size() > 0) {
-
-                List<String> intersection = presentCategories.stream()
-                    .filter(category -> isSpecified(category, specifiedCategories))
-                    .collect(Collectors.toList());
-
-                if (strategyConfig.isMatchAll()) {
-                    return intersection.size() == specifiedCategories.size();
-                } else {
-                    return !intersection.isEmpty();
-                }
-            }
-            return true;
+        final List<String> presentCategories = getPresentCategories(clazz);
+        if (presentCategories.isEmpty()) {
+            return false;
         }
-        return false;
+
+        final List<String> intersection = presentCategories.stream()
+            .filter(category -> isSpecified(category, specifiedCategories))
+            .collect(Collectors.toList());
+
+        if (strategyConfig.isMatchAll() || specifiedCategories.isEmpty()) {
+            return intersection.size() == specifiedCategories.size();
+        } else {
+            return !intersection.isEmpty();
+        }
     }
 
     private List<String> getPresentCategories(Class<?> clazz) {

--- a/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategorizedConfiguration.java
+++ b/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategorizedConfiguration.java
@@ -1,0 +1,67 @@
+package org.arquillian.smart.testing.strategies.categorized;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.arquillian.smart.testing.configuration.ConfigurationItem;
+import org.arquillian.smart.testing.spi.StrategyConfiguration;
+
+import static org.arquillian.smart.testing.strategies.categorized.CategorizedTestsDetector.CATEGORIZED;
+
+public class CategorizedConfiguration implements StrategyConfiguration {
+
+    private static final String SMART_TESTING_CATEGORIZED_CATEGORIES = "smart.testing.categorized.categories";
+    private static final String SMART_TESTING_CATEGORIZED_MATCH_ALL = "smart.testing.categorized.match.all";
+    private static final String SMART_TESTING_CATEGORIZED_CASE_SENSITIVE = "smart.testing.categorized.case.sensitive";
+    private static final String SMART_TESTING_CATEGORIZED_REVERSED = "smart.testing.categorized.reversed";
+    private String[] categories;
+    private boolean matchAll;
+    private boolean caseSensitive;
+    private boolean reversed;
+
+    @Override
+    public String name() {
+        return CATEGORIZED;
+    }
+
+    @Override
+    public List<ConfigurationItem> registerConfigurationItems() {
+        ArrayList<ConfigurationItem> items = new ArrayList<>();
+        items.add(new ConfigurationItem("categories", SMART_TESTING_CATEGORIZED_CATEGORIES, new String[0]));
+        items.add(new ConfigurationItem("matchAll", SMART_TESTING_CATEGORIZED_MATCH_ALL, false));
+        items.add(new ConfigurationItem("caseSensitive", SMART_TESTING_CATEGORIZED_CASE_SENSITIVE, false));
+        items.add(new ConfigurationItem("reversed", SMART_TESTING_CATEGORIZED_REVERSED, false));
+        return items;
+    }
+
+    public String[] getCategories() {
+        return categories;
+    }
+
+    public void setCategories(String[] categories) {
+        this.categories = categories;
+    }
+
+    public boolean isMatchAll() {
+        return matchAll;
+    }
+
+    public void setMatchAll(boolean matchAll) {
+        this.matchAll = matchAll;
+    }
+
+    public boolean isCaseSensitive() {
+        return caseSensitive;
+    }
+
+    public void setCaseSensitive(boolean caseSensitive) {
+        this.caseSensitive = caseSensitive;
+    }
+
+    public boolean isReversed() {
+        return reversed;
+    }
+
+    public void setReversed(boolean reversed) {
+        this.reversed = reversed;
+    }
+}

--- a/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategorizedTestsDetector.java
+++ b/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategorizedTestsDetector.java
@@ -1,0 +1,56 @@
+package org.arquillian.smart.testing.strategies.categorized;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.arquillian.smart.testing.TestSelection;
+import org.arquillian.smart.testing.configuration.Configuration;
+import org.arquillian.smart.testing.spi.TestExecutionPlanner;
+
+public class CategorizedTestsDetector implements TestExecutionPlanner {
+
+    static final String CATEGORIZED = "categorized";
+
+    private final CategorizedConfiguration strategyConfig;
+    private final CategoriesParser categoriesParser;
+
+    public CategorizedTestsDetector(Configuration configuration) {
+        strategyConfig = (CategorizedConfiguration) configuration.getStrategyConfiguration(CATEGORIZED);
+        categoriesParser = new CategoriesParser(strategyConfig);
+    }
+
+    @Override
+    public Collection<TestSelection> selectTestsFromNames(Iterable<String> testsToRun) {
+        List<Class<?>> classes = StreamSupport.stream(testsToRun.spliterator(), false)
+            .map(name -> {
+                try {
+                    return Class.forName(name);
+                } catch (ClassNotFoundException e) {
+                    throw new IllegalStateException("It is not possible to use categorized strategy in this environment. "
+                        + "The classes you want to run are not on the classpath when Smart Testing is invoked, so they cannot be loaded.");
+                }
+            }).collect(Collectors.toList());
+        return selectTestsFromClasses(classes);
+    }
+
+    @Override
+    public Collection<TestSelection> selectTestsFromClasses(Iterable<Class<?>> testsToRun) {
+        return StreamSupport.stream(testsToRun.spliterator(), false)
+            .filter(this::hasCorrectCategoriesMatchingReversed)
+            .map(clazz -> new TestSelection(clazz.getName(), CATEGORIZED))
+            .collect(Collectors.toList());
+    }
+
+    private boolean hasCorrectCategoriesMatchingReversed(Class<?> clazz) {
+        if (strategyConfig.isReversed()) {
+            return !categoriesParser.hasCorrectCategories(clazz);
+        }
+        return categoriesParser.hasCorrectCategories(clazz);
+    }
+
+    @Override
+    public String getName() {
+        return CATEGORIZED;
+    }
+}

--- a/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategorizedTestsDetectorFactory.java
+++ b/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategorizedTestsDetectorFactory.java
@@ -1,0 +1,33 @@
+package org.arquillian.smart.testing.strategies.categorized;
+
+import java.io.File;
+import org.arquillian.smart.testing.api.TestVerifier;
+import org.arquillian.smart.testing.configuration.Configuration;
+import org.arquillian.smart.testing.spi.StrategyConfiguration;
+import org.arquillian.smart.testing.spi.TestExecutionPlanner;
+import org.arquillian.smart.testing.spi.TestExecutionPlannerFactory;
+
+import static org.arquillian.smart.testing.strategies.categorized.CategorizedTestsDetector.CATEGORIZED;
+
+public class CategorizedTestsDetectorFactory implements TestExecutionPlannerFactory {
+
+    @Override
+    public String alias() {
+        return CATEGORIZED;
+    }
+
+    @Override
+    public boolean isFor(String name) {
+        return alias().equalsIgnoreCase(name);
+    }
+
+    @Override
+    public TestExecutionPlanner create(File projectDir, TestVerifier verifier, Configuration configuration) {
+        return new CategorizedTestsDetector(configuration);
+    }
+
+    @Override
+    public StrategyConfiguration strategyConfiguration() {
+        return new CategorizedConfiguration();
+    }
+}

--- a/strategies/categorized/src/main/resources/META-INF/services/org.arquillian.smart.testing.spi.TestExecutionPlannerFactory
+++ b/strategies/categorized/src/main/resources/META-INF/services/org.arquillian.smart.testing.spi.TestExecutionPlannerFactory
@@ -1,0 +1,1 @@
+org.arquillian.smart.testing.strategies.categorized.CategorizedTestsDetectorFactory

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/CategoriesParserTest.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/CategoriesParserTest.java
@@ -1,0 +1,151 @@
+package org.arquillian.smart.testing.strategies.categorized;
+
+import org.arquillian.smart.testing.strategies.categorized.project.FirstAndSecondCategorizedClass;
+import org.arquillian.smart.testing.strategies.categorized.project.FirstCategorizedClass;
+import org.arquillian.smart.testing.strategies.categorized.project.NonCategorizedClass;
+import org.arquillian.smart.testing.strategies.categorized.project.ThirdCategorizedClass;
+import org.arquillian.smart.testing.strategies.categorized.project.categories.FirstCategory;
+import org.arquillian.smart.testing.strategies.categorized.project.categories.SecondCategory;
+import org.arquillian.smart.testing.strategies.categorized.project.categories.ThirdCategory;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class CategoriesParserTest {
+
+    @Test
+    public void should_return_true_for_class_containing_category_when_no_category_set() {
+        // given
+        CategorizedConfiguration categorizedConfig = prepareConfig();
+        CategoriesParser categoriesParser = new CategoriesParser(categorizedConfig);
+
+        // when
+        boolean hasCorrectCategories = categoriesParser.hasCorrectCategories(FirstCategorizedClass.class);
+
+        // then
+        Assertions.assertThat(hasCorrectCategories).isTrue();
+    }
+
+    @Test
+    public void should_return_false_for_class_containing_no_category_when_no_category_set() {
+        // given
+        CategorizedConfiguration categorizedConfig = prepareConfig();
+        CategoriesParser categoriesParser = new CategoriesParser(categorizedConfig);
+
+        // when
+        boolean hasCorrectCategories = categoriesParser.hasCorrectCategories(NonCategorizedClass.class);
+
+        // then
+        Assertions.assertThat(hasCorrectCategories).isFalse();
+    }
+
+    @Test
+    public void should_return_true_for_class_containing_one_of_the_set_categories() {
+        // given
+        CategorizedConfiguration categorizedConfig =
+            prepareConfig(FirstCategory.class.getSimpleName().toLowerCase(), ThirdCategory.class.getName());
+        CategoriesParser categoriesParser = new CategoriesParser(categorizedConfig);
+
+        // when
+        boolean hasCorrectCategories = categoriesParser.hasCorrectCategories(FirstAndSecondCategorizedClass.class);
+
+        // then
+        Assertions.assertThat(hasCorrectCategories).isTrue();
+    }
+
+    @Test
+    public void should_return_false_for_class_containing_none_of_the_set_categories() {
+        // given
+        CategorizedConfiguration categorizedConfig =
+            prepareConfig(FirstCategory.class.getSimpleName(), SecondCategory.class.getName());
+        CategoriesParser categoriesParser = new CategoriesParser(categorizedConfig);
+
+        // when
+        boolean hasCorrectCategories = categoriesParser.hasCorrectCategories(ThirdCategorizedClass.class);
+
+        // then
+        Assertions.assertThat(hasCorrectCategories).isFalse();
+    }
+
+    @Test
+    public void should_return_true_for_class_containing_all_of_the_set_categories_when_matching_all() {
+        // given
+        CategorizedConfiguration categorizedConfig =
+            prepareConfig(FirstCategory.class.getSimpleName().toLowerCase(), SecondCategory.class.getName());
+        categorizedConfig.setMatchAll(true);
+        CategoriesParser categoriesParser = new CategoriesParser(categorizedConfig);
+
+        // when
+        boolean hasCorrectCategories = categoriesParser.hasCorrectCategories(FirstAndSecondCategorizedClass.class);
+
+        // then
+        Assertions.assertThat(hasCorrectCategories).isTrue();
+    }
+
+    @Test
+    public void should_return_false_for_class_not_containing_all_of_the_set_categories_when_matching_all() {
+        // given
+        CategorizedConfiguration categorizedConfig =
+            prepareConfig(FirstCategory.class.getSimpleName(), SecondCategory.class.getSimpleName());
+        categorizedConfig.setMatchAll(true);
+        CategoriesParser categoriesParser = new CategoriesParser(categorizedConfig);
+
+        // when
+        boolean hasCorrectCategories = categoriesParser.hasCorrectCategories(FirstCategorizedClass.class);
+
+        // then
+        Assertions.assertThat(hasCorrectCategories).isFalse();
+    }
+
+    @Test
+    public void should_return_false_for_class_not_containing_any_of_the_set_categories_when_case_sensitive() {
+        // given
+        CategorizedConfiguration categorizedConfig = prepareConfig(FirstCategory.class.getSimpleName().toLowerCase(),
+            SecondCategory.class.getName().toLowerCase());
+        categorizedConfig.setCaseSensitive(true);
+        CategoriesParser categoriesParser = new CategoriesParser(categorizedConfig);
+
+        // when
+        boolean hasCorrectCategories = categoriesParser.hasCorrectCategories(FirstAndSecondCategorizedClass.class);
+
+        // then
+        Assertions.assertThat(hasCorrectCategories).isFalse();
+    }
+
+    @Test
+    public void should_return_true_for_class_containing_all_of_the_set_categories_when_matching_all_and_case_sensitive() {
+        // given
+        CategorizedConfiguration categorizedConfig =
+            prepareConfig(FirstCategory.class.getSimpleName(), SecondCategory.class.getName());
+        categorizedConfig.setMatchAll(true);
+        categorizedConfig.setCaseSensitive(true);
+        CategoriesParser categoriesParser = new CategoriesParser(categorizedConfig);
+
+        // when
+        boolean hasCorrectCategories = categoriesParser.hasCorrectCategories(FirstAndSecondCategorizedClass.class);
+
+        // then
+        Assertions.assertThat(hasCorrectCategories).isTrue();
+    }
+
+    @Test
+    public void should_return_false_for_class_not_containing_all_of_the_set_categories_when_matching_all_and_case_sensitive() {
+        // given
+        CategorizedConfiguration categorizedConfig =
+            prepareConfig(FirstCategory.class.getSimpleName(), SecondCategory.class.getName().toLowerCase());
+        categorizedConfig.setMatchAll(true);
+        categorizedConfig.setCaseSensitive(true);
+        CategoriesParser categoriesParser = new CategoriesParser(categorizedConfig);
+
+        // when
+        boolean hasCorrectCategories = categoriesParser.hasCorrectCategories(FirstAndSecondCategorizedClass.class);
+
+        // then
+        Assertions.assertThat(hasCorrectCategories).isFalse();
+    }
+
+    private CategorizedConfiguration prepareConfig(String... categories) {
+        CategorizedConfiguration categorizedConfig = new CategorizedConfiguration();
+        categorizedConfig.setCategories(categories);
+        return categorizedConfig;
+    }
+}

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/CategorizedTestsDetectorTest.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/CategorizedTestsDetectorTest.java
@@ -1,0 +1,137 @@
+package org.arquillian.smart.testing.strategies.categorized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import org.arquillian.smart.testing.TestSelection;
+import org.arquillian.smart.testing.api.SmartTesting;
+import org.arquillian.smart.testing.configuration.Configuration;
+import org.arquillian.smart.testing.configuration.ConfigurationLoader;
+import org.arquillian.smart.testing.strategies.categorized.project.FirstAndSecondCategorizedClass;
+import org.arquillian.smart.testing.strategies.categorized.project.FirstCategorizedClass;
+import org.arquillian.smart.testing.strategies.categorized.project.NonCategorizedClass;
+import org.arquillian.smart.testing.strategies.categorized.project.ThirdCategorizedClass;
+import org.arquillian.smart.testing.strategies.categorized.project.categories.FirstCategory;
+import org.arquillian.smart.testing.strategies.categorized.project.categories.SecondCategory;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CategorizedTestsDetectorTest {
+
+    @Rule
+    public final TemporaryFolder tmpFolderRule = new TemporaryFolder();
+
+    private List<Class<?>> classesToProcess =
+        Arrays.asList(ThirdCategorizedClass.class, FirstAndSecondCategorizedClass.class, FirstCategorizedClass.class,
+            NonCategorizedClass.class);
+
+    private Configuration config;
+    private CategorizedConfiguration categorizedConfig;
+
+    @Before
+    public void prepareConfig() {
+        config = ConfigurationLoader.load(tmpFolderRule.getRoot());
+        categorizedConfig =
+            (CategorizedConfiguration) config.getStrategyConfiguration(CategorizedTestsDetector.CATEGORIZED);
+        config.getStrategiesConfiguration().add(categorizedConfig);
+    }
+
+    @Test
+    public void should_return_classes_with_first_category_no_case_sensitive() {
+        // given
+        categorizedConfig.setCategories(new String[] {FirstCategory.class.getName().toLowerCase()});
+
+        // when
+        Collection<TestSelection> testSelection =
+            new CategorizedTestsDetector(config).selectTestsFromClasses(classesToProcess);
+
+        // then
+        assertThat(testSelection).hasSize(2);
+        assertThat(SmartTesting.getClasses(new HashSet<>(testSelection)))
+            .contains(FirstAndSecondCategorizedClass.class, FirstCategorizedClass.class);
+    }
+
+    @Test
+    public void should_return_classes_with_first_and_second_category_based_on_simple_class_name() {
+        // given
+        categorizedConfig.setCategories(
+            new String[] {FirstCategory.class.getSimpleName(), SecondCategory.class.getSimpleName().toLowerCase()});
+
+        // when
+        Collection<TestSelection> testSelection =
+            new CategorizedTestsDetector(config).selectTestsFromClasses(classesToProcess);
+
+        // then
+        assertThat(testSelection).hasSize(2);
+        assertThat(SmartTesting.getClasses(new HashSet<>(testSelection)))
+            .contains(FirstAndSecondCategorizedClass.class, FirstCategorizedClass.class);
+    }
+
+    @Test
+    public void should_return_class_with_both_first_and_second_category_using_match_all() {
+        // given
+        categorizedConfig.setCategories(
+            new String[] {FirstCategory.class.getSimpleName(), SecondCategory.class.getSimpleName().toLowerCase()});
+        categorizedConfig.setMatchAll(true);
+
+        // when
+        Collection<TestSelection> testSelection =
+            new CategorizedTestsDetector(config).selectTestsFromClasses(classesToProcess);
+
+        // then
+        assertThat(testSelection).hasSize(1);
+        assertThat(SmartTesting.getClasses(new HashSet<>(testSelection)))
+            .contains(FirstAndSecondCategorizedClass.class);
+    }
+
+    @Test
+    public void should_return_class_with_second_category_when_case_sensitivity_is_set() {
+        // given
+        categorizedConfig.setCategories(
+            new String[] {FirstCategory.class.getSimpleName().toLowerCase(), SecondCategory.class.getSimpleName()});
+        categorizedConfig.setCaseSensitive(true);
+
+        // when
+        Collection<TestSelection> testSelection =
+            new CategorizedTestsDetector(config).selectTestsFromClasses(classesToProcess);
+
+        // then
+        assertThat(testSelection).hasSize(1);
+        assertThat(SmartTesting.getClasses(new HashSet<>(testSelection)))
+            .contains(FirstAndSecondCategorizedClass.class);
+    }
+
+    @Test
+    public void should_return_all_classes_with_any_category_when_no_category_is_set() {
+        // when
+        Collection<TestSelection> testSelection =
+            new CategorizedTestsDetector(config).selectTestsFromClasses(classesToProcess);
+
+        // then
+        assertThat(testSelection).hasSize(3);
+        assertThat(SmartTesting.getClasses(new HashSet<>(testSelection)))
+            .contains(ThirdCategorizedClass.class, FirstAndSecondCategorizedClass.class, FirstCategorizedClass.class);
+    }
+
+    @Test
+    public void should_return_classes_without_first_category_when_reversed_is_used() {
+        // given
+        categorizedConfig.setCategories(
+            new String[] {FirstCategory.class.getSimpleName()});
+        categorizedConfig.setReversed(true);
+
+        // when
+        Collection<TestSelection> testSelection =
+            new CategorizedTestsDetector(config).selectTestsFromClasses(classesToProcess);
+
+        // then
+        assertThat(testSelection).hasSize(2);
+        assertThat(SmartTesting.getClasses(new HashSet<>(testSelection)))
+            .contains(ThirdCategorizedClass.class, NonCategorizedClass.class);
+    }
+}

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/CategorizedTestsDetectorTest.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/CategorizedTestsDetectorTest.java
@@ -51,9 +51,8 @@ public class CategorizedTestsDetectorTest {
             new CategorizedTestsDetector(config).selectTestsFromClasses(classesToProcess);
 
         // then
-        assertThat(testSelection).hasSize(2);
         assertThat(SmartTesting.getClasses(new HashSet<>(testSelection)))
-            .contains(FirstAndSecondCategorizedClass.class, FirstCategorizedClass.class);
+            .containsExactlyInAnyOrder(FirstAndSecondCategorizedClass.class, FirstCategorizedClass.class);
     }
 
     @Test
@@ -67,9 +66,8 @@ public class CategorizedTestsDetectorTest {
             new CategorizedTestsDetector(config).selectTestsFromClasses(classesToProcess);
 
         // then
-        assertThat(testSelection).hasSize(2);
         assertThat(SmartTesting.getClasses(new HashSet<>(testSelection)))
-            .contains(FirstAndSecondCategorizedClass.class, FirstCategorizedClass.class);
+            .containsExactlyInAnyOrder(FirstAndSecondCategorizedClass.class, FirstCategorizedClass.class);
     }
 
     @Test
@@ -84,9 +82,8 @@ public class CategorizedTestsDetectorTest {
             new CategorizedTestsDetector(config).selectTestsFromClasses(classesToProcess);
 
         // then
-        assertThat(testSelection).hasSize(1);
         assertThat(SmartTesting.getClasses(new HashSet<>(testSelection)))
-            .contains(FirstAndSecondCategorizedClass.class);
+            .containsExactly(FirstAndSecondCategorizedClass.class);
     }
 
     @Test
@@ -101,9 +98,8 @@ public class CategorizedTestsDetectorTest {
             new CategorizedTestsDetector(config).selectTestsFromClasses(classesToProcess);
 
         // then
-        assertThat(testSelection).hasSize(1);
         assertThat(SmartTesting.getClasses(new HashSet<>(testSelection)))
-            .contains(FirstAndSecondCategorizedClass.class);
+            .containsExactly(FirstAndSecondCategorizedClass.class);
     }
 
     @Test
@@ -113,9 +109,9 @@ public class CategorizedTestsDetectorTest {
             new CategorizedTestsDetector(config).selectTestsFromClasses(classesToProcess);
 
         // then
-        assertThat(testSelection).hasSize(3);
         assertThat(SmartTesting.getClasses(new HashSet<>(testSelection)))
-            .contains(ThirdCategorizedClass.class, FirstAndSecondCategorizedClass.class, FirstCategorizedClass.class);
+            .containsExactlyInAnyOrder(ThirdCategorizedClass.class, FirstAndSecondCategorizedClass.class,
+                FirstCategorizedClass.class);
     }
 
     @Test
@@ -130,8 +126,7 @@ public class CategorizedTestsDetectorTest {
             new CategorizedTestsDetector(config).selectTestsFromClasses(classesToProcess);
 
         // then
-        assertThat(testSelection).hasSize(2);
         assertThat(SmartTesting.getClasses(new HashSet<>(testSelection)))
-            .contains(ThirdCategorizedClass.class, NonCategorizedClass.class);
+            .containsExactlyInAnyOrder(ThirdCategorizedClass.class, NonCategorizedClass.class);
     }
 }

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/FirstAndSecondCategorizedClass.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/FirstAndSecondCategorizedClass.java
@@ -1,0 +1,9 @@
+package org.arquillian.smart.testing.strategies.categorized.project;
+
+import org.arquillian.smart.testing.strategies.categorized.project.categories.FirstCategory;
+import org.arquillian.smart.testing.strategies.categorized.project.categories.SecondCategory;
+import org.junit.experimental.categories.Category;
+
+@Category({FirstCategory.class, SecondCategory.class})
+public class FirstAndSecondCategorizedClass {
+}

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/FirstCategorizedClass.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/FirstCategorizedClass.java
@@ -1,0 +1,8 @@
+package org.arquillian.smart.testing.strategies.categorized.project;
+
+import org.arquillian.smart.testing.strategies.categorized.project.categories.FirstCategory;
+import org.junit.experimental.categories.Category;
+
+@Category(FirstCategory.class)
+public class FirstCategorizedClass {
+}

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/NonCategorizedClass.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/NonCategorizedClass.java
@@ -1,0 +1,4 @@
+package org.arquillian.smart.testing.strategies.categorized.project;
+
+public class NonCategorizedClass {
+}

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/ThirdCategorizedClass.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/ThirdCategorizedClass.java
@@ -1,0 +1,8 @@
+package org.arquillian.smart.testing.strategies.categorized.project;
+
+import org.arquillian.smart.testing.strategies.categorized.project.categories.ThirdCategory;
+import org.junit.experimental.categories.Category;
+
+@Category(ThirdCategory.class)
+public class ThirdCategorizedClass {
+}

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/categories/FirstCategory.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/categories/FirstCategory.java
@@ -1,0 +1,4 @@
+package org.arquillian.smart.testing.strategies.categorized.project.categories;
+
+public class FirstCategory {
+}

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/categories/SecondCategory.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/categories/SecondCategory.java
@@ -1,0 +1,4 @@
+package org.arquillian.smart.testing.strategies.categorized.project.categories;
+
+public class SecondCategory {
+}

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/categories/ThirdCategory.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/categories/ThirdCategory.java
@@ -1,0 +1,4 @@
+package org.arquillian.smart.testing.strategies.categorized.project.categories;
+
+public class ThirdCategory {
+}


### PR DESCRIPTION
#### Short description of what this resolves:

Introducing `categorized` strategy.  Selects tests based on JUnit 4 annotation `@Category`. This annotation has a list of classes that represent categories - eg:
`@Category(FirstCategory.class, SecondCategory.class)`

* it doesn't expect only fqn of the classes specified in the category, but a simple name can be used as well
* if no category is specified, but the strategy is used, then it selects all classes that contain the annotation, no matter which classes are specified inside of the annotations.
* it is possible to set
  * list of categories (fully qualified names or just simple class names)
  * case sensitivity (default is non-case sensitive)
  * if it should match all specified categories or when one category class is matched then it is enough (default is the second one - when one category class is matched then the test is selected)
  * reversed function - selects classes that don't match (default value is false)

Fixes #283 

- [x] write documentation
