### PR TITLE
feat(#305): added support for test method selection

### DIFF
--- a/core/src/main/java/org/arquillian/smart/testing/TestSelection.java
+++ b/core/src/main/java/org/arquillian/smart/testing/TestSelection.java
@@ -4,8 +4,8 @@ import java.lang.reflect.Array;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Objects;
 
 import static java.lang.String.format;
@@ -18,7 +18,7 @@ public class TestSelection {
 
     private final Collection<String> appliedStrategies;
 
-    private final List<String> testMethodNames;
+    private final Collection<String> testMethodNames;
 
     public static final TestSelection NOT_MATCHED = new TestSelection("");
 
@@ -27,9 +27,13 @@ public class TestSelection {
     }
 
     public TestSelection(String className, String ... appliedStrategies) {
+        this(className, new ArrayList<>(), appliedStrategies);
+    }
+
+    public TestSelection(String className, Collection<String> testMethodNames, String ... appliedStrategies) {
         this.className = className;
         this.appliedStrategies = new LinkedHashSet<>(asList(appliedStrategies));
-        this.testMethodNames = new ArrayList<>();
+        this.testMethodNames = testMethodNames;
     }
 
     public String getClassName() {
@@ -37,7 +41,11 @@ public class TestSelection {
     }
 
     public Collection<String> getAppliedStrategies() {
-        return appliedStrategies; // TODO should we return clone to avoid manipulation?
+        return Collections.unmodifiableCollection(appliedStrategies);
+    }
+
+    public Collection<String> getTestMethodNames() {
+        return Collections.unmodifiableCollection(testMethodNames);
     }
 
     @Override
@@ -80,9 +88,5 @@ public class TestSelection {
         arraycopy(first, 0, result, 0, first.length);
         arraycopy(second, 0, result, first.length, second.length);
         return result;
-    }
-
-    public List<String> getTestMethodNames() {
-        return testMethodNames;
     }
 }

--- a/core/src/main/java/org/arquillian/smart/testing/TestSelection.java
+++ b/core/src/main/java/org/arquillian/smart/testing/TestSelection.java
@@ -2,8 +2,10 @@ package org.arquillian.smart.testing;
 
 import java.lang.reflect.Array;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Objects;
 
 import static java.lang.String.format;
@@ -14,23 +16,28 @@ public class TestSelection {
 
     private final String className;
 
-    private final Collection<String> types; // TODO or strategy instead (misleading name)
+    private final Collection<String> appliedStrategies;
 
-    public TestSelection(Path location, String... type) {
-        this(new ClassNameExtractor().extractFullyQualifiedName(location), type);
+    private final List<String> testMethodNames;
+
+    public static final TestSelection NOT_MATCHED = new TestSelection("");
+
+    public TestSelection(Path location, String... appliedStrategies) {
+        this(new ClassNameExtractor().extractFullyQualifiedName(location), appliedStrategies);
     }
 
-    public TestSelection(String className, String ... type) {
+    public TestSelection(String className, String ... appliedStrategies) {
         this.className = className;
-        this.types = new LinkedHashSet<>(asList(type));
+        this.appliedStrategies = new LinkedHashSet<>(asList(appliedStrategies));
+        this.testMethodNames = new ArrayList<>();
     }
 
     public String getClassName() {
         return className;
     }
 
-    public Collection<String> getTypes() {
-        return types; // TODO should we return clone to avoid manipulation?
+    public Collection<String> getAppliedStrategies() {
+        return appliedStrategies; // TODO should we return clone to avoid manipulation?
     }
 
     @Override
@@ -52,7 +59,7 @@ public class TestSelection {
 
     @Override
     public String toString() {
-        return "TestSelection{" + "className='" + className + '\'' + ", types=" + types + '}';
+        return "TestSelection{" + "className='" + className + '\'' + ", appliedStrategies=" + appliedStrategies + '}';
     }
 
     public TestSelection merge(TestSelection other) {
@@ -63,9 +70,9 @@ public class TestSelection {
                     other.getClassName()));
         }
 
-        final String[] types = getTypes().toArray(new String[getTypes().size()]);
-        final String[] typesOfOther = other.getTypes().toArray(new String[other.getTypes().size()]);
-        return new TestSelection(getClassName(), concat(types, typesOfOther));
+        final String[] appliedStrategies = getAppliedStrategies().toArray(new String[getAppliedStrategies().size()]);
+        final String[] otherAppliedStrategies = other.getAppliedStrategies().toArray(new String[other.getAppliedStrategies().size()]);
+        return new TestSelection(getClassName(), concat(appliedStrategies, otherAppliedStrategies));
     }
 
     private String[] concat(String[] first, String[] second) {
@@ -73,5 +80,9 @@ public class TestSelection {
         arraycopy(first, 0, result, 0, first.length);
         arraycopy(second, 0, result, first.length, second.length);
         return result;
+    }
+
+    public List<String> getTestMethodNames() {
+        return testMethodNames;
     }
 }

--- a/core/src/main/java/org/arquillian/smart/testing/impl/TestSelector.java
+++ b/core/src/main/java/org/arquillian/smart/testing/impl/TestSelector.java
@@ -103,7 +103,7 @@ abstract class TestSelector<CLASS_INFO_TYPE> {
             final StrategiesComparator byStrategies = new StrategiesComparator(strategies);
 
             return testSelections.stream()
-                .sorted(Comparator.comparing(TestSelection::getTypes, byStrategies))
+                .sorted(Comparator.comparing(TestSelection::getAppliedStrategies, byStrategies))
                 .collect(Collectors.toCollection(LinkedHashSet::new));
         }
 

--- a/core/src/main/java/org/arquillian/smart/testing/report/SmartTestingReportGenerator.java
+++ b/core/src/main/java/org/arquillian/smart/testing/report/SmartTestingReportGenerator.java
@@ -45,7 +45,7 @@ public class SmartTestingReportGenerator {
     private TestConfiguration getTestConfiguration(TestSelection testSelection) {
         return TestConfiguration.builder()
             .withName(testSelection.getClassName())
-            .withStrategies(testSelection.getTypes())
+            .withStrategies(testSelection.getAppliedStrategies())
             .build();
     }
 

--- a/core/src/test/java/org/arquillian/smart/testing/TestSelectionTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/TestSelectionTest.java
@@ -28,7 +28,7 @@ public class TestSelectionTest {
         final TestSelection mergedTestSelection = testSelection.merge(new TestSelection(CLASS_NAME_1, CHANGED));
         
         // then
-        assertThat(mergedTestSelection.getTypes()).containsExactly(NEW, CHANGED);
+        assertThat(mergedTestSelection.getAppliedStrategies()).containsExactly(NEW, CHANGED);
         assertThat(mergedTestSelection.getClassName()).isEqualTo(CLASS_NAME_1);
     }
 
@@ -41,7 +41,7 @@ public class TestSelectionTest {
         final TestSelection mergedTestSelection = testSelection.merge(new TestSelection(CLASS_NAME_1, CHANGED));
 
         // then
-        assertThat(mergedTestSelection.getTypes()).containsExactly(NEW, AFFECTED, CHANGED);
+        assertThat(mergedTestSelection.getAppliedStrategies()).containsExactly(NEW, AFFECTED, CHANGED);
         assertThat(mergedTestSelection.getClassName()).isEqualTo(CLASS_NAME_1);
     }
 
@@ -68,7 +68,7 @@ public class TestSelectionTest {
         final TestSelection mergedTestSelection = testSelection.merge(new TestSelection(path, NEW));
 
         // then
-        assertThat(mergedTestSelection.getTypes()).containsExactly(AFFECTED, NEW);
+        assertThat(mergedTestSelection.getAppliedStrategies()).containsExactly(AFFECTED, NEW);
     }
 
     private Path getPath(String fileName) {

--- a/core/src/test/java/org/arquillian/smart/testing/impl/TestSelectorTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/impl/TestSelectorTest.java
@@ -46,7 +46,7 @@ public class TestSelectorTest {
         // then
         Assertions.assertThat(testSelections)
             .hasSize(1)
-            .flatExtracting("types").containsExactly("new", "changed");
+            .flatExtracting("appliedStrategies").containsExactly("new", "changed");
     }
 
     @Test
@@ -72,7 +72,7 @@ public class TestSelectorTest {
         // then
         Assertions.assertThat(testSelections)
             .hasSize(2)
-            .flatExtracting("types").containsExactly("new", "changed");
+            .flatExtracting("appliedStrategies").containsExactly("new", "changed");
     }
 
     private TestExecutionPlannerLoader prepareLoader(final Set<Class<?>> testsToRun) {

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/SecurityUtils.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/SecurityUtils.java
@@ -1,6 +1,7 @@
 package org.arquillian.smart.testing.surefire.provider;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
@@ -80,5 +81,28 @@ class SecurityUtils {
                 }
             }
         }
+    }
+
+    public static Field getField(final Class<?> source, final String name) {
+        Field declaredAccessibleField = AccessController.doPrivileged(new PrivilegedAction<Field>() {
+            public Field run() {
+                Field foundField = null;
+                Class<?> nextSource = source;
+                while (nextSource != Object.class) {
+                    try {
+                        foundField = nextSource.getDeclaredField(name);
+                        if (!foundField.isAccessible()) {
+                            foundField.setAccessible(true);
+                        }
+                        break;
+                    } catch (NoSuchFieldException e) {
+                        // Nothing to do - just scan the super class
+                    }
+                    nextSource = nextSource.getSuperclass();
+                }
+                return foundField;
+            }
+        });
+        return declaredAccessibleField;
     }
 }

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/SecurityUtils.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/SecurityUtils.java
@@ -84,25 +84,22 @@ class SecurityUtils {
     }
 
     public static Field getField(final Class<?> source, final String name) {
-        Field declaredAccessibleField = AccessController.doPrivileged(new PrivilegedAction<Field>() {
-            public Field run() {
-                Field foundField = null;
-                Class<?> nextSource = source;
-                while (nextSource != Object.class) {
-                    try {
-                        foundField = nextSource.getDeclaredField(name);
-                        if (!foundField.isAccessible()) {
-                            foundField.setAccessible(true);
-                        }
-                        break;
-                    } catch (NoSuchFieldException e) {
-                        // Nothing to do - just scan the super class
+        return AccessController.doPrivileged((PrivilegedAction<Field>) () -> {
+            Field foundField = null;
+            Class<?> nextSource = source;
+            while (nextSource != Object.class) {
+                try {
+                    foundField = nextSource.getDeclaredField(name);
+                    if (!foundField.isAccessible()) {
+                        foundField.setAccessible(true);
                     }
-                    nextSource = nextSource.getSuperclass();
+                    break;
+                } catch (NoSuchFieldException e) {
+                    // Nothing to do - just scan the super class
                 }
-                return foundField;
+                nextSource = nextSource.getSuperclass();
             }
+            return foundField;
         });
-        return declaredAccessibleField;
     }
 }

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/SmartTestingInvoker.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/SmartTestingInvoker.java
@@ -1,0 +1,18 @@
+package org.arquillian.smart.testing.surefire.provider;
+
+import java.io.File;
+import java.util.Set;
+import org.apache.maven.surefire.util.TestsToRun;
+import org.arquillian.smart.testing.TestSelection;
+import org.arquillian.smart.testing.api.SmartTesting;
+import org.arquillian.smart.testing.configuration.Configuration;
+
+public class SmartTestingInvoker {
+
+    Set<TestSelection> invokeSmartTestingAPI(TestsToRun testsToRun, Configuration configuration, File projectDir) {
+        return SmartTesting
+            .with(className -> testsToRun.getClassByName(className) != null, configuration)
+            .in(projectDir)
+            .applyOnClasses(testsToRun);
+    }
+}

--- a/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/SurefireProviderFactory.java
+++ b/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/SurefireProviderFactory.java
@@ -12,12 +12,10 @@ import org.arquillian.smart.testing.surefire.provider.info.TestNgProviderInfo;
 public class SurefireProviderFactory {
 
     private final ProviderInfo providerInfo;
-    private final ProviderParameters providerParameters;
     private final Class<SurefireProvider> surefireProviderClass;
 
     SurefireProviderFactory(ProviderParametersParser paramParser, File projectDir) {
         providerInfo = detectProvider(paramParser, projectDir);
-        providerParameters = paramParser.getProviderParameters();
         surefireProviderClass = loadProviderClass();
     }
 
@@ -32,7 +30,7 @@ public class SurefireProviderFactory {
         return autoDetectOneProvider(wellKnownProviders);
     }
 
-    public SurefireProvider createInstance() {
+    public SurefireProvider createInstance(ProviderParameters providerParameters) {
         return SecurityUtils.newInstance(surefireProviderClass, new Class[] {ProviderParameters.class},
             new Object[] {providerInfo.convertProviderParameters(providerParameters)});
     }

--- a/surefire-provider/src/test/java/org/arquillian/smart/testing/surefire/provider/SmartTestingProviderTest.java
+++ b/surefire-provider/src/test/java/org/arquillian/smart/testing/surefire/provider/SmartTestingProviderTest.java
@@ -138,9 +138,8 @@ public class SmartTestingProviderTest {
     @Test
     public void should_add_test_method_selection_to_test_list_resolver() throws TestSetFailedException, InvocationTargetException {
         // given
-        TestSelection strategy = new TestSelection(ATest.class.getName(), "strategy");
-        strategy.getTestMethodNames().add("firstMethod");
-        strategy.getTestMethodNames().add("secondMethod");
+        TestSelection strategy =
+            new TestSelection(ATest.class.getName(), Arrays.asList("firstMethod", "secondMethod"), "strategy");
 
         prepareTestListResolver();
 

--- a/surefire-provider/src/test/java/org/arquillian/smart/testing/surefire/provider/custom/assertions/SurefireProviderSoftAssertions.java
+++ b/surefire-provider/src/test/java/org/arquillian/smart/testing/surefire/provider/custom/assertions/SurefireProviderSoftAssertions.java
@@ -1,5 +1,6 @@
 package org.arquillian.smart.testing.surefire.provider.custom.assertions;
 
+import org.apache.maven.surefire.testset.TestListResolver;
 import org.arquillian.smart.testing.surefire.provider.info.CustomProviderInfo;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.rules.TestRule;
@@ -10,6 +11,10 @@ public class SurefireProviderSoftAssertions extends SoftAssertions implements Te
 
     public CustomProviderAssert assertThat(CustomProviderInfo actual) {
         return proxy(CustomProviderAssert.class, CustomProviderInfo.class, actual);
+    }
+
+    public TestListResolverAssert assertThat(TestListResolver actual) {
+        return proxy(TestListResolverAssert.class, TestListResolver.class, actual);
     }
 
     @Override

--- a/surefire-provider/src/test/java/org/arquillian/smart/testing/surefire/provider/custom/assertions/TestListResolverAssert.java
+++ b/surefire-provider/src/test/java/org/arquillian/smart/testing/surefire/provider/custom/assertions/TestListResolverAssert.java
@@ -1,0 +1,65 @@
+package org.arquillian.smart.testing.surefire.provider.custom.assertions;
+
+import java.util.Objects;
+import org.apache.maven.surefire.testset.ResolvedTest;
+import org.apache.maven.surefire.testset.TestListResolver;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.IterableAssert;
+
+public class TestListResolverAssert extends AbstractAssert<TestListResolverAssert, TestListResolver> {
+
+    TestListResolverAssert(TestListResolver actual) {
+        super(actual, TestListResolverAssert.class);
+    }
+
+    public static TestListResolverAssert assertThat(TestListResolver customProviderInfo) {
+        return new TestListResolverAssert(customProviderInfo);
+    }
+
+    public TestListResolverAssert hasIncludedMethodPatterns(boolean hasIncludedMethodPatterns) {
+        isNotNull();
+
+        if (!Objects.equals(actual.hasIncludedMethodPatterns(), hasIncludedMethodPatterns)) {
+            failWithMessage("The given test list resolver <%s> should have <%s> included-method-patterns but it had <%s>",
+                actual, not(hasIncludedMethodPatterns), not(actual.hasIncludedMethodPatterns()));
+        }
+        return this;
+    }
+
+    public TestListResolverAssert hasMethodPatterns(boolean hasMethodPatterns) {
+        isNotNull();
+
+        if (!Objects.equals(actual.hasMethodPatterns(), hasMethodPatterns)) {
+            failWithMessage("The given test list resolver <%s> should have <%s> method-patterns but it had <%s>",
+                actual, not(hasMethodPatterns), not(actual.hasMethodPatterns()));
+        }
+        return this;
+    }
+
+    public TestListResolverAssert hasExcludedMethodPatterns(boolean hasExcludedMethodPatterns) {
+        isNotNull();
+
+        if (!Objects.equals(actual.hasExcludedMethodPatterns(), hasExcludedMethodPatterns)) {
+            failWithMessage("The given test list resolver <%s> should have <%s> excluded-method-patterns but it had <%s>",
+                actual, not(hasExcludedMethodPatterns), not(actual.hasExcludedMethodPatterns()));
+        }
+        return this;
+    }
+
+    public IterableAssert<ResolvedTest> includedPatterns() {
+        isNotNull();
+
+        return Assertions.assertThat(actual.getIncludedPatterns());
+    }
+
+    public IterableAssert<ResolvedTest> excludedPatterns() {
+        isNotNull();
+
+        return Assertions.assertThat(actual.getExcludedPatterns());
+    }
+
+    private String not(boolean bool){
+        return bool ? "" : "NOT";
+    }
+}


### PR DESCRIPTION
#### Short description of what this resolves:

This PR brings a support for selecting particular test methods (not only the whole test classes).
The solution is using `TestListResolver` - this class is used by the providers to check and filter any method pattern specified by a user. Unfortunately, it is an immutable object set as a private field inside of another immutable object, so the only way to make it working is using a Java reflection.

This PR contains only a support in Core, next PR introducing a resolution of categories on test methods will show and test a real usage.

#### Changes proposed in this pull request:

- new variable `testMethodNames` in `TestSelection` containing a list of test method names that should be selected. if the list is empty, then the whole class should be executed
- in `TestSelection` class has been also renamed variable `types` to `appliedStrategies`
- in `SmartTestingSurefireProvider` class, there has been introduced `SmartTestingInvoker` that invokes Smart Testing API - this change is because of unit tests - to mock SP API
- renamed  `bootParams` to `providerParameters` to reflect the type of this object


Fixes #305 
