### PR TITLE
 feat(304): categorized strategy is resolving also categories specified on test methods

### DIFF
--- a/core/src/main/java/org/arquillian/smart/testing/TestSelection.java
+++ b/core/src/main/java/org/arquillian/smart/testing/TestSelection.java
@@ -67,7 +67,9 @@ public class TestSelection {
 
     @Override
     public String toString() {
-        return "TestSelection{" + "className='" + className + '\'' + ", appliedStrategies=" + appliedStrategies + '}';
+        return "TestSelection{" + "className='" + className + '\''
+            + ", appliedStrategies=" + appliedStrategies + '\''
+            + ", testMethodNames=" + testMethodNames + '}';
     }
 
     public TestSelection merge(TestSelection other) {

--- a/docs/configfile.adoc
+++ b/docs/configfile.adoc
@@ -208,6 +208,9 @@ a| List of categories the strategy should be looking for (can be either whole fu
 a| caseSensitive
 a| Sets case sensitivity of the category names. (default is false)
 
+a| methods
+a| Sets if the resolution of categories/tags should be performed only on test classes or also on test methods. (default is true)
+
 a| matchAll
 a| Sets that the classes should contain all categories specified in the list of the categories. (default is false)
 

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -204,11 +204,8 @@ All reports from previous local build are automatically copied by the maven exte
 
 ==== Categorized
 
-`Categorized` strategy selects tests based in the JUnit 4 annotation `@Category` and the classes specified in it. With this strategy, you can easily set which classes you want to run without any need of changing your `pom.xml` file with complicated profiles.
+`Categorized` strategy selects tests based in the JUnit 4 annotation `@Category` or JUnit 5 annotations `@Tag` and `@Tags` (including meta annotations). With this strategy, you can easily set which classes or methods you want to run without any need of changing your `pom.xml` file with complicated profiles.
 
-You can say which categories should be executed by saying either the fully qualified names of the classes or just simple class names (case sensitivity can be set via configuration).
+In case of JUnit 4, you can say which categories should be executed by saying either the fully qualified names of the classes or just simple class names (case sensitivity can be set via configuration).
 For more information about the parameters see <<_categorized_configuration_options, Configuration Options>>.
 
-This strategy also supports JUnit 5 annotations `@Tag` and `@Tags` as well as meta annotations.
-
-NOTE: It works on the level of classes, so it doesn't reflect method annotations.

--- a/docs/refcard.adoc
+++ b/docs/refcard.adoc
@@ -98,6 +98,11 @@ a| `const:strategies/categorized/src/main/java/org/arquillian/smart/testing/stra
 a| `false`
 a|`categorized`
 
+a| `const:strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategorizedConfiguration.java[name="SMART_TESTING_CATEGORIZED_METHODS"]`
+| Sets if the resolution of categories/tags should be performed only on test classes or also on test methods.
+a| `true`
+a|`categorized`
+
 a| `const:strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategorizedConfiguration.java[name="SMART_TESTING_CATEGORIZED_MATCH_ALL"]`
 | Sets that the classes should contain all categories specified in the list of the categories.
 a| `false`

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/TestResults.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/project/TestResults.java
@@ -52,4 +52,8 @@ public class TestResults {
             .filter(testResult -> expectedStatuses.contains(testResult.getStatus()))
             .collect(Collectors.toList());
     }
+
+    public List<TestResult> getTestResults() {
+        return testResults;
+    }
 }

--- a/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/testresults/TestResult.java
+++ b/functional-tests/test-bed/src/main/java/org/arquillian/smart/testing/ftest/testbed/testresults/TestResult.java
@@ -44,7 +44,24 @@ public class TestResult {
             throw new IllegalArgumentException(
                 "Too many arguments passed to create TestResult. Expected to get status code and name, got [" + Arrays.toString(testResultParts) + "]");
         }
-        return new TestResult(testResultParts[1], "*", Status.from(testResultParts[0]));
+
+        String className;
+        String methodName;
+
+        if (expectedTestContainsSpecificMethodDefinition(testResultParts[1])) {
+            String[] classWithMethod = testResultParts[1].split("#");
+            className = classWithMethod[0];
+            methodName = classWithMethod[1];
+
+        } else {
+            className = testResultParts[1];
+            methodName = "*";
+        }
+        return new TestResult(className, methodName, Status.from(testResultParts[0]));
+    }
+
+    private static boolean expectedTestContainsSpecificMethodDefinition(String expectedTest) {
+        return expectedTest.contains("#");
     }
 
     @Override

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/categorized/CategorizedTestSelectionFunctionalTests.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/categorized/CategorizedTestSelectionFunctionalTests.java
@@ -49,4 +49,33 @@ public class CategorizedTestSelectionFunctionalTests {
         assertThat(actualTestResults.accumulatedPerTestClass()).containsAll(expectedTestResults)
             .hasSameSizeAs(expectedTestResults);
     }
+
+    @Test
+    public void should_run_test_methods_with_categories_either_event_or_exception() throws Exception {
+        // given
+        final Project project = testBed.getProject();
+        project
+            .configureSmartTesting()
+            .executionOrder(CATEGORIZED)
+            .inMode(SELECTING)
+            .enable();
+
+        final Collection<TestResult> expectedTestResults =
+            project.applyAsCommits("Added categories to test methods in core/impl-base");
+
+        // when
+        final TestResults actualTestResults =
+            project.build("core/impl-base")
+                .options()
+                .withSystemProperties(
+                    "smart.testing.categorized.categories", "exceptionCategory,EventCategory",
+                    "test", "Event*,*Impl*,Observer*",
+                    "failIfNoTests", "false")
+                .configure()
+                .run();
+
+        // then
+        assertThat(actualTestResults.getTestResults()).containsAll(expectedTestResults)
+            .hasSameSizeAs(expectedTestResults);
+    }
 }

--- a/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategoriesParser.java
+++ b/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategoriesParser.java
@@ -18,8 +18,8 @@ class CategoriesParser extends AbstractParser {
     }
 
     @Override
-    protected List<String> findCategories(Class<?> clazz) {
-        return Arrays.stream(clazz.getAnnotations())
+    protected List<String> findCategories(Annotation[] annotations) {
+        return Arrays.stream(annotations)
             .filter(this::isJUnit4Category)
             .flatMap(this::retrieveCategoriesFromAnnotation)
             .map(this::changeIfNonCaseSensitive)
@@ -36,6 +36,12 @@ class CategoriesParser extends AbstractParser {
             return false;
         }
         return true;
+    }
+
+    @Override
+    protected boolean isTestMethod(Method method) {
+        return Arrays.stream(method.getAnnotations())
+            .anyMatch(annotation -> annotation.annotationType().getName().equals("org.junit.Test"));
     }
 
     private Stream<String> retrieveCategoriesFromAnnotation(Annotation categoryAnnotation) {

--- a/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategorizedConfiguration.java
+++ b/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategorizedConfiguration.java
@@ -13,10 +13,12 @@ public class CategorizedConfiguration implements StrategyConfiguration {
     private static final String SMART_TESTING_CATEGORIZED_MATCH_ALL = "smart.testing.categorized.match.all";
     private static final String SMART_TESTING_CATEGORIZED_CASE_SENSITIVE = "smart.testing.categorized.case.sensitive";
     private static final String SMART_TESTING_CATEGORIZED_REVERSED = "smart.testing.categorized.reversed";
+    private static final String SMART_TESTING_CATEGORIZED_METHODS = "smart.testing.categorized.methods";
     private String[] categories;
     private boolean matchAll;
     private boolean caseSensitive;
     private boolean reversed;
+    private boolean methods;
 
     @Override
     public String name() {
@@ -30,6 +32,7 @@ public class CategorizedConfiguration implements StrategyConfiguration {
         items.add(new ConfigurationItem("matchAll", SMART_TESTING_CATEGORIZED_MATCH_ALL, false));
         items.add(new ConfigurationItem("caseSensitive", SMART_TESTING_CATEGORIZED_CASE_SENSITIVE, false));
         items.add(new ConfigurationItem("reversed", SMART_TESTING_CATEGORIZED_REVERSED, false));
+        items.add(new ConfigurationItem("methods", SMART_TESTING_CATEGORIZED_METHODS, true));
         return items;
     }
 
@@ -63,5 +66,13 @@ public class CategorizedConfiguration implements StrategyConfiguration {
 
     public void setReversed(boolean reversed) {
         this.reversed = reversed;
+    }
+
+    public boolean isMethods() {
+        return methods;
+    }
+
+    public void setMethods(boolean methods) {
+        this.methods = methods;
     }
 }

--- a/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategorizedTestsDetector.java
+++ b/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategorizedTestsDetector.java
@@ -1,5 +1,6 @@
 package org.arquillian.smart.testing.strategies.categorized;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -39,16 +40,16 @@ public class CategorizedTestsDetector implements TestExecutionPlanner {
     @Override
     public Collection<TestSelection> selectTestsFromClasses(Iterable<Class<?>> testsToRun) {
         return StreamSupport.stream(testsToRun.spliterator(), false)
-            .filter(this::hasCorrectCategoriesMatchingReversed)
-            .map(clazz -> new TestSelection(clazz.getName(), CATEGORIZED))
+            .map(this::getSelectionForClass)
+            .filter(testSelection -> !testSelection.equals(TestSelection.NOT_MATCHED))
             .collect(Collectors.toList());
     }
 
-    private boolean hasCorrectCategoriesMatchingReversed(Class<?> clazz) {
-        if (strategyConfig.isReversed()) {
-            return !categoriesParser.hasCorrectCategories(clazz) && !tagsParser.hasCorrectCategories(clazz);
+    TestSelection getSelectionForClass(Class clazz){
+        if (Arrays.stream(clazz.getDeclaredMethods()).anyMatch(tagsParser::isTestMethod)) {
+            return tagsParser.getTestSelectionIfMatched(clazz);
         }
-        return categoriesParser.hasCorrectCategories(clazz) || tagsParser.hasCorrectCategories(clazz);
+        return categoriesParser.getTestSelectionIfMatched(clazz);
     }
 
     @Override

--- a/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/TagsParser.java
+++ b/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/TagsParser.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.arquillian.smart.testing.logger.Log;
@@ -23,9 +22,9 @@ class TagsParser extends AbstractParser {
     }
 
     @Override
-    protected List<String> findCategories(Class<?> clazz) {
+    protected List<String> findCategories(Annotation[] annotations) {
 
-        return Arrays.stream(clazz.getAnnotations())
+        return Arrays.stream(annotations)
             .map(this::findJUnit5TagAnnotation)
             .filter(Objects::nonNull)
             .flatMap(this::retrieveTagFromAnnotation)
@@ -106,6 +105,12 @@ class TagsParser extends AbstractParser {
 
         return annotation;
 
+    }
+
+    @Override
+    protected boolean isTestMethod(Method method) {
+        return Arrays.stream(method.getAnnotations())
+            .anyMatch(annotation -> annotation.annotationType().getName().equals("org.junit.jupiter.api.Test"));
     }
 }
 

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/CategoriesParserTest.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/CategoriesParserTest.java
@@ -1,5 +1,6 @@
 package org.arquillian.smart.testing.strategies.categorized;
 
+import org.arquillian.smart.testing.TestSelection;
 import org.arquillian.smart.testing.strategies.categorized.project.categories.FirstAndSecondCategorizedClass;
 import org.arquillian.smart.testing.strategies.categorized.project.categories.FirstCategorizedClass;
 import org.arquillian.smart.testing.strategies.categorized.project.categories.NonCategorizedClass;
@@ -19,10 +20,10 @@ public class CategoriesParserTest {
         CategoriesParser categoriesParser = new CategoriesParser(categorizedConfig);
 
         // when
-        boolean hasCorrectCategories = categoriesParser.hasCorrectCategories(FirstCategorizedClass.class);
+        TestSelection selection = categoriesParser.getTestSelectionIfMatched(FirstCategorizedClass.class);
 
         // then
-        Assertions.assertThat(hasCorrectCategories).isTrue();
+        Assertions.assertThat(selection).isNotEqualTo(TestSelection.NOT_MATCHED);
     }
 
     @Test
@@ -32,10 +33,10 @@ public class CategoriesParserTest {
         CategoriesParser categoriesParser = new CategoriesParser(categorizedConfig);
 
         // when
-        boolean hasCorrectCategories = categoriesParser.hasCorrectCategories(NonCategorizedClass.class);
+        TestSelection selection = categoriesParser.getTestSelectionIfMatched(NonCategorizedClass.class);
 
         // then
-        Assertions.assertThat(hasCorrectCategories).isFalse();
+        Assertions.assertThat(selection).isEqualTo(TestSelection.NOT_MATCHED);
     }
 
     @Test
@@ -46,10 +47,10 @@ public class CategoriesParserTest {
         CategoriesParser categoriesParser = new CategoriesParser(categorizedConfig);
 
         // when
-        boolean hasCorrectCategories = categoriesParser.hasCorrectCategories(FirstAndSecondCategorizedClass.class);
+        TestSelection selection = categoriesParser.getTestSelectionIfMatched(FirstAndSecondCategorizedClass.class);
 
         // then
-        Assertions.assertThat(hasCorrectCategories).isTrue();
+        Assertions.assertThat(selection).isNotEqualTo(TestSelection.NOT_MATCHED);
     }
 
     @Test
@@ -60,10 +61,10 @@ public class CategoriesParserTest {
         CategoriesParser categoriesParser = new CategoriesParser(categorizedConfig);
 
         // when
-        boolean hasCorrectCategories = categoriesParser.hasCorrectCategories(ThirdCategorizedClass.class);
+        TestSelection selection = categoriesParser.getTestSelectionIfMatched(ThirdCategorizedClass.class);
 
         // then
-        Assertions.assertThat(hasCorrectCategories).isFalse();
+        Assertions.assertThat(selection).isEqualTo(TestSelection.NOT_MATCHED);
     }
 
     @Test
@@ -75,10 +76,10 @@ public class CategoriesParserTest {
         CategoriesParser categoriesParser = new CategoriesParser(categorizedConfig);
 
         // when
-        boolean hasCorrectCategories = categoriesParser.hasCorrectCategories(FirstAndSecondCategorizedClass.class);
+        TestSelection selection = categoriesParser.getTestSelectionIfMatched(FirstAndSecondCategorizedClass.class);
 
         // then
-        Assertions.assertThat(hasCorrectCategories).isTrue();
+        Assertions.assertThat(selection).isNotEqualTo(TestSelection.NOT_MATCHED);
     }
 
     @Test
@@ -90,10 +91,10 @@ public class CategoriesParserTest {
         CategoriesParser categoriesParser = new CategoriesParser(categorizedConfig);
 
         // when
-        boolean hasCorrectCategories = categoriesParser.hasCorrectCategories(FirstCategorizedClass.class);
+        TestSelection selection = categoriesParser.getTestSelectionIfMatched(FirstCategorizedClass.class);
 
         // then
-        Assertions.assertThat(hasCorrectCategories).isFalse();
+        Assertions.assertThat(selection).isEqualTo(TestSelection.NOT_MATCHED);
     }
 
     @Test
@@ -105,10 +106,10 @@ public class CategoriesParserTest {
         CategoriesParser categoriesParser = new CategoriesParser(categorizedConfig);
 
         // when
-        boolean hasCorrectCategories = categoriesParser.hasCorrectCategories(FirstAndSecondCategorizedClass.class);
+        TestSelection selection = categoriesParser.getTestSelectionIfMatched(FirstAndSecondCategorizedClass.class);
 
         // then
-        Assertions.assertThat(hasCorrectCategories).isFalse();
+        Assertions.assertThat(selection).isEqualTo(TestSelection.NOT_MATCHED);
     }
 
     @Test
@@ -121,10 +122,10 @@ public class CategoriesParserTest {
         CategoriesParser categoriesParser = new CategoriesParser(categorizedConfig);
 
         // when
-        boolean hasCorrectCategories = categoriesParser.hasCorrectCategories(FirstAndSecondCategorizedClass.class);
+        TestSelection selection = categoriesParser.getTestSelectionIfMatched(FirstAndSecondCategorizedClass.class);
 
         // then
-        Assertions.assertThat(hasCorrectCategories).isTrue();
+        Assertions.assertThat(selection).isNotEqualTo(TestSelection.NOT_MATCHED);
     }
 
     @Test
@@ -137,10 +138,10 @@ public class CategoriesParserTest {
         CategoriesParser categoriesParser = new CategoriesParser(categorizedConfig);
 
         // when
-        boolean hasCorrectCategories = categoriesParser.hasCorrectCategories(FirstAndSecondCategorizedClass.class);
+        TestSelection selection = categoriesParser.getTestSelectionIfMatched(FirstAndSecondCategorizedClass.class);
 
         // then
-        Assertions.assertThat(hasCorrectCategories).isFalse();
+        Assertions.assertThat(selection).isEqualTo(TestSelection.NOT_MATCHED);
     }
 
     private CategorizedConfiguration prepareConfig(String... categories) {

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/TagsParserTest.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/TagsParserTest.java
@@ -1,5 +1,6 @@
 package org.arquillian.smart.testing.strategies.categorized;
 
+import org.arquillian.smart.testing.TestSelection;
 import org.arquillian.smart.testing.strategies.categorized.project.tags.FastTaggedClass;
 import org.arquillian.smart.testing.strategies.categorized.project.tags.FirstAndSecondTaggedClass;
 import org.arquillian.smart.testing.strategies.categorized.project.tags.FirstTaggedClass;
@@ -17,23 +18,23 @@ public class TagsParserTest {
         TagsParser tagsParser = new TagsParser(categorizedConfig);
 
         // when
-        boolean hasCorrectTags = tagsParser.hasCorrectCategories(FirstTaggedClass.class);
+        TestSelection selection = tagsParser.getTestSelectionIfMatched(FirstTaggedClass.class);
 
         // then
-        Assertions.assertThat(hasCorrectTags).isTrue();
+        Assertions.assertThat(selection).isNotEqualTo(TestSelection.NOT_MATCHED);
     }
 
     @Test
     public void should_return_false_for_class_containing_no_tag_when_no_category_set() {
         // given
         CategorizedConfiguration categorizedConfig = prepareConfig();
-        TagsParser tagParser = new TagsParser(categorizedConfig);
+        TagsParser tagsParser = new TagsParser(categorizedConfig);
 
         // when
-        boolean hasCorrectTags = tagParser.hasCorrectCategories(NonTaggedClass.class);
+        TestSelection selection = tagsParser.getTestSelectionIfMatched(NonTaggedClass.class);
 
         // then
-        Assertions.assertThat(hasCorrectTags).isFalse();
+        Assertions.assertThat(selection).isEqualTo(TestSelection.NOT_MATCHED);
     }
 
     @Test
@@ -44,10 +45,10 @@ public class TagsParserTest {
         TagsParser tagsParser = new TagsParser(categorizedConfig);
 
         // when
-        boolean hasCorrectTags = tagsParser.hasCorrectCategories(FirstAndSecondTaggedClass.class);
+        TestSelection selection = tagsParser.getTestSelectionIfMatched(FirstAndSecondTaggedClass.class);
 
         // then
-        Assertions.assertThat(hasCorrectTags).isTrue();
+        Assertions.assertThat(selection).isNotEqualTo(TestSelection.NOT_MATCHED);
     }
 
     @Test
@@ -58,10 +59,10 @@ public class TagsParserTest {
         TagsParser tagsParser = new TagsParser(categorizedConfig);
 
         // when
-        boolean hasCorrectTags = tagsParser.hasCorrectCategories(FastTaggedClass.class);
+        TestSelection selection = tagsParser.getTestSelectionIfMatched(FastTaggedClass.class);
 
         // then
-        Assertions.assertThat(hasCorrectTags).isTrue();
+        Assertions.assertThat(selection).isNotEqualTo(TestSelection.NOT_MATCHED);
     }
 
     @Test
@@ -72,10 +73,10 @@ public class TagsParserTest {
         TagsParser tagsParser = new TagsParser(categorizedConfig);
 
         // when
-        boolean hasCorrectTags = tagsParser.hasCorrectCategories(ThirdTaggedClass.class);
+        TestSelection selection = tagsParser.getTestSelectionIfMatched(ThirdTaggedClass.class);
 
         // then
-        Assertions.assertThat(hasCorrectTags).isFalse();
+        Assertions.assertThat(selection).isEqualTo(TestSelection.NOT_MATCHED);
     }
 
     @Test
@@ -87,10 +88,10 @@ public class TagsParserTest {
         TagsParser tagsParser = new TagsParser(categorizedConfig);
 
         // when
-        boolean hasCorrectTags = tagsParser.hasCorrectCategories(FirstAndSecondTaggedClass.class);
+        TestSelection selection = tagsParser.getTestSelectionIfMatched(FirstAndSecondTaggedClass.class);
 
         // then
-        Assertions.assertThat(hasCorrectTags).isTrue();
+        Assertions.assertThat(selection).isNotEqualTo(TestSelection.NOT_MATCHED);
     }
 
     @Test
@@ -102,10 +103,10 @@ public class TagsParserTest {
         TagsParser tagsParser = new TagsParser(categorizedConfig);
 
         // when
-        boolean hasCorrectTags = tagsParser.hasCorrectCategories(FirstTaggedClass.class);
+        TestSelection selection = tagsParser.getTestSelectionIfMatched(FirstTaggedClass.class);
 
         // then
-        Assertions.assertThat(hasCorrectTags).isFalse();
+        Assertions.assertThat(selection).isEqualTo(TestSelection.NOT_MATCHED);
     }
 
     @Test
@@ -117,10 +118,10 @@ public class TagsParserTest {
         TagsParser tagsParser = new TagsParser(categorizedConfig);
 
         // when
-        boolean hasCorrectTags = tagsParser.hasCorrectCategories(FirstAndSecondTaggedClass.class);
+        TestSelection selection = tagsParser.getTestSelectionIfMatched(FirstAndSecondTaggedClass.class);
 
         // then
-        Assertions.assertThat(hasCorrectTags).isFalse();
+        Assertions.assertThat(selection).isEqualTo(TestSelection.NOT_MATCHED);
     }
 
     @Test
@@ -133,10 +134,10 @@ public class TagsParserTest {
         TagsParser tagsParser = new TagsParser(categorizedConfig);
 
         // when
-        boolean hasCorrectTags = tagsParser.hasCorrectCategories(FirstAndSecondTaggedClass.class);
+        TestSelection selection = tagsParser.getTestSelectionIfMatched(FirstAndSecondTaggedClass.class);
 
         // then
-        Assertions.assertThat(hasCorrectTags).isTrue();
+        Assertions.assertThat(selection).isNotEqualTo(TestSelection.NOT_MATCHED);
     }
 
     @Test
@@ -149,10 +150,10 @@ public class TagsParserTest {
         TagsParser tagsParser = new TagsParser(categorizedConfig);
 
         // when
-        boolean hasCorrectTags = tagsParser.hasCorrectCategories(FirstAndSecondTaggedClass.class);
+        TestSelection selection = tagsParser.getTestSelectionIfMatched(FirstAndSecondTaggedClass.class);
 
         // then
-        Assertions.assertThat(hasCorrectTags).isFalse();
+        Assertions.assertThat(selection).isEqualTo(TestSelection.NOT_MATCHED);
     }
 
     private CategorizedConfiguration prepareConfig(String... categories) {

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/custom/assertions/TestSelectionCollectionAssert.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/custom/assertions/TestSelectionCollectionAssert.java
@@ -1,0 +1,103 @@
+package org.arquillian.smart.testing.strategies.categorized.custom.assertions;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.arquillian.smart.testing.TestSelection;
+import org.assertj.core.api.AbstractAssert;
+
+public class TestSelectionCollectionAssert
+    extends AbstractAssert<TestSelectionCollectionAssert, Collection<TestSelection>> {
+
+    public TestSelectionCollectionAssert(Collection<TestSelection> testSelectionCollection) {
+        super(testSelectionCollection, TestSelectionCollectionAssert.class);
+    }
+
+    public static TestSelectionCollectionAssert assertThat(Collection<TestSelection> testSelectionCollection) {
+        return new TestSelectionCollectionAssert(testSelectionCollection);
+    }
+
+    public void containsTestClassSelectionsExactlyInAnyOrder(TestSelection... expectedTestSelections) {
+        isNotNull();
+        List<TestSelection> expectedSelections = Arrays.asList(expectedTestSelections);
+
+        List<TestSelection> notFound = actual.stream()
+            .filter(actualTestSelection -> !isTestSelectionInTheList(actualTestSelection, expectedSelections))
+            .collect(Collectors.toList());
+
+        if (!notFound.isEmpty()) {
+            failWithMessage(
+                "The actual collection of test selections: \n<%s> \n\nshould contain exactly in any order: \n <%s>, "
+                    + "\n\nbut it wasn't possible to find: \n<%s>",
+                actual, expectedSelections, notFound);
+        }
+
+        if (actual.size() != expectedSelections.size()) {
+            List<TestSelection> notExpected = expectedSelections.stream()
+                .filter(
+                    expectedTestSelection -> !isTestSelectionInTheList(expectedTestSelection, new ArrayList<>(actual)))
+                .collect(Collectors.toList());
+
+            failWithMessage(
+                "The actual collection of test selections: \n<%s> \n\nshould contain exactly in any order: \n <%s>, "
+                    + "\n\nbut these selections are present and not expected: \n<%s>",
+                actual, expectedSelections, notExpected);
+        }
+    }
+
+    private boolean isTestSelectionInTheList(TestSelection testSelection, List<TestSelection> testSelectionList) {
+        int index = testSelectionList.indexOf(testSelection);
+        if (index >= 0) {
+            TestSelection expTestSelection = testSelectionList.get(index);
+            if (!collectionsHasExactlySameContent(testSelection.getAppliedStrategies(),
+                expTestSelection.getAppliedStrategies())) {
+                return false;
+            }
+            if (!collectionsHasSameContent(testSelection.getTestMethodNames(),
+                expTestSelection.getTestMethodNames())) {
+                return false;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private boolean collectionsHasExactlySameContent(Collection<String> actualCollection,
+        Collection<String> expectedCollection) {
+        if (!nullAndSizeVerification(actualCollection, expectedCollection)) {
+            return false;
+        }
+        for (int i = 0; i < actualCollection.size(); i++) {
+            if (!Objects.equals(actualCollection.toArray()[i], expectedCollection.toArray()[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean collectionsHasSameContent(Collection<String> actualCollection,
+        Collection<String> expectedCollection) {
+        if (!nullAndSizeVerification(actualCollection, expectedCollection)) {
+            return false;
+        }
+        if (actualCollection.isEmpty()){
+            return true;
+        }
+
+        return actualCollection.stream().anyMatch(actualContent -> expectedCollection.contains(actualContent));
+    }
+
+    private boolean nullAndSizeVerification(Collection<String> actualCollection, Collection<String> expectedCollection) {
+        if ((actualCollection == null && expectedCollection != null)
+            || (actualCollection != null && expectedCollection == null)) {
+            return false;
+        }
+        if (actualCollection.size() != expectedCollection.size()) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/categories/FirstAndSecondCategorizedClass.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/categories/FirstAndSecondCategorizedClass.java
@@ -1,7 +1,12 @@
 package org.arquillian.smart.testing.strategies.categorized.project.categories;
 
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category({FirstCategory.class, SecondCategory.class})
 public class FirstAndSecondCategorizedClass {
+
+    @Test
+    public void test() {
+    }
 }

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/categories/FirstCategorizedClass.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/categories/FirstCategorizedClass.java
@@ -1,7 +1,12 @@
 package org.arquillian.smart.testing.strategies.categorized.project.categories;
 
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(FirstCategory.class)
 public class FirstCategorizedClass {
+
+    @Test
+    public void test() {
+    }
 }

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/categories/NonCategorizedClass.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/categories/NonCategorizedClass.java
@@ -1,4 +1,10 @@
 package org.arquillian.smart.testing.strategies.categorized.project.categories;
 
+import org.junit.Test;
+
 public class NonCategorizedClass {
+
+    @Test
+    public void test() {
+    }
 }

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/categories/ThirdCategorizedClass.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/categories/ThirdCategorizedClass.java
@@ -1,7 +1,12 @@
 package org.arquillian.smart.testing.strategies.categorized.project.categories;
 
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(ThirdCategory.class)
 public class ThirdCategorizedClass {
+
+    @Test
+    public void test() {
+    }
 }

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/categories/WithCategorizedMethodsClass.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/categories/WithCategorizedMethodsClass.java
@@ -1,0 +1,26 @@
+package org.arquillian.smart.testing.strategies.categorized.project.categories;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+public class WithCategorizedMethodsClass {
+
+    @Test
+    @Category(FirstCategory.class)
+    public void testWithFirstCategory() {
+    }
+
+    @Test
+    @Category(SecondCategory.class)
+    public void testWithSecondCategory() {
+    }
+
+    @Test
+    @Category(ThirdCategory.class)
+    public void testWithThirdCategory() {
+    }
+
+    @Test
+    public void testWithoutCategory() {
+    }
+}

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/tags/FastTaggedClass.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/tags/FastTaggedClass.java
@@ -1,5 +1,11 @@
 package org.arquillian.smart.testing.strategies.categorized.project.tags;
 
+import org.junit.jupiter.api.Test;
+
 @Fast
 public class FastTaggedClass {
+
+    @Test
+    public void test() {
+    }
 }

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/tags/FirstAndSecondTaggedClass.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/tags/FirstAndSecondTaggedClass.java
@@ -1,8 +1,13 @@
 package org.arquillian.smart.testing.strategies.categorized.project.tags;
 
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 @Tag("first")
 @Tag("second")
 public class FirstAndSecondTaggedClass {
+
+    @Test
+    public void test() {
+    }
 }

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/tags/FirstTaggedClass.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/tags/FirstTaggedClass.java
@@ -1,7 +1,12 @@
 package org.arquillian.smart.testing.strategies.categorized.project.tags;
 
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 @Tag("first")
 public class FirstTaggedClass {
+
+    @Test
+    public void test() {
+    }
 }

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/tags/NonTaggedClass.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/tags/NonTaggedClass.java
@@ -1,4 +1,10 @@
 package org.arquillian.smart.testing.strategies.categorized.project.tags;
 
+import org.junit.jupiter.api.Test;
+
 public class NonTaggedClass {
+
+    @Test
+    public void test() {
+    }
 }

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/tags/ThirdTaggedClass.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/tags/ThirdTaggedClass.java
@@ -1,7 +1,12 @@
 package org.arquillian.smart.testing.strategies.categorized.project.tags;
 
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 @Tag("third")
 public class ThirdTaggedClass {
+
+    @Test
+    public void test() {
+    }
 }

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/tags/WithTaggedMethodsClass.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/tags/WithTaggedMethodsClass.java
@@ -1,0 +1,31 @@
+package org.arquillian.smart.testing.strategies.categorized.project.tags;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+public class WithTaggedMethodsClass {
+
+    @Test
+    @Tag("fast")
+    public void testWithFastTag() {
+    }
+
+    @Test
+    @Tag("first")
+    public void testWithFirstTag() {
+    }
+
+    @Test
+    @Tag("second")
+    public void testWithSecondTag() {
+    }
+
+    @Test
+    @Tag("third")
+    public void testWithThirdTag() {
+    }
+
+    @Test
+    public void testWithoutTag() {
+    }
+}


### PR DESCRIPTION
#### Short description of what this resolves:

This is a specific implementation of test method selection for the `categorized` strategy. It is built on top of the implementation proposed in this PR #308 

The resolution works for both JUnit 4 categories and JUnit 5 tags.

#### Changes proposed in this pull request:

- added `smart.testing.categorized.methods` config parameter to disable/enable method recognition (default is `true`)
- changed `AbstractParser` to get categories/tags annotated on test methods; added abstract method `isTestMethod` to check which method is a test method.
- test-bed - slightly modified test result parser to get results on the test method level

#### Missing:
- [x] documentation

Fixes #304 
