### PR TITLE
Categorized exclusions

### DIFF
--- a/docs/configfile.adoc
+++ b/docs/configfile.adoc
@@ -205,17 +205,15 @@ a| Sets list of packages to be included while applying transitivity.
 a| categories
 a| List of categories the strategy should be looking for (can be either whole fully qualified names or only simple class names). If nothing is set, but the strategy is used, then all classes containing the annotation `@Category` are selected.
 
+a| excludedCategories
+a| List of categories the strategy should exclude from looking for (can be either whole fully qualified names or only simple class names)
+
 a| caseSensitive
 a| Sets case sensitivity of the category names. (default is false)
 
 a| methods
 a| Sets if the resolution of categories/tags should be performed only on test classes or also on test methods. (default is true)
 
-a| matchAll
-a| Sets that the classes should contain all categories specified in the list of the categories. (default is false)
-
-a| reversed
-a| Sets that the selection should be reversed - all classes that don't match the categories will be selected. (default is false)
 |===
 
 ==== Failed Configuration Options

--- a/docs/configfile.adoc
+++ b/docs/configfile.adoc
@@ -203,7 +203,7 @@ a| Sets list of packages to be included while applying transitivity.
 |===
 |Field | Description
 a| categories
-a| List of categories the strategy should be looking for (can be either whole fully qualified names or only simple class names). If nothing is set, but the strategy is used, then all classes containing the annotation `@Category` are selected.
+a| List of categories the strategy should be looking for (can be either whole fully qualified names or only simple class names). If nothing is set, but the strategy is used, then all classes are selected.
 
 a| excludedCategories
 a| List of categories the strategy should exclude from looking for (can be either whole fully qualified names or only simple class names)

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -204,7 +204,9 @@ All reports from previous local build are automatically copied by the maven exte
 
 ==== Categorized
 
-`Categorized` strategy selects tests based in the JUnit 4 annotation `@Category` or JUnit 5 annotations `@Tag` and `@Tags` (including meta annotations). With this strategy, you can easily set which classes or methods you want to run without any need of changing your `pom.xml` file with complicated profiles.
+`Categorized` strategy selects tests based in the JUnit 4 annotation `@Category` or JUnit 5 annotations `@Tag` and `@Tags` (including meta annotations).
+With this strategy, you can easily set which classes or methods you want to run (or don't want to run)
+as you would in the configuration of the `maven-surefire-plugin` without any need of changing your `pom.xml` file with complicated profiles.
 
 In case of JUnit 4, you can say which categories should be executed by saying either the fully qualified names of the classes or just simple class names (case sensitivity can be set via configuration).
 For more information about the parameters see <<_categorized_configuration_options, Configuration Options>>.

--- a/docs/refcard.adoc
+++ b/docs/refcard.adoc
@@ -93,6 +93,11 @@ a| `const:strategies/categorized/src/main/java/org/arquillian/smart/testing/stra
 a| -
 a|`categorized`
 
+a| `const:strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategorizedConfiguration.java[name="SMART_TESTING_CATEGORIZED_EXCLUDED_CATEGORIES"]`
+| List of categories the strategy should exclude from looking for (can be either whole fully qualified names or only simple class names)
+a| -
+a|`categorized`
+
 a| `const:strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategorizedConfiguration.java[name="SMART_TESTING_CATEGORIZED_CASE_SENSITIVE"]`
 | Sets case sensitivity of the category names.
 a| `false`
@@ -103,20 +108,11 @@ a| `const:strategies/categorized/src/main/java/org/arquillian/smart/testing/stra
 a| `true`
 a|`categorized`
 
-a| `const:strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategorizedConfiguration.java[name="SMART_TESTING_CATEGORIZED_MATCH_ALL"]`
-| Sets that the classes should contain all categories specified in the list of the categories.
-a| `false`
-a|`categorized`
-
-a| `const:strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategorizedConfiguration.java[name="SMART_TESTING_CATEGORIZED_REVERSED"]`
-| Sets that the selection should be reversed - all classes that don't match the categories will be selected.
-a| `false`
-a|`categorized`
-
 a| `const:strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/FailedConfiguration.java[name="SMART_TESTING_FAILED_METHODS"]`
 | Sets if the strategy should select the particular failed test methods or take the whole classes
 a| `true`
 a|`failed`
+
 |===
 
 === Getting insights of the execution

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/categorized/CategorizedTestSelectionFunctionalTests.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/categorized/CategorizedTestSelectionFunctionalTests.java
@@ -32,7 +32,6 @@ public class CategorizedTestSelectionFunctionalTests {
         final Project project = testBed.getProject();
         CategorizedConfiguration categorizedConfiguration = new CategorizedConfiguration();
         categorizedConfiguration.setCategories(new String[] {"LoaderCategory", "serviceCategory"});
-        categorizedConfiguration.setMatchAll(true);
         Configuration config = new ConfigurationBuilder()
             .strategies(CATEGORIZED)
             .strategiesConfiguration()

--- a/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/AbstractParser.java
+++ b/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/AbstractParser.java
@@ -2,9 +2,15 @@ package org.arquillian.smart.testing.strategies.categorized;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
-import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Arrays;
 import java.util.stream.Collectors;
+
+import java.util.stream.Stream;
 import org.arquillian.smart.testing.TestSelection;
 
 import static org.arquillian.smart.testing.strategies.categorized.CategorizedTestsDetector.CATEGORIZED;
@@ -13,67 +19,71 @@ public abstract class AbstractParser {
 
     private final CategorizedConfiguration strategyConfig;
     private final List<String> specifiedCategories;
+    private final List<String> excludedCategories;
 
     AbstractParser(CategorizedConfiguration strategyConfig) {
         this.strategyConfig = strategyConfig;
         specifiedCategories = Arrays.stream(strategyConfig.getCategories())
             .map(this::changeIfNonCaseSensitive)
             .collect(Collectors.toList());
+        excludedCategories = Arrays.stream(strategyConfig.getExcludedCategories())
+            .map(this::changeIfNonCaseSensitive)
+            .collect(Collectors.toList());
     }
 
-    TestSelection getTestSelectionIfMatched(Class<?> clazz){
-        List<String> classCategories = findCategories(clazz.getAnnotations());
-        if (strategyConfig.isMethods() && classCategories.isEmpty()) {
+    TestSelection getTestSelectionIfMatched(Class<?> clazz) {
+        if (strategyConfig.isMethods()) {
             return getSelectionWithMethods(clazz);
-        } else {
-            if (containsCorrectCategoriesMatchingReversed(classCategories)) {
-                return new TestSelection(clazz.getName(), CATEGORIZED);
-            }
         }
-        return TestSelection.NOT_MATCHED;
+        return shouldBeIncluded(findCategories(clazz.getAnnotations())) ? new TestSelection(clazz.getName(), CATEGORIZED)
+            : TestSelection.NOT_MATCHED;
     }
 
-    private TestSelection getSelectionWithMethods(Class<?> clazz){
-        List<Method> testMethods = Arrays.stream(clazz.getDeclaredMethods())
-            .filter(this::isTestMethod)
-            .collect(Collectors.toList());
-
-        List<String> selectedMethods = testMethods.stream()
-            .filter(method -> containsCorrectCategoriesMatchingReversed(findCategories(method.getAnnotations())))
-            .map(Method::getName)
-            .collect(Collectors.toList());
-
-        if (!selectedMethods.isEmpty()) {
-            if (selectedMethods.size() != testMethods.size()) {
-                return new TestSelection(clazz.getName(), selectedMethods, CATEGORIZED);
-            } else {
-                return new TestSelection(clazz.getName(), CATEGORIZED);
-            }
-        }
-        return TestSelection.NOT_MATCHED;
-    }
-
-    private boolean containsCorrectCategoriesMatchingReversed(List<String> presentCategories) {
-        if (strategyConfig.isReversed()) {
-            return !containsCorrectCategories(presentCategories);
-        }
-        return containsCorrectCategories(presentCategories);
-    }
-
-    private boolean containsCorrectCategories(List<String> presentCategories) {
+    private boolean matchesCategories(Collection<String> presentCategories, Collection<String> categories) {
         if (presentCategories.isEmpty()) {
             return false;
         }
 
         final List<String> intersection = presentCategories.stream()
-            .filter(category -> this.isSpecified(category, specifiedCategories))
+            .filter(category -> isSpecified(category, new ArrayList<>(categories)))
             .collect(Collectors.toList());
+        return !intersection.isEmpty();
+    }
 
-        if (strategyConfig.isMatchAll() || specifiedCategories.isEmpty()) {
-            return intersection.size() == specifiedCategories.size();
-        } else {
-            return !intersection.isEmpty();
+    private boolean shouldBeIncluded(Collection<String> presentCategories) {
+        if (specifiedCategories.isEmpty()) {
+            return true;
         }
+        return matchesCategories(presentCategories, specifiedCategories);
+    }
+
+    private boolean areCategoriesIncluded(Collection<String> presentCategories) {
+        return shouldBeIncluded(presentCategories) && !matchesCategories(presentCategories, excludedCategories);
+    }
+
+    private TestSelection getSelectionWithMethods(Class<?> clazz) {
+        List<String> classLevelCategories = findCategories(clazz.getAnnotations());
+        List<CategorizedMethod> categorizedMethods = getTestMethods(clazz)
+            .stream()
+            .map(method -> new CategorizedMethod(method, classLevelCategories))
+            .collect(Collectors.toList());
+        List<String> applicableMethodNames = categorizedMethods.stream()
+            .filter(method -> areCategoriesIncluded(method.getCategories()))
+            .map(CategorizedMethod::getName)
+            .collect(Collectors.toList());
+        if (applicableMethodNames.size() == getTestMethods(clazz).size()) {
+            return new TestSelection(clazz.getName(), CATEGORIZED);
+        }
+        if (!applicableMethodNames.isEmpty()) {
+            return new TestSelection(clazz.getName(), applicableMethodNames, CATEGORIZED);
+        }
+        return TestSelection.NOT_MATCHED;
+    }
+
+    private List<Method> getTestMethods(Class<?> clazz) {
+        return Arrays.stream(clazz.getDeclaredMethods())
+            .filter(this::isTestMethod)
+            .collect(Collectors.toList());
     }
 
     protected String changeIfNonCaseSensitive(String category) {
@@ -81,7 +91,28 @@ public abstract class AbstractParser {
     }
 
     protected abstract List<String> findCategories(Annotation[] annotations);
+
     protected abstract boolean isSpecified(String category, List<String> specifiedCategories);
+
     protected abstract boolean isTestMethod(Method method);
 
+    private class CategorizedMethod {
+
+        private final String name;
+        private final Set<String> categories;
+
+        CategorizedMethod(Method method, Collection<String> classLevelCategories) {
+            this.name = method.getName();
+            this.categories = Stream.concat(classLevelCategories.stream(), findCategories(method.getAnnotations()).stream())
+                .collect(Collectors.toSet());
+        }
+
+        Set<String> getCategories() {
+            return categories;
+        }
+
+        String getName() {
+            return name;
+        }
+    }
 }

--- a/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/AbstractParser.java
+++ b/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/AbstractParser.java
@@ -63,11 +63,9 @@ public abstract class AbstractParser {
 
     private TestSelection getSelectionWithMethods(Class<?> clazz) {
         List<String> classLevelCategories = findCategories(clazz.getAnnotations());
-        List<CategorizedMethod> categorizedMethods = getTestMethods(clazz)
+        List<String> applicableMethodNames = getTestMethods(clazz)
             .stream()
             .map(method -> new CategorizedMethod(method, classLevelCategories))
-            .collect(Collectors.toList());
-        List<String> applicableMethodNames = categorizedMethods.stream()
             .filter(method -> areCategoriesIncluded(method.getCategories()))
             .map(CategorizedMethod::getName)
             .collect(Collectors.toList());

--- a/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/AbstractParser.java
+++ b/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/AbstractParser.java
@@ -81,7 +81,7 @@ public abstract class AbstractParser {
     }
 
     private List<Method> getTestMethods(Class<?> clazz) {
-        return Arrays.stream(clazz.getDeclaredMethods())
+        return Arrays.stream(clazz.getMethods())
             .filter(this::isTestMethod)
             .collect(Collectors.toList());
     }

--- a/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategorizedConfiguration.java
+++ b/strategies/categorized/src/main/java/org/arquillian/smart/testing/strategies/categorized/CategorizedConfiguration.java
@@ -10,14 +10,12 @@ import static org.arquillian.smart.testing.strategies.categorized.CategorizedTes
 public class CategorizedConfiguration implements StrategyConfiguration {
 
     private static final String SMART_TESTING_CATEGORIZED_CATEGORIES = "smart.testing.categorized.categories";
-    private static final String SMART_TESTING_CATEGORIZED_MATCH_ALL = "smart.testing.categorized.match.all";
+    private static final String SMART_TESTING_CATEGORIZED_EXCLUDED_CATEGORIES = "smart.testing.categorized.excluded.categories";
     private static final String SMART_TESTING_CATEGORIZED_CASE_SENSITIVE = "smart.testing.categorized.case.sensitive";
-    private static final String SMART_TESTING_CATEGORIZED_REVERSED = "smart.testing.categorized.reversed";
     private static final String SMART_TESTING_CATEGORIZED_METHODS = "smart.testing.categorized.methods";
+    private String[] excludedCategories;
     private String[] categories;
-    private boolean matchAll;
     private boolean caseSensitive;
-    private boolean reversed;
     private boolean methods;
 
     @Override
@@ -29,9 +27,8 @@ public class CategorizedConfiguration implements StrategyConfiguration {
     public List<ConfigurationItem> registerConfigurationItems() {
         ArrayList<ConfigurationItem> items = new ArrayList<>();
         items.add(new ConfigurationItem("categories", SMART_TESTING_CATEGORIZED_CATEGORIES, new String[0]));
-        items.add(new ConfigurationItem("matchAll", SMART_TESTING_CATEGORIZED_MATCH_ALL, false));
+        items.add(new ConfigurationItem("excludedCategories", SMART_TESTING_CATEGORIZED_EXCLUDED_CATEGORIES, new String[0]));
         items.add(new ConfigurationItem("caseSensitive", SMART_TESTING_CATEGORIZED_CASE_SENSITIVE, false));
-        items.add(new ConfigurationItem("reversed", SMART_TESTING_CATEGORIZED_REVERSED, false));
         items.add(new ConfigurationItem("methods", SMART_TESTING_CATEGORIZED_METHODS, true));
         return items;
     }
@@ -44,12 +41,12 @@ public class CategorizedConfiguration implements StrategyConfiguration {
         this.categories = categories;
     }
 
-    public boolean isMatchAll() {
-        return matchAll;
+    public String[] getExcludedCategories() {
+        return excludedCategories;
     }
 
-    public void setMatchAll(boolean matchAll) {
-        this.matchAll = matchAll;
+    public void setExcludedCategories(String[] excludedCategories) {
+        this.excludedCategories = excludedCategories;
     }
 
     public boolean isCaseSensitive() {
@@ -58,14 +55,6 @@ public class CategorizedConfiguration implements StrategyConfiguration {
 
     public void setCaseSensitive(boolean caseSensitive) {
         this.caseSensitive = caseSensitive;
-    }
-
-    public boolean isReversed() {
-        return reversed;
-    }
-
-    public void setReversed(boolean reversed) {
-        this.reversed = reversed;
     }
 
     public boolean isMethods() {

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/CategoriesParserTest.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/CategoriesParserTest.java
@@ -14,20 +14,7 @@ import org.junit.Test;
 public class CategoriesParserTest {
 
     @Test
-    public void should_return_true_for_class_containing_category_when_no_category_set() {
-        // given
-        CategorizedConfiguration categorizedConfig = prepareConfig();
-        CategoriesParser categoriesParser = new CategoriesParser(categorizedConfig);
-
-        // when
-        TestSelection selection = categoriesParser.getTestSelectionIfMatched(FirstCategorizedClass.class);
-
-        // then
-        Assertions.assertThat(selection).isNotEqualTo(TestSelection.NOT_MATCHED);
-    }
-
-    @Test
-    public void should_return_false_for_class_containing_no_category_when_no_category_set() {
+    public void should_return_true_for_class_containing_no_category_when_no_category_set() {
         // given
         CategorizedConfiguration categorizedConfig = prepareConfig();
         CategoriesParser categoriesParser = new CategoriesParser(categorizedConfig);
@@ -36,7 +23,7 @@ public class CategoriesParserTest {
         TestSelection selection = categoriesParser.getTestSelectionIfMatched(NonCategorizedClass.class);
 
         // then
-        Assertions.assertThat(selection).isEqualTo(TestSelection.NOT_MATCHED);
+        Assertions.assertThat(selection).isNotEqualTo(TestSelection.NOT_MATCHED);
     }
 
     @Test
@@ -68,36 +55,6 @@ public class CategoriesParserTest {
     }
 
     @Test
-    public void should_return_true_for_class_containing_all_of_the_set_categories_when_matching_all() {
-        // given
-        CategorizedConfiguration categorizedConfig =
-            prepareConfig(FirstCategory.class.getSimpleName().toLowerCase(), SecondCategory.class.getName());
-        categorizedConfig.setMatchAll(true);
-        CategoriesParser categoriesParser = new CategoriesParser(categorizedConfig);
-
-        // when
-        TestSelection selection = categoriesParser.getTestSelectionIfMatched(FirstAndSecondCategorizedClass.class);
-
-        // then
-        Assertions.assertThat(selection).isNotEqualTo(TestSelection.NOT_MATCHED);
-    }
-
-    @Test
-    public void should_return_false_for_class_not_containing_all_of_the_set_categories_when_matching_all() {
-        // given
-        CategorizedConfiguration categorizedConfig =
-            prepareConfig(FirstCategory.class.getSimpleName(), SecondCategory.class.getSimpleName());
-        categorizedConfig.setMatchAll(true);
-        CategoriesParser categoriesParser = new CategoriesParser(categorizedConfig);
-
-        // when
-        TestSelection selection = categoriesParser.getTestSelectionIfMatched(FirstCategorizedClass.class);
-
-        // then
-        Assertions.assertThat(selection).isEqualTo(TestSelection.NOT_MATCHED);
-    }
-
-    @Test
     public void should_return_false_for_class_not_containing_any_of_the_set_categories_when_case_sensitive() {
         // given
         CategorizedConfiguration categorizedConfig = prepareConfig(FirstCategory.class.getSimpleName().toLowerCase(),
@@ -112,41 +69,10 @@ public class CategoriesParserTest {
         Assertions.assertThat(selection).isEqualTo(TestSelection.NOT_MATCHED);
     }
 
-    @Test
-    public void should_return_true_for_class_containing_all_of_the_set_categories_when_matching_all_and_case_sensitive() {
-        // given
-        CategorizedConfiguration categorizedConfig =
-            prepareConfig(FirstCategory.class.getSimpleName(), SecondCategory.class.getName());
-        categorizedConfig.setMatchAll(true);
-        categorizedConfig.setCaseSensitive(true);
-        CategoriesParser categoriesParser = new CategoriesParser(categorizedConfig);
-
-        // when
-        TestSelection selection = categoriesParser.getTestSelectionIfMatched(FirstAndSecondCategorizedClass.class);
-
-        // then
-        Assertions.assertThat(selection).isNotEqualTo(TestSelection.NOT_MATCHED);
-    }
-
-    @Test
-    public void should_return_false_for_class_not_containing_all_of_the_set_categories_when_matching_all_and_case_sensitive() {
-        // given
-        CategorizedConfiguration categorizedConfig =
-            prepareConfig(FirstCategory.class.getSimpleName(), SecondCategory.class.getName().toLowerCase());
-        categorizedConfig.setMatchAll(true);
-        categorizedConfig.setCaseSensitive(true);
-        CategoriesParser categoriesParser = new CategoriesParser(categorizedConfig);
-
-        // when
-        TestSelection selection = categoriesParser.getTestSelectionIfMatched(FirstAndSecondCategorizedClass.class);
-
-        // then
-        Assertions.assertThat(selection).isEqualTo(TestSelection.NOT_MATCHED);
-    }
-
     private CategorizedConfiguration prepareConfig(String... categories) {
         CategorizedConfiguration categorizedConfig = new CategorizedConfiguration();
         categorizedConfig.setCategories(categories);
+        categorizedConfig.setExcludedCategories(new String[0]);
         return categorizedConfig;
     }
 }

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/CategorizedTestsDetectorTest.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/CategorizedTestsDetectorTest.java
@@ -2,24 +2,32 @@ package org.arquillian.smart.testing.strategies.categorized;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import org.arquillian.smart.testing.TestSelection;
 import org.arquillian.smart.testing.configuration.Configuration;
 import org.arquillian.smart.testing.configuration.ConfigurationLoader;
-import org.arquillian.smart.testing.strategies.categorized.project.categories.FirstAndSecondCategorizedClass;
-import org.arquillian.smart.testing.strategies.categorized.project.categories.FirstCategorizedClass;
 import org.arquillian.smart.testing.strategies.categorized.project.categories.FirstCategory;
-import org.arquillian.smart.testing.strategies.categorized.project.categories.NonCategorizedClass;
+import org.arquillian.smart.testing.strategies.categorized.project.categories.FirstCategorizedClass;
 import org.arquillian.smart.testing.strategies.categorized.project.categories.SecondCategory;
+import org.arquillian.smart.testing.strategies.categorized.project.categories.FirstAndSecondCategorizedClass;
+import org.arquillian.smart.testing.strategies.categorized.project.categories.ThirdCategory;
 import org.arquillian.smart.testing.strategies.categorized.project.categories.ThirdCategorizedClass;
+import org.arquillian.smart.testing.strategies.categorized.project.categories.NonCategorizedClass;
 import org.arquillian.smart.testing.strategies.categorized.project.categories.WithCategorizedMethodsClass;
+import org.arquillian.smart.testing.strategies.categorized.project.categories.Included;
+import org.arquillian.smart.testing.strategies.categorized.project.categories.Excluded;
+import org.arquillian.smart.testing.strategies.categorized.project.categories.WithExcludedMethodClass;
+import org.arquillian.smart.testing.strategies.categorized.project.categories.WithIncludedAndExcludedCategoriesOnMethodsClass;
 import org.arquillian.smart.testing.strategies.categorized.project.tags.FastTaggedClass;
-import org.arquillian.smart.testing.strategies.categorized.project.tags.FirstAndSecondTaggedClass;
 import org.arquillian.smart.testing.strategies.categorized.project.tags.FirstTaggedClass;
+import org.arquillian.smart.testing.strategies.categorized.project.tags.FirstAndSecondTaggedClass;
 import org.arquillian.smart.testing.strategies.categorized.project.tags.NonTaggedClass;
 import org.arquillian.smart.testing.strategies.categorized.project.tags.ThirdTaggedClass;
 import org.arquillian.smart.testing.strategies.categorized.project.tags.WithTaggedMethodsClass;
+import org.arquillian.smart.testing.strategies.categorized.project.tags.WithExcludedTagClass;
 import org.assertj.core.api.JUnitSoftAssertions;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -53,6 +61,34 @@ public class CategorizedTestsDetectorTest {
         categorizedConfig =
             (CategorizedConfiguration) config.getStrategyConfiguration(CATEGORIZED);
         config.getStrategiesConfiguration().add(categorizedConfig);
+    }
+
+    @Test
+    public void should_return_all_classes_and_methods_with_any_category_when_no_category_is_set() {
+        //given
+        categorizedConfig.setCategories(new String[0]);
+
+        //when
+        Collection<TestSelection> testSelection =
+            new CategorizedTestsDetector(config).selectTestsFromClasses(classesToProcess);
+
+        //then
+        assertThat(testSelection).containsTestClassSelectionsExactlyInAnyOrder(
+            classesToProcess.stream().map(this::getTestSelection).toArray(TestSelection[]::new));
+    }
+
+    @Test
+    public void should_exclude_classes_with_matching_category_when_no_included_category_is_set() {
+        //given
+        categorizedConfig.setCategories(new String[0]);
+        categorizedConfig.setExcludedCategories(new String[] {SecondCategory.class.getSimpleName()});
+
+        //when
+        Collection<TestSelection> testSelection =
+            new CategorizedTestsDetector(config).selectTestsFromClasses(Arrays.asList(FirstCategorizedClass.class,
+                FirstAndSecondCategorizedClass.class));
+        //then
+        assertThat(testSelection).containsTestClassSelectionsExactlyInAnyOrder(getTestSelection(FirstCategorizedClass.class));
     }
 
     @Test
@@ -133,24 +169,6 @@ public class CategorizedTestsDetectorTest {
             .containsTestClassSelectionsExactlyInAnyOrder(
                 getTestSelection(FastTaggedClass.class),
                 testSelectionWithMethods);
-
-    }
-
-    @Test
-    public void should_return_class_and_methods_with_both_first_and_second_category_using_match_all() {
-        // given
-        categorizedConfig.setCategories(
-            new String[] {FirstCategory.class.getSimpleName(), SecondCategory.class.getSimpleName().toLowerCase()});
-        categorizedConfig.setMatchAll(true);
-
-        // when
-        Collection<TestSelection> testSelection =
-            new CategorizedTestsDetector(config).selectTestsFromClasses(classesToProcess);
-
-        // then
-        assertThat(testSelection)
-            .containsTestClassSelectionsExactlyInAnyOrder(
-                getTestSelection(FirstAndSecondCategorizedClass.class));
     }
 
     @Test
@@ -174,43 +192,86 @@ public class CategorizedTestsDetectorTest {
     }
 
     @Test
-    public void should_return_all_classes_and_methods_with_any_category_when_no_category_is_set() {
-        // when
-        Collection<TestSelection> testSelection =
-            new CategorizedTestsDetector(config).selectTestsFromClasses(classesToProcess);
+    public void should_return_methods_without_excluded_category() {
+        //given
+        categorizedConfig.setCategories(new String[] {Included.class.getSimpleName()});
+        categorizedConfig.setExcludedCategories(new String[] {Excluded.class.getSimpleName()});
 
-        // then
+        //when
+        Collection<TestSelection> testSelection =
+            new CategorizedTestsDetector(config).selectTestsFromClasses(
+                Collections.singleton(WithExcludedMethodClass.class));
+
+        //then
         TestSelection testSelectionWithMethods =
-            getTestSelectionWithMethods(WithCategorizedMethodsClass.class, "testWithFirstCategory",
-                "testWithSecondCategory", "testWithThirdCategory");
-        assertThat(testSelection)
-            .containsTestClassSelectionsExactlyInAnyOrder(
-                getTestSelection(ThirdCategorizedClass.class),
-                getTestSelection(FirstAndSecondCategorizedClass.class),
-                getTestSelection(FirstCategorizedClass.class),
-                testSelectionWithMethods);
+            getTestSelectionWithMethods(WithExcludedMethodClass.class, "testWithoutExcludedCategory");
+
+        assertThat(testSelection).containsTestClassSelectionsExactlyInAnyOrder(testSelectionWithMethods);
     }
 
     @Test
-    public void should_return_classes_and_methods_without_first_category_when_reversed_is_used() {
-        // given
-        categorizedConfig.setCategories(
-            new String[] {FirstCategory.class.getSimpleName()});
-        categorizedConfig.setReversed(true);
+    public void should_return_methods_without_excluded_tag() {
+        //given
+        categorizedConfig.setCategories(new String[] {"included"});
+        categorizedConfig.setExcludedCategories(new String[] {"excluded"});
 
-        // when
+        //when
         Collection<TestSelection> testSelection =
-            new CategorizedTestsDetector(config).selectTestsFromClasses(classesToProcess);
+            new CategorizedTestsDetector(config).selectTestsFromClasses(
+                Collections.singleton(WithExcludedTagClass.class));
 
-        // then
+        //then
         TestSelection testSelectionWithMethods =
-            getTestSelectionWithMethods(WithCategorizedMethodsClass.class, "testWithSecondCategory",
-                "testWithThirdCategory", "testWithoutCategory");
-        assertThat(testSelection)
-            .containsTestClassSelectionsExactlyInAnyOrder(
-                getTestSelection(ThirdCategorizedClass.class),
-                getTestSelection(NonCategorizedClass.class),
-                testSelectionWithMethods);
+            getTestSelectionWithMethods(WithExcludedTagClass.class, "includedMethod");
+
+        assertThat(testSelection).containsTestClassSelectionsExactlyInAnyOrder(testSelectionWithMethods);
+    }
+
+    @Test
+    public void should_return_class_when_no_methods_are_matched_to_be_excluded() {
+        //given
+        categorizedConfig.setCategories(new String[] {FirstCategory.class.getSimpleName()});
+        categorizedConfig.setExcludedCategories(new String[] {Excluded.class.getSimpleName()});
+
+        //when
+        Collection<TestSelection> testSelection =
+            new CategorizedTestsDetector(config).selectTestsFromClasses(
+                Collections.singleton(FirstCategorizedClass.class));
+
+        assertThat(testSelection).containsTestClassSelectionsExactlyInAnyOrder(
+            getTestSelection(FirstCategorizedClass.class));
+    }
+
+    @Test
+    public void should_exclude_test_class_when_excluding_single_category_of_many() {
+        //given
+        categorizedConfig.setCategories(new String[] {FirstCategory.class.getSimpleName()});
+        categorizedConfig.setExcludedCategories(new String[] {SecondCategory.class.getSimpleName()});
+
+        //when
+        Collection<TestSelection> testSelection =
+            new CategorizedTestsDetector(config).selectTestsFromClasses(
+                Collections.singleton(FirstAndSecondCategorizedClass.class));
+
+        Assert.assertTrue(testSelection.isEmpty());
+    }
+
+    @Test
+    public void should_exclude_methods_when_matched_and_class_is_not_annotated() {
+        //given
+        categorizedConfig.setCategories(new String[] {FirstCategory.class.getSimpleName()});
+        categorizedConfig.setExcludedCategories(
+            new String[] {SecondCategory.class.getSimpleName(), ThirdCategory.class.getSimpleName()});
+
+        //when
+        Collection<TestSelection> testSelection =
+            new CategorizedTestsDetector(config).selectTestsFromClasses(
+                Collections.singleton(WithIncludedAndExcludedCategoriesOnMethodsClass.class));
+
+        TestSelection testSelectionWithMethods =
+            getTestSelectionWithMethods(WithIncludedAndExcludedCategoriesOnMethodsClass.class, "testWithFirstCategory");
+
+        assertThat(testSelection).containsTestClassSelectionsExactlyInAnyOrder(testSelectionWithMethods);
     }
 
     private TestSelection getTestSelection(Class clazz) {

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/TagsParserTest.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/TagsParserTest.java
@@ -12,20 +12,8 @@ import org.junit.Test;
 public class TagsParserTest {
 
     @Test
-    public void should_return_true_for_class_containing_tag_when_no_category_set() {
-        // given
-        CategorizedConfiguration categorizedConfig = prepareConfig();
-        TagsParser tagsParser = new TagsParser(categorizedConfig);
+    public void should_return_true_for_class_containing_no_tag_when_no_category_set() {
 
-        // when
-        TestSelection selection = tagsParser.getTestSelectionIfMatched(FirstTaggedClass.class);
-
-        // then
-        Assertions.assertThat(selection).isNotEqualTo(TestSelection.NOT_MATCHED);
-    }
-
-    @Test
-    public void should_return_false_for_class_containing_no_tag_when_no_category_set() {
         // given
         CategorizedConfiguration categorizedConfig = prepareConfig();
         TagsParser tagsParser = new TagsParser(categorizedConfig);
@@ -34,7 +22,7 @@ public class TagsParserTest {
         TestSelection selection = tagsParser.getTestSelectionIfMatched(NonTaggedClass.class);
 
         // then
-        Assertions.assertThat(selection).isEqualTo(TestSelection.NOT_MATCHED);
+        Assertions.assertThat(selection).isNotEqualTo(TestSelection.NOT_MATCHED);
     }
 
     @Test
@@ -80,36 +68,6 @@ public class TagsParserTest {
     }
 
     @Test
-    public void should_return_true_for_class_containing_all_of_the_set_categories_when_matching_all() {
-        // given
-        CategorizedConfiguration categorizedConfig =
-            prepareConfig("first", "second");
-        categorizedConfig.setMatchAll(true);
-        TagsParser tagsParser = new TagsParser(categorizedConfig);
-
-        // when
-        TestSelection selection = tagsParser.getTestSelectionIfMatched(FirstAndSecondTaggedClass.class);
-
-        // then
-        Assertions.assertThat(selection).isNotEqualTo(TestSelection.NOT_MATCHED);
-    }
-
-    @Test
-    public void should_return_false_for_class_not_containing_all_of_the_set_categories_when_matching_all() {
-        // given
-        CategorizedConfiguration categorizedConfig =
-            prepareConfig("first", "second");
-        categorizedConfig.setMatchAll(true);
-        TagsParser tagsParser = new TagsParser(categorizedConfig);
-
-        // when
-        TestSelection selection = tagsParser.getTestSelectionIfMatched(FirstTaggedClass.class);
-
-        // then
-        Assertions.assertThat(selection).isEqualTo(TestSelection.NOT_MATCHED);
-    }
-
-    @Test
     public void should_return_false_for_class_not_containing_any_of_the_set_tags_when_case_sensitive() {
         // given
         CategorizedConfiguration categorizedConfig = prepareConfig("First",
@@ -124,42 +82,10 @@ public class TagsParserTest {
         Assertions.assertThat(selection).isEqualTo(TestSelection.NOT_MATCHED);
     }
 
-    @Test
-    public void should_return_true_for_class_containing_all_of_the_set_tags_when_matching_all_and_case_sensitive() {
-        // given
-        CategorizedConfiguration categorizedConfig =
-            prepareConfig("first", "second");
-        categorizedConfig.setMatchAll(true);
-        categorizedConfig.setCaseSensitive(true);
-        TagsParser tagsParser = new TagsParser(categorizedConfig);
-
-        // when
-        TestSelection selection = tagsParser.getTestSelectionIfMatched(FirstAndSecondTaggedClass.class);
-
-        // then
-        Assertions.assertThat(selection).isNotEqualTo(TestSelection.NOT_MATCHED);
-    }
-
-    @Test
-    public void should_return_false_for_class_not_containing_all_of_the_set_tags_when_matching_all_and_case_sensitive() {
-        // given
-        CategorizedConfiguration categorizedConfig =
-            prepareConfig("first", "Second");
-        categorizedConfig.setMatchAll(true);
-        categorizedConfig.setCaseSensitive(true);
-        TagsParser tagsParser = new TagsParser(categorizedConfig);
-
-        // when
-        TestSelection selection = tagsParser.getTestSelectionIfMatched(FirstAndSecondTaggedClass.class);
-
-        // then
-        Assertions.assertThat(selection).isEqualTo(TestSelection.NOT_MATCHED);
-    }
-
     private CategorizedConfiguration prepareConfig(String... categories) {
         CategorizedConfiguration categorizedConfig = new CategorizedConfiguration();
         categorizedConfig.setCategories(categories);
+        categorizedConfig.setExcludedCategories(new String[0]);
         return categorizedConfig;
     }
-
 }

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/categories/Excluded.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/categories/Excluded.java
@@ -1,0 +1,4 @@
+package org.arquillian.smart.testing.strategies.categorized.project.categories;
+
+public class Excluded {
+}

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/categories/Included.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/categories/Included.java
@@ -1,0 +1,4 @@
+package org.arquillian.smart.testing.strategies.categorized.project.categories;
+
+public class Included {
+}

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/categories/WithExcludedMethodClass.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/categories/WithExcludedMethodClass.java
@@ -1,0 +1,20 @@
+package org.arquillian.smart.testing.strategies.categorized.project.categories;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(Included.class)
+public class WithExcludedMethodClass {
+
+    @Test
+    public void testWithoutExcludedCategory() {
+
+    }
+
+    @Test
+    @Category(Excluded.class)
+    public void testWithExcludedCategory() {
+
+    }
+
+}

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/categories/WithIncludedAndExcludedCategoriesOnMethodsClass.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/categories/WithIncludedAndExcludedCategoriesOnMethodsClass.java
@@ -1,0 +1,32 @@
+package org.arquillian.smart.testing.strategies.categorized.project.categories;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+public class WithIncludedAndExcludedCategoriesOnMethodsClass {
+
+    @Test
+    @Category(FirstCategory.class)
+    public void testWithFirstCategory() {
+
+    }
+
+    @Test
+    @Category({FirstCategory.class, SecondCategory.class})
+    public void testWithFirstAndSecondCategory() {
+
+    }
+
+    @Test
+    @Category({FirstCategory.class, ThirdCategory.class})
+    public void testWithFirstAndThirdCategory() {
+
+    }
+
+    @Test
+    @Category({SecondCategory.class, ThirdCategory.class})
+    public void testWithSecondAndThirdCategory() {
+
+    }
+
+}

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/tags/WithExcludedTagClass.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/project/tags/WithExcludedTagClass.java
@@ -1,0 +1,19 @@
+package org.arquillian.smart.testing.strategies.categorized.project.tags;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
+
+@Tag("included")
+public class WithExcludedTagClass {
+
+    @Test
+    public void includedMethod() {
+
+    }
+
+    @Tag("excluded")
+    @Test
+    public void excludedMethod() {
+
+    }
+}


### PR DESCRIPTION
<!-- 
Many thanks for contributing to Arquillian! Together we can make the testing world better.

Please tell us what this PR brings following the template we provided. 
And don't forget to link to the issue (or create one if there is none).

If you are still working on the change please prefix this pull request title with "WIP"

YOU CAN DELETE THIS COMMENT :)
-->

#### Short description of what this resolves:

This PR implements the possibility to manually exclude test classes/methods from execution based on their category (see #310 )

#### Changes proposed in this pull request:

- added the ``excludedCategories`` into the ``categorized`` configuration
- changed the ``AbstractParser`` logic to support this feature
- added the ``CategorizedTestSelection`` which serves as an information holder to the categorized selection, which then transforms to the ``TestSelection`` using the ``toTestSelection()`` method.


Fixes #
