### PR TITLE
feat(#306): failed strategy selects the particular failed test methods

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -111,6 +111,17 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/core/src/main/java/org/arquillian/smart/testing/TestSelection.java
+++ b/core/src/main/java/org/arquillian/smart/testing/TestSelection.java
@@ -3,9 +3,11 @@ package org.arquillian.smart.testing;
 import java.lang.reflect.Array;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Objects;
 
 import static java.lang.String.format;
@@ -82,7 +84,20 @@ public class TestSelection {
 
         final String[] appliedStrategies = getAppliedStrategies().toArray(new String[getAppliedStrategies().size()]);
         final String[] otherAppliedStrategies = other.getAppliedStrategies().toArray(new String[other.getAppliedStrategies().size()]);
-        return new TestSelection(getClassName(), concat(appliedStrategies, otherAppliedStrategies));
+
+        List<String> mergedListOfMethods = getMergedTestMethods(other);
+
+        return new TestSelection(getClassName(), mergedListOfMethods, concat(appliedStrategies, otherAppliedStrategies));
+    }
+
+    private List<String> getMergedTestMethods(TestSelection other) {
+        if (getTestMethodNames().size() == 0 || other.getTestMethodNames().size() == 0) {
+            return new ArrayList<>();
+        }
+        final String[] testMethodNames = getTestMethodNames().toArray(new String[getTestMethodNames().size()]);
+        final String[] otherTestMethodNames =
+            other.getTestMethodNames().toArray(new String[other.getTestMethodNames().size()]);
+        return Arrays.asList(concat(testMethodNames, otherTestMethodNames));
     }
 
     private String[] concat(String[] first, String[] second) {

--- a/core/src/main/java/org/arquillian/smart/testing/TestSelection.java
+++ b/core/src/main/java/org/arquillian/smart/testing/TestSelection.java
@@ -91,7 +91,7 @@ public class TestSelection {
     }
 
     private List<String> getMergedTestMethods(TestSelection other) {
-        if (getTestMethodNames().size() == 0 || other.getTestMethodNames().size() == 0) {
+        if (getTestMethodNames().isEmpty() || other.getTestMethodNames().isEmpty()) {
             return new ArrayList<>();
         }
         final String[] testMethodNames = getTestMethodNames().toArray(new String[getTestMethodNames().size()]);

--- a/core/src/main/java/org/arquillian/smart/testing/spi/TestResult.java
+++ b/core/src/main/java/org/arquillian/smart/testing/spi/TestResult.java
@@ -14,8 +14,8 @@ public class TestResult {
         this.result = result;
     }
 
-    public TestResult(String className, Result result) {
-        this(className, "", 0f, result);
+    public TestResult(String className, String testMethod, Result result) {
+        this(className, testMethod, 0f, result);
     }
 
     public TestResult(String className, String testMethod, Float testDuration) {

--- a/core/src/test/java/org/arquillian/smart/testing/TestSelectionTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/TestSelectionTest.java
@@ -1,5 +1,6 @@
 package org.arquillian.smart.testing;
 
+import java.util.Arrays;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -69,6 +70,33 @@ public class TestSelectionTest {
 
         // then
         assertThat(mergedTestSelection.getAppliedStrategies()).containsExactly(AFFECTED, NEW);
+    }
+
+    @Test
+    public void should_merge_test_methods_selection_when_in_both_are_specified() {
+        // given
+        final String className = "TestClass.java";
+        final TestSelection testSelection = new TestSelection(className, Arrays.asList("firstTestMethod"), AFFECTED);
+
+        // when
+        final TestSelection mergedTestSelection =
+            testSelection.merge(new TestSelection(className, Arrays.asList("secondTestMethod"), NEW));
+
+        // then
+        assertThat(mergedTestSelection.getTestMethodNames()).containsExactly("firstTestMethod", "secondTestMethod");
+    }
+
+    @Test
+    public void should_return_merged_test_selection_without_methods_when_the_other_one_does_not_contain_any() {
+        // given
+        final String className = "TestClass.java";
+        final TestSelection testSelection = new TestSelection(className, Arrays.asList("firstTestMethod"), AFFECTED);
+
+        // when
+        final TestSelection mergedTestSelection = testSelection.merge(new TestSelection(className, NEW));
+
+        // then
+        assertThat(mergedTestSelection.getTestMethodNames()).isEmpty();
     }
 
     private Path getPath(String fileName) {

--- a/core/src/test/java/org/arquillian/smart/testing/custom/assertions/TestSelectionCollectionAssert.java
+++ b/core/src/test/java/org/arquillian/smart/testing/custom/assertions/TestSelectionCollectionAssert.java
@@ -1,4 +1,4 @@
-package org.arquillian.smart.testing.strategies.categorized.custom.assertions;
+package org.arquillian.smart.testing.custom.assertions;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/core/src/test/java/org/arquillian/smart/testing/impl/TestStrategyApplierUsingPropertyTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/impl/TestStrategyApplierUsingPropertyTest.java
@@ -1,7 +1,5 @@
 package org.arquillian.smart.testing.impl;
 
-import java.io.File;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;

--- a/docs/configfile.adoc
+++ b/docs/configfile.adoc
@@ -218,3 +218,12 @@ a| reversed
 a| Sets that the selection should be reversed - all classes that don't match the categories will be selected. (default is false)
 |===
 
+==== Failed Configuration Options
+[cols="2,6", options="header"]
+|===
+|Field | Description
+a| methods
+a| Sets if the strategy should select the particular failed test methods or take the whole classes. (default is true)
+
+|===
+

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -196,7 +196,7 @@ IMPORTANT: Location is relative to current project/module. This means that if yo
 
 ==== Failed
 
-`Failed` strategy just gets all tests that failed from previous executions and mark them as *important* tests to run first (_ordering_) or not filtered (_selecting_).
+`Failed` strategy just gets all tests that failed from previous executions and mark them as *important* tests to run first (_ordering_) or not filtered (_selecting_). When the _selecting_ mode is used then, by default, the resolution is on the test methods level (selects the particular failed test methods) - you can disable it by setting the parameter `-Dconst:strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/FailedConfiguration.java[name="SMART_TESTING_FAILED_METHODS"]=false`
 
 This strategy uses the _JUnit_ XML https://github.com/apache/maven-surefire/blob/master/maven-surefire-plugin/src/site/resources/xsd/surefire-test-report.xsd[report] for reading past executions.
 All reports from previous local build are automatically copied by the maven extension to a temp directory `${project.directory}/const:core/src/main/java/org/arquillian/smart/testing/hub/storage/local/DuringExecutionLocalStorage.java[name="SMART_TESTING_WORKING_DIRECTORY_NAME"]/const:core/src/main/java/org/arquillian/smart/testing/hub/storage/local/DuringExecutionLocalStorage.java[name="TEMPORARY_SUBDIRECTORY"]/const:core/src/main/java/org/arquillian/smart/testing/hub/storage/local/TemporaryInternalFiles.java[name="TEMP_REPORT_DIR"]` and when the build is finished the directory is removed.

--- a/docs/refcard.adoc
+++ b/docs/refcard.adoc
@@ -112,6 +112,11 @@ a| `const:strategies/categorized/src/main/java/org/arquillian/smart/testing/stra
 | Sets that the selection should be reversed - all classes that don't match the categories will be selected.
 a| `false`
 a|`categorized`
+
+a| `const:strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/FailedConfiguration.java[name="SMART_TESTING_FAILED_METHODS"]`
+| Sets if the strategy should select the particular failed test methods or take the whole classes
+a| `true`
+a|`failed`
 |===
 
 === Getting insights of the execution

--- a/docs/registering-strategies.adoc
+++ b/docs/registering-strategies.adoc
@@ -53,7 +53,6 @@ include::../strategies/failed/src/main/java/org/arquillian/smart/testing/strateg
 ----
 <1> Method that returns list of tests to execute based on the provided set of fully qualified class names of tests that were previously selected to be executed.
 <2> Method that returns list of tests to execute based on the provided set of tests classes that were previously selected to be executed.
-<3> `TestSelection` requires fully qualified test class name and the strategy where is calculated
 
 ==== ChangeStorage, ChangeResolver and TestResultParser
 

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/failed/LocalChangesFailedTestsSelectionExecutionFunctionalTest.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/failed/LocalChangesFailedTestsSelectionExecutionFunctionalTest.java
@@ -47,14 +47,14 @@ public class LocalChangesFailedTestsSelectionExecutionFunctionalTest {
             .enable();
 
         final Collection<TestResult> expectedTestResults =
-            project.applyAsLocalChanges("fix: Introduces error by changing return value");
+            project.applyAsLocalChanges("fix: Introduces error in test method by changing return value");
 
 
         // when
         final TestResults actualTestResults = project.build("container/impl-base").run();
 
         // then
-        softly.assertThat(actualTestResults.accumulatedPerTestClass())
+        softly.assertThat(actualTestResults.getTestResults())
             .containsAll(expectedTestResults)
             .hasSameSizeAs(expectedTestResults);
 

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,13 @@
         <version>${version.arquillian.spacelift}</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>org.arquillian.smart.testing</groupId>
+        <artifactId>core</artifactId>
+        <version>${project.version}</version>
+        <classifier>tests</classifier>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/strategies/categorized/pom.xml
+++ b/strategies/categorized/pom.xml
@@ -31,6 +31,13 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.arquillian.smart.testing</groupId>
+      <artifactId>core</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/strategies/categorized/pom.xml
+++ b/strategies/categorized/pom.xml
@@ -34,7 +34,6 @@
     <dependency>
       <groupId>org.arquillian.smart.testing</groupId>
       <artifactId>core</artifactId>
-      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/CategorizedTestsDetectorTest.java
+++ b/strategies/categorized/src/test/java/org/arquillian/smart/testing/strategies/categorized/CategorizedTestsDetectorTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import static org.arquillian.smart.testing.strategies.categorized.CategorizedTestsDetector.CATEGORIZED;
-import static org.arquillian.smart.testing.strategies.categorized.custom.assertions.TestSelectionCollectionAssert.assertThat;
+import static org.arquillian.smart.testing.custom.assertions.TestSelectionCollectionAssert.assertThat;
 
 public class CategorizedTestsDetectorTest {
 

--- a/strategies/failed/pom.xml
+++ b/strategies/failed/pom.xml
@@ -36,6 +36,13 @@
       <artifactId>junit-test-result-parser</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.arquillian.smart.testing</groupId>
+      <artifactId>core</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/strategies/failed/pom.xml
+++ b/strategies/failed/pom.xml
@@ -39,7 +39,6 @@
     <dependency>
       <groupId>org.arquillian.smart.testing</groupId>
       <artifactId>core</artifactId>
-      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/FailedConfiguration.java
+++ b/strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/FailedConfiguration.java
@@ -9,6 +9,10 @@ import static org.arquillian.smart.testing.strategies.failed.FailedTestsDetector
 
 public class FailedConfiguration implements StrategyConfiguration {
 
+
+    private static final String SMART_TESTING_FAILED_METHODS = "smart.testing.failed.methods";
+    private boolean methods;
+
     @Override
     public String name() {
         return FAILED;
@@ -16,6 +20,17 @@ public class FailedConfiguration implements StrategyConfiguration {
 
     @Override
     public List<ConfigurationItem> registerConfigurationItems() {
-        return new ArrayList<>();
+        ArrayList<ConfigurationItem> items = new ArrayList<>();
+        items.add(new ConfigurationItem("methods", SMART_TESTING_FAILED_METHODS, true));
+        return items;
+    }
+
+
+    public boolean isMethods() {
+        return methods;
+    }
+
+    public void setMethods(boolean methods) {
+        this.methods = methods;
     }
 }

--- a/strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/FailedTestsDetector.java
+++ b/strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/FailedTestsDetector.java
@@ -1,10 +1,10 @@
 package org.arquillian.smart.testing.strategies.failed;
 //tag::documentation[]
+
 import java.io.File;
 import java.util.Collection;
-import java.util.LinkedHashSet;
-import java.util.stream.Collectors;
 import org.arquillian.smart.testing.TestSelection;
+import org.arquillian.smart.testing.configuration.Configuration;
 import org.arquillian.smart.testing.spi.JavaSPILoader;
 import org.arquillian.smart.testing.spi.TestExecutionPlanner;
 
@@ -13,9 +13,11 @@ public class FailedTestsDetector implements TestExecutionPlanner {
     static final String FAILED = "failed";
 
     private final File projectDir;
+    private final FailedConfiguration strategyConfig;
 
-    public FailedTestsDetector(File projectDir) {
+    public FailedTestsDetector(File projectDir, Configuration configuration) {
         this.projectDir = projectDir;
+        strategyConfig = (FailedConfiguration) configuration.getStrategyConfiguration(FAILED);
     }
 
     @Override
@@ -29,11 +31,8 @@ public class FailedTestsDetector implements TestExecutionPlanner {
     }
 
     public Collection<TestSelection> getTests() {
-        TestReportLoader testReportLoader = new InProjectTestReportLoader(new JavaSPILoader(), projectDir);
-        return testReportLoader.loadTestResults()
-            .stream()
-            .map(result -> new TestSelection(result, getName())) // <3>
-            .collect(Collectors.toCollection(LinkedHashSet::new));
+        InProjectTestReportLoader reportLoader = new InProjectTestReportLoader(new JavaSPILoader(), projectDir);
+        return TestResultsFilter.getFailedTests(strategyConfig, reportLoader.loadTestResults());
     }
 
     @Override

--- a/strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/FailedTestsDetectorFactory.java
+++ b/strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/FailedTestsDetectorFactory.java
@@ -23,7 +23,7 @@ public class FailedTestsDetectorFactory implements TestExecutionPlannerFactory {
 
     @Override
     public TestExecutionPlanner create(File projectDir, TestVerifier verifier, Configuration configuration) {
-        return new FailedTestsDetector(projectDir);
+        return new FailedTestsDetector(projectDir, configuration);
     } // <2>
 
     @Override

--- a/strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/InProjectTestReportLoader.java
+++ b/strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/InProjectTestReportLoader.java
@@ -30,9 +30,9 @@ public class InProjectTestReportLoader implements TestReportLoader {
     }
 
     @Override
-    public Set<String> loadTestResults() {
+    public Set<TestResult> loadTestResults() {
 
-        final Set<String> testResults = new HashSet<>();
+        final Set<TestResult> testResults = new HashSet<>();
 
         final Path reportDir = TemporaryInternalFiles.createTestReportDirAction(rootDirectory).getPath();
 
@@ -40,7 +40,7 @@ public class InProjectTestReportLoader implements TestReportLoader {
 
             try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(reportDir)) {
 
-                final Set<String> testFailures = StreamSupport.stream(directoryStream.spliterator(), false)
+                final Set<TestResult> testFailures = StreamSupport.stream(directoryStream.spliterator(), false)
                     .map(path -> {
                         try {
                             return Files.newInputStream(path);
@@ -57,8 +57,6 @@ public class InProjectTestReportLoader implements TestReportLoader {
                         return testResultParser.get().parse(is);
                     })
                     .flatMap(Set::stream)
-                    .filter(TestResult::isFailing)
-                    .map(TestResult::getClassName)
                     .collect(Collectors.toSet());
 
                 testResults.addAll(testFailures);

--- a/strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/TestReportLoader.java
+++ b/strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/TestReportLoader.java
@@ -1,13 +1,14 @@
 package org.arquillian.smart.testing.strategies.failed;
 
 import java.util.Set;
+import org.arquillian.smart.testing.spi.TestResult;
 
 public interface TestReportLoader {
 
     /**
-     * Returns all test class names that contains failures.
-     * @return Test classes with failing methods.
+     * Returns all test results
+     * @return Loaded test results
      */
-    Set<String> loadTestResults();
+    Set<TestResult> loadTestResults();
 
 }

--- a/strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/TestResultsFilter.java
+++ b/strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/TestResultsFilter.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
 import org.arquillian.smart.testing.TestSelection;
 import org.arquillian.smart.testing.spi.TestResult;
 
-public class TestResultsFilter {
+class TestResultsFilter {
 
     static Collection<TestSelection> getFailedTests(FailedConfiguration strategyConfig, Set<TestResult> testResults) {
 

--- a/strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/TestResultsFilter.java
+++ b/strategies/failed/src/main/java/org/arquillian/smart/testing/strategies/failed/TestResultsFilter.java
@@ -1,0 +1,34 @@
+package org.arquillian.smart.testing.strategies.failed;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.arquillian.smart.testing.TestSelection;
+import org.arquillian.smart.testing.spi.TestResult;
+
+public class TestResultsFilter {
+
+    static Collection<TestSelection> getFailedTests(FailedConfiguration strategyConfig, Set<TestResult> testResults) {
+
+        return testResults
+            .stream()
+            .filter(TestResult::isFailing)
+            .map(testResult -> createTestSelection(strategyConfig, testResult))
+            .collect(
+                Collectors.toMap(TestSelection::getClassName, Function.identity(), TestSelection::merge,
+                    LinkedHashMap::new))
+            .values();
+    }
+
+    private static TestSelection createTestSelection(FailedConfiguration strategyConfig, TestResult testResult) {
+        if (strategyConfig.isMethods()) {
+            return new TestSelection(testResult.getClassName(), Arrays.asList(testResult.getTestMethod()),
+                FailedTestsDetector.FAILED);
+        } else {
+            return new TestSelection(testResult.getClassName(), FailedTestsDetector.FAILED);
+        }
+    }
+}

--- a/strategies/failed/src/test/java/org/arquillian/smart/testing/strategies/failed/FailedResultsFilterTest.java
+++ b/strategies/failed/src/test/java/org/arquillian/smart/testing/strategies/failed/FailedResultsFilterTest.java
@@ -1,0 +1,94 @@
+package org.arquillian.smart.testing.strategies.failed;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import org.arquillian.smart.testing.TestSelection;
+import org.arquillian.smart.testing.configuration.ConfigurationLoader;
+import org.arquillian.smart.testing.spi.TestResult;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.arquillian.smart.testing.custom.assertions.TestSelectionCollectionAssert.assertThat;
+import static org.arquillian.smart.testing.strategies.failed.FailedTestsDetector.FAILED;
+
+public class FailedResultsFilterTest {
+
+    private FailedConfiguration config;
+
+    @Before
+    public void prepareConfig() {
+        config = (FailedConfiguration) ConfigurationLoader.load(new File("")).getStrategyConfiguration(FAILED);
+    }
+
+    @Test
+    public void should_return_selections_with_failed_method() {
+        // given
+        Set<TestResult> results = new HashSet<>();
+        results.add(new TestResult("FirstTestClass", "failedMethod", TestResult.Result.FAILURE));
+        results.add(new TestResult("FirstTestClass", "passedMethod", TestResult.Result.PASSED));
+        results.add(new TestResult("SecondTestClass", "failedMethod", TestResult.Result.FAILURE));
+        results.add(new TestResult("SecondTestClass", "passedMethod", TestResult.Result.PASSED));
+
+        // when
+        Collection<TestSelection> failedTests = TestResultsFilter.getFailedTests(config, results);
+
+        // then
+        assertThat(failedTests).containsTestClassSelectionsExactlyInAnyOrder(
+            new TestSelection("FirstTestClass", Arrays.asList("failedMethod"), FAILED),
+            new TestSelection("SecondTestClass", Arrays.asList("failedMethod"), FAILED));
+    }
+
+    @Test
+    public void should_not_return_any_selection_as_all_are_passed() {
+        // given
+        Set<TestResult> results = new HashSet<>();
+        results.add(new TestResult("TestClass", "firstPassedMethod", TestResult.Result.PASSED));
+        results.add(new TestResult("TestClass", "secondPassedMethod", TestResult.Result.PASSED));
+
+        // when
+        Collection<TestSelection> failedTests = TestResultsFilter.getFailedTests(config, results);
+
+        // then
+        Assertions.assertThat(failedTests).isEmpty();
+    }
+
+    @Test
+    public void should_merge_selections_for_multiple_failed_methods_within_one_class() {
+        // given
+        Set<TestResult> results = new HashSet<>();
+        results.add(new TestResult("FirstTestClass", "firstFailedMethod", TestResult.Result.FAILURE));
+        results.add(new TestResult("FirstTestClass", "secondFailedMethod", TestResult.Result.FAILURE));
+        results.add(new TestResult("FirstTestClass", "thirdFailedMethod", TestResult.Result.FAILURE));
+        results.add(new TestResult("FirstTestClass", "passedMethod", TestResult.Result.PASSED));
+        results.add(new TestResult("SecondTestClass", "failedMethod", TestResult.Result.FAILURE));
+        results.add(new TestResult("SecondTestClass", "passedMethod", TestResult.Result.PASSED));
+
+        // when
+        Collection<TestSelection> failedTests = TestResultsFilter.getFailedTests(config, results);
+
+        // then
+        assertThat(failedTests).containsTestClassSelectionsExactlyInAnyOrder(
+            new TestSelection("FirstTestClass",
+                Arrays.asList("firstFailedMethod", "secondFailedMethod", "thirdFailedMethod"), FAILED),
+            new TestSelection("SecondTestClass", Arrays.asList("failedMethod"), FAILED));
+    }
+
+    @Test
+    public void should_return_selections_without_methods_specified_when_methods_resolution_in_config_is_disabled() {
+        // given
+        Set<TestResult> results = new HashSet<>();
+        results.add(new TestResult("FirstTestClass", "firstFailedMethod", TestResult.Result.FAILURE));
+        results.add(new TestResult("FirstTestClass", "secondFailedMethod", TestResult.Result.FAILURE));
+        config.setMethods(false);
+
+        // when
+        Collection<TestSelection> failedTests = TestResultsFilter.getFailedTests(config, results);
+
+        // then
+        assertThat(failedTests).containsTestClassSelectionsExactlyInAnyOrder(new TestSelection("FirstTestClass", FAILED));
+    }
+}

--- a/strategies/failed/src/test/java/org/arquillian/smart/testing/strategies/failed/InProjectTestReportLoaderTest.java
+++ b/strategies/failed/src/test/java/org/arquillian/smart/testing/strategies/failed/InProjectTestReportLoaderTest.java
@@ -2,6 +2,7 @@ package org.arquillian.smart.testing.strategies.failed;
 
 import java.util.Set;
 import org.arquillian.smart.testing.spi.JavaSPILoader;
+import org.arquillian.smart.testing.spi.TestResult;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -15,11 +16,15 @@ public class InProjectTestReportLoaderTest {
             new InProjectTestReportLoader(new JavaSPILoader(), "src/test/resources");
 
         // when
-        final Set<String> testClassesWithFailingCases = surefireInProjectTestReportLoader.loadTestResults();
+        final Set<TestResult> testClassesWithFailingCases = surefireInProjectTestReportLoader.loadTestResults();
 
         // then
         assertThat(testClassesWithFailingCases)
-            .containsExactly("org.arquillian.smart.testing.strategies.affected.ClassDependenciesGraphTest");
+            .containsExactlyInAnyOrder(
+                new TestResult("org.arquillian.smart.testing.strategies.affected.ClassDependenciesGraphTest",
+                "should_detect_simple_test_to_execute", TestResult.Result.FAILURE),
+                new TestResult("org.arquillian.smart.testing.strategies.affected.ClassDependenciesGraphTest",
+                    "should_detect_test_with_multiple_main_classes", TestResult.Result.FAILURE));
 
     }
 


### PR DESCRIPTION
#### Short description of what this resolves:

Currently, the failed strategy selects the whole test classes no matter how many of the test methods failed in the previous run. This PR brings the support for selecting particular test methods that failed. By default, it is enabled - can be disabled using config property. 

#### Changes proposed in this pull request:

- To reuse the `TestSelectionCollectionAssert` I've moved it to the `core` module and packing it inside of the test-jar

Fixes #306 
