### PR TITLE
fix(#314): test method selection is applied only when selecting mode is used

### DIFF
--- a/core/src/main/java/org/arquillian/smart/testing/impl/TestSelector.java
+++ b/core/src/main/java/org/arquillian/smart/testing/impl/TestSelector.java
@@ -39,7 +39,10 @@ abstract class TestSelector<CLASS_INFO_TYPE> {
     protected abstract TestSelection createTestSelection(CLASS_INFO_TYPE testClass);
 
     Set<TestSelection> orderTests() {
-        final Set<TestSelection> orderedTests = new LinkedHashSet<>(selectTests());
+        final Set<TestSelection> orderedTests = new LinkedHashSet<>();
+         selectTests().stream()
+            .forEachOrdered(selection -> orderedTests.add(createSelectionWithoutMethods(selection)));
+
         getTestsToRun()
             .iterator()
             .forEachRemaining(testClass -> orderedTests.add(createTestSelection(testClass)));
@@ -76,6 +79,11 @@ abstract class TestSelector<CLASS_INFO_TYPE> {
         }
 
         return new LinkedHashSet<>(testSelections);
+    }
+
+    private TestSelection createSelectionWithoutMethods(TestSelection selection) {
+        return new TestSelection(selection.getClassName(),
+            selection.getAppliedStrategies().toArray(new String[selection.getAppliedStrategies().size()]));
     }
 
     private List<String> retrieveStrategies() {


### PR DESCRIPTION
Small explanation what I'm doing there:
The only change in the src code is this:
```java
final Set<TestSelection> orderedTests = new LinkedHashSet<>();
      selectTests().stream()
      .forEachOrdered(selection -> orderedTests.add(createSelectionWithoutMethods(selection)));
```
There are two stategies that are supporting test method selection: `failed` & `categorized`. When the `methods` parameter is used there, they select the methods to be executed and set it into the `TestSelection` object. eg:
```java
TestSelection(TestClass, {"firstTestMethod", "thirdTestMethod"}, "failed")
```
The presence of the test method names is then [checked](https://github.com/arquillian/smart-testing/blob/master/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/SmartTestingSurefireProvider.java#L80-L82) inside of our surefire provider. if there is some test method selection, then it [sets (using reflection)](https://github.com/arquillian/smart-testing/blob/master/surefire-provider/src/main/java/org/arquillian/smart/testing/surefire/provider/SmartTestingSurefireProvider.java#L173-L192) additional parameters. But this make sense only for the `selecting` mode, so in case of `ordering` mode I need to remove any potentional test method selections.
That's why, in case of `ordering` mode, I'm creating a new `TestSelection` without the methods - only with the test class and the strategy names: 
```java
private TestSelection createSelectionWithoutMethods(TestSelection selection) {
    return new TestSelection(selection.getClassName(),
        selection.getAppliedStrategies().toArray(new String[selection.getAppliedStrategies().size()]));
}
```
Fixes #314 
