### PR TITLE
fix(#316): removed unnecessary runtime dependencies from mvn-extension

### DIFF
--- a/mvn-extension/pom.xml
+++ b/mvn-extension/pom.xml
@@ -25,29 +25,6 @@
       <artifactId>known-surefire-providers</artifactId>
     </dependency>
 
-    <!--
-      This explicit include prevents us from adding new implementations dynamically,
-      for this purpose we should probably try something like Chameleon does - automatically pulling in all
-      the jars based on meta-file (e.g.json).
-       - Adding jar as below as an <extension> in <extensions.xml> does not work
-       - TODO: which classloader is in use for Maven Extensions?ow JDK 9 would affect that?
-    -->
-    <dependency>
-      <groupId>org.arquillian.smart.testing</groupId>
-      <artifactId>strategy-affected</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.arquillian.smart.testing</groupId>
-      <artifactId>strategy-changed</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.arquillian.smart.testing</groupId>
-      <artifactId>strategy-failed</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/dependencies/DependencyResolver.java
+++ b/mvn-extension/src/main/java/org/arquillian/smart/testing/mvn/ext/dependencies/DependencyResolver.java
@@ -47,7 +47,6 @@ public class DependencyResolver {
             final Dependency dependency = dependencies.get(strategy);
             model.addDependency(dependency);
         });
-        configuration.loadStrategyConfigurations(strategies);
     }
 
     public void addAsPluginDependency(Plugin plugin) {


### PR DESCRIPTION
#### Short description of what this resolves:

I've removed the runtime dependencies of the strategies from mvn-extension pom file as they are not necessary there. They are there just because of loading strategy configurations, but this can be loaded lazily when they are needed. So, we can minimize the stack of dependencies that is fetched at the very beginning of the Maven build.

Fixes #316 
