### PR TITLE
fix(#318): the variable containing map of strategy configs is dumped as well

### DIFF
--- a/core/src/main/java/org/arquillian/smart/testing/configuration/Configuration.java
+++ b/core/src/main/java/org/arquillian/smart/testing/configuration/Configuration.java
@@ -54,7 +54,7 @@ public class Configuration implements ConfigurationSection {
     private Report report;
     private Scm scm;
 
-    private Map<String, Object> strategiesConfig = new HashMap<>();
+    private Map<String, Object> rawStrategyConfigurations = new HashMap<>();
 
     private List<StrategyConfiguration> strategiesConfiguration = new ArrayList<>();
 
@@ -139,8 +139,13 @@ public class Configuration implements ConfigurationSection {
         this.strategiesConfiguration = strategiesConfiguration;
     }
 
-    public void setStrategiesConfig(Map<String, Object> strategiesConfig) {
-        this.strategiesConfig = strategiesConfig;
+    public void setRawStrategyConfigurations(Map<String, Object> rawStrategyConfigurations) {
+        this.rawStrategyConfigurations = rawStrategyConfigurations;
+    }
+
+    @SuppressWarnings("unused") // Used to map YAML data to Java Objects in snakeYAML
+    public Map<String, Object> getRawStrategyConfigurations() {
+        return rawStrategyConfigurations;
     }
 
     public String[] getCustomProviders() {
@@ -181,7 +186,7 @@ public class Configuration implements ConfigurationSection {
     private StrategyConfiguration loadStrategyConfiguration(StrategyConfiguration strategyConfiguration) {
         final Class<StrategyConfiguration> strategyConfigurationClass =
             (Class<StrategyConfiguration>) strategyConfiguration.getClass();
-        final Object strategyConfig = strategiesConfig.get(strategyConfiguration.name());
+        final Object strategyConfig = rawStrategyConfigurations.get(strategyConfiguration.name());
         Map<String, Object> strategyConfigMap = new HashMap<>();
         if (strategyConfig != null) {
             strategyConfigMap = (Map<String, Object>) strategyConfig;

--- a/core/src/main/java/org/arquillian/smart/testing/configuration/ConfigurationLoader.java
+++ b/core/src/main/java/org/arquillian/smart/testing/configuration/ConfigurationLoader.java
@@ -113,7 +113,7 @@ public class ConfigurationLoader {
                 configuration.setRawStrategyConfigurations((Map<String, Object>) strategiesConfiguration);
 
             } else if (strategiesConfiguration instanceof List) {
-                HashMap<String, Object> configMap = new HashMap<>();
+                Map<String, Object> configMap = new HashMap<>();
                 ((List) strategiesConfiguration).stream()
                     .filter(item -> item instanceof Map)
                     .forEach(config -> configMap.putAll((Map) config));

--- a/core/src/main/java/org/arquillian/smart/testing/configuration/ConfigurationLoader.java
+++ b/core/src/main/java/org/arquillian/smart/testing/configuration/ConfigurationLoader.java
@@ -3,8 +3,9 @@ package org.arquillian.smart.testing.configuration;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import org.arquillian.smart.testing.hub.storage.local.LocalStorage;
@@ -108,7 +109,16 @@ public class ConfigurationLoader {
 
         final Configuration configuration = mapToObject(Configuration.class, yamlConfiguration);
         if (strategiesConfiguration != null) {
-            configuration.setStrategiesConfig((Map<String, Object>) strategiesConfiguration);
+            if (strategiesConfiguration instanceof Map) {
+                configuration.setRawStrategyConfigurations((Map<String, Object>) strategiesConfiguration);
+
+            } else if (strategiesConfiguration instanceof List) {
+                HashMap<String, Object> configMap = new HashMap<>();
+                ((List) strategiesConfiguration).stream()
+                    .filter(item -> item instanceof Map)
+                    .forEach(config -> configMap.putAll((Map) config));
+                configuration.setRawStrategyConfigurations(configMap);
+            }
         }
         return configuration;
     }

--- a/core/src/test/java/org/arquillian/smart/testing/configuration/ConfigurationTest.java
+++ b/core/src/test/java/org/arquillian/smart/testing/configuration/ConfigurationTest.java
@@ -142,7 +142,7 @@ public class ConfigurationTest {
         expectedConfiguration.setScm(scm);
         expectedConfiguration.setReport(report);
         expectedConfiguration.setAutocorrect(true);
-        expectedConfiguration.setStrategiesConfig(strategiesConfig);
+        expectedConfiguration.setRawStrategyConfigurations(strategiesConfig);
         expectedConfiguration.setCustomStrategies(
             new String[] {"smart.testing.strategy.cool=org.arquillian.smart.testing:strategy-cool:1.0.0",
                 "smart.testing.strategy.experimental=org.arquillian.smart.testing:strategy-experimental:1.0.0"});

--- a/functional-tests/test-bed/pom.xml
+++ b/functional-tests/test-bed/pom.xml
@@ -71,6 +71,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.arquillian.smart.testing</groupId>
+      <artifactId>strategy-categorized</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/categorized/CategorizedTestSelectionFunctionalTests.java
+++ b/functional-tests/test-bed/src/test/java/org/arquillian/smart/testing/ftest/categorized/CategorizedTestSelectionFunctionalTests.java
@@ -1,11 +1,14 @@
 package org.arquillian.smart.testing.ftest.categorized;
 
 import java.util.Collection;
+import org.arquillian.smart.testing.configuration.Configuration;
+import org.arquillian.smart.testing.ftest.testbed.configuration.builder.ConfigurationBuilder;
 import org.arquillian.smart.testing.ftest.testbed.project.Project;
 import org.arquillian.smart.testing.ftest.testbed.project.TestResults;
 import org.arquillian.smart.testing.ftest.testbed.testresults.TestResult;
 import org.arquillian.smart.testing.rules.TestBed;
 import org.arquillian.smart.testing.rules.git.GitClone;
+import org.arquillian.smart.testing.strategies.categorized.CategorizedConfiguration;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -27,10 +30,21 @@ public class CategorizedTestSelectionFunctionalTests {
     public void should_run_test_with_categories_loader_and_service() throws Exception {
         // given
         final Project project = testBed.getProject();
+        CategorizedConfiguration categorizedConfiguration = new CategorizedConfiguration();
+        categorizedConfiguration.setCategories(new String[] {"LoaderCategory", "serviceCategory"});
+        categorizedConfiguration.setMatchAll(true);
+        Configuration config = new ConfigurationBuilder()
+            .strategies(CATEGORIZED)
+            .strategiesConfiguration()
+            .add(categorizedConfiguration)
+            .build()
+            .build();
+
         project
             .configureSmartTesting()
             .executionOrder(CATEGORIZED)
             .inMode(SELECTING)
+            .withConfiguration(config).createConfigFile()
             .enable();
 
         final Collection<TestResult> expectedTestResults =
@@ -39,10 +53,6 @@ public class CategorizedTestSelectionFunctionalTests {
         // when
         final TestResults actualTestResults =
             project.build("core/impl-base")
-                .options()
-                .withSystemProperties("smart.testing.categorized.categories", "LoaderCategory,serviceCategory",
-                    "smart.testing.categorized.match.all", "true")
-                .configure()
                 .run();
 
         // then


### PR DESCRIPTION
#### Short description of what this resolves:

The variable containing a map of raw strategy configs is dumped into the precalculated config as well to make it available for later loading directly from the strategy implementations.

#### Changes proposed in this pull request:

- Renamed `strategiesConfig` to `rawStrategyConfigurations`
- created getter to add the `rawStrategyConfigurations` variable to the dumped file
- fixed test-bed implementation to allow adding strategy configurations
- changed the logic that loads strategy configurations from the file - added a detection when the strategy config is not a map, but a list - eg. in this case:
```yaml
{autocorrect: false, customProviders: [], customStrategies: [], debug: false, disable: false,
  strategies: [categorized], strategiesConfiguration: [categorized: {
      caseSensitive: false, categories: [LoaderCategory, serviceCategory], matchAll: false,
      methods: false, reversed: false}]}
```


Fixes #318 
