### PR TITLE
fix(#320): scans classes defined as annotations attributes

### DIFF
--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ast/ClassExtractorAnnotationMemberValue.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ast/ClassExtractorAnnotationMemberValue.java
@@ -13,6 +13,7 @@ import javassist.bytecode.annotation.EnumMemberValue;
 import javassist.bytecode.annotation.FloatMemberValue;
 import javassist.bytecode.annotation.IntegerMemberValue;
 import javassist.bytecode.annotation.LongMemberValue;
+import javassist.bytecode.annotation.MemberValue;
 import javassist.bytecode.annotation.MemberValueVisitor;
 import javassist.bytecode.annotation.ShortMemberValue;
 import javassist.bytecode.annotation.StringMemberValue;
@@ -27,8 +28,11 @@ class ClassExtractorAnnotationMemberValue implements MemberValueVisitor {
 
     @Override
     public void visitArrayMemberValue(ArrayMemberValue node) {
-        final String clazz = node.getType().toString();
-        imports.add(clazz.substring(0, clazz.lastIndexOf(".class")));
+        final MemberValue type = node.getType();
+        if (type != null && type.toString().endsWith(".class")) {
+            final String clazz = type.toString();
+            imports.add(extractClass(clazz));
+        }
     }
 
     @Override
@@ -49,7 +53,9 @@ class ClassExtractorAnnotationMemberValue implements MemberValueVisitor {
 
     @Override
     public void visitEnumMemberValue(EnumMemberValue node) {
-        imports.add(node.getType());
+        if (node.getType() != null) {
+            imports.add(node.getType());
+        }
     }
 
     @Override
@@ -76,6 +82,11 @@ class ClassExtractorAnnotationMemberValue implements MemberValueVisitor {
     public void visitClassMemberValue(ClassMemberValue node) {
         imports.add(node.getValue());
     }
+
+    private String extractClass(String clazz) {
+        return clazz.substring(0, clazz.lastIndexOf(".class"));
+    }
+
 
     Collection<String> getImports() {
         return imports;

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ast/ClassExtractorAnnotationMemberValue.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ast/ClassExtractorAnnotationMemberValue.java
@@ -1,0 +1,83 @@
+package org.arquillian.smart.testing.strategies.affected.ast;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import javassist.bytecode.annotation.AnnotationMemberValue;
+import javassist.bytecode.annotation.ArrayMemberValue;
+import javassist.bytecode.annotation.BooleanMemberValue;
+import javassist.bytecode.annotation.ByteMemberValue;
+import javassist.bytecode.annotation.CharMemberValue;
+import javassist.bytecode.annotation.ClassMemberValue;
+import javassist.bytecode.annotation.DoubleMemberValue;
+import javassist.bytecode.annotation.EnumMemberValue;
+import javassist.bytecode.annotation.FloatMemberValue;
+import javassist.bytecode.annotation.IntegerMemberValue;
+import javassist.bytecode.annotation.LongMemberValue;
+import javassist.bytecode.annotation.MemberValueVisitor;
+import javassist.bytecode.annotation.ShortMemberValue;
+import javassist.bytecode.annotation.StringMemberValue;
+
+class ClassExtractorAnnotationMemberValue implements MemberValueVisitor {
+
+    private Collection<String> imports = new ArrayList<>();
+
+    @Override
+    public void visitAnnotationMemberValue(AnnotationMemberValue node) {
+    }
+
+    @Override
+    public void visitArrayMemberValue(ArrayMemberValue node) {
+        final String clazz = node.getType().toString();
+        imports.add(clazz.substring(0, clazz.lastIndexOf(".class")));
+    }
+
+    @Override
+    public void visitBooleanMemberValue(BooleanMemberValue node) {
+    }
+
+    @Override
+    public void visitByteMemberValue(ByteMemberValue node) {
+    }
+
+    @Override
+    public void visitCharMemberValue(CharMemberValue node) {
+    }
+
+    @Override
+    public void visitDoubleMemberValue(DoubleMemberValue node) {
+    }
+
+    @Override
+    public void visitEnumMemberValue(EnumMemberValue node) {
+        imports.add(node.getType());
+    }
+
+    @Override
+    public void visitFloatMemberValue(FloatMemberValue node) {
+    }
+
+    @Override
+    public void visitIntegerMemberValue(IntegerMemberValue node) {
+    }
+
+    @Override
+    public void visitLongMemberValue(LongMemberValue node) {
+    }
+
+    @Override
+    public void visitShortMemberValue(ShortMemberValue node) {
+    }
+
+    @Override
+    public void visitStringMemberValue(StringMemberValue node) {
+    }
+
+    @Override
+    public void visitClassMemberValue(ClassMemberValue node) {
+        imports.add(node.getValue());
+    }
+
+    Collection<String> getImports() {
+        return imports;
+    }
+}

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ast/JavaAssistClass.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ast/JavaAssistClass.java
@@ -163,71 +163,20 @@ public class JavaAssistClass extends AbstractJavaClass {
 
                 final Set<String> memberNames = each.getMemberNames();
 
-                for (String memberName : memberNames) {
-                    addSubtypes(imports, each, memberName);
+                if (memberNames != null) {
+                    for (String memberName : memberNames) {
+                        imports.addAll(addSubtypes(each, memberName));
+                    }
                 }
             }
         }
     }
 
-    private void addSubtypes(Collection<String> imports, Annotation each, String memberName) {
-        each.getMemberValue(memberName).accept(new MemberValueVisitor() {
-            @Override
-            public void visitAnnotationMemberValue(AnnotationMemberValue node) {
-            }
+    private Collection<String> addSubtypes(Annotation each, String memberName) {
+        final ClassExtractorAnnotationMemberValue classExtractorAnnotationMemberValue  = new ClassExtractorAnnotationMemberValue();
+        each.getMemberValue(memberName).accept(classExtractorAnnotationMemberValue);
 
-            @Override
-            public void visitArrayMemberValue(ArrayMemberValue node) {
-                final String clazz = node.getType().toString();
-                imports.add(clazz.substring(0, clazz.lastIndexOf(".class")));
-            }
-
-            @Override
-            public void visitBooleanMemberValue(BooleanMemberValue node) {
-            }
-
-            @Override
-            public void visitByteMemberValue(ByteMemberValue node) {
-            }
-
-            @Override
-            public void visitCharMemberValue(CharMemberValue node) {
-            }
-
-            @Override
-            public void visitDoubleMemberValue(DoubleMemberValue node) {
-            }
-
-            @Override
-            public void visitEnumMemberValue(EnumMemberValue node) {
-                imports.add(node.getType());
-            }
-
-            @Override
-            public void visitFloatMemberValue(FloatMemberValue node) {
-            }
-
-            @Override
-            public void visitIntegerMemberValue(IntegerMemberValue node) {
-            }
-
-            @Override
-            public void visitLongMemberValue(LongMemberValue node) {
-            }
-
-            @Override
-            public void visitShortMemberValue(ShortMemberValue node) {
-            }
-
-            @Override
-            public void visitStringMemberValue(StringMemberValue node) {
-            }
-
-            @Override
-            public void visitClassMemberValue(ClassMemberValue node) {
-                imports.add(node.getValue());
-            }
-        });
+        return classExtractorAnnotationMemberValue.getImports();
     }
 
     private void addDependenciesFromConstantPool(CtClass ctClass, Collection<String> imports) {

--- a/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ast/JavaAssistClass.java
+++ b/strategies/affected/src/main/java/org/arquillian/smart/testing/strategies/affected/ast/JavaAssistClass.java
@@ -43,6 +43,20 @@ import javassist.bytecode.ConstPool;
 import javassist.bytecode.MethodInfo;
 import javassist.bytecode.ParameterAnnotationsAttribute;
 import javassist.bytecode.annotation.Annotation;
+import javassist.bytecode.annotation.AnnotationMemberValue;
+import javassist.bytecode.annotation.ArrayMemberValue;
+import javassist.bytecode.annotation.BooleanMemberValue;
+import javassist.bytecode.annotation.ByteMemberValue;
+import javassist.bytecode.annotation.CharMemberValue;
+import javassist.bytecode.annotation.ClassMemberValue;
+import javassist.bytecode.annotation.DoubleMemberValue;
+import javassist.bytecode.annotation.EnumMemberValue;
+import javassist.bytecode.annotation.FloatMemberValue;
+import javassist.bytecode.annotation.IntegerMemberValue;
+import javassist.bytecode.annotation.LongMemberValue;
+import javassist.bytecode.annotation.MemberValueVisitor;
+import javassist.bytecode.annotation.ShortMemberValue;
+import javassist.bytecode.annotation.StringMemberValue;
 
 import static javassist.bytecode.AnnotationsAttribute.invisibleTag;
 import static javassist.bytecode.AnnotationsAttribute.visibleTag;
@@ -146,8 +160,74 @@ public class JavaAssistClass extends AbstractJavaClass {
         if (annotations != null) {
             for (Annotation each : annotations.getAnnotations()) {
                 imports.add(each.getTypeName());
+
+                final Set<String> memberNames = each.getMemberNames();
+
+                for (String memberName : memberNames) {
+                    addSubtypes(imports, each, memberName);
+                }
             }
         }
+    }
+
+    private void addSubtypes(Collection<String> imports, Annotation each, String memberName) {
+        each.getMemberValue(memberName).accept(new MemberValueVisitor() {
+            @Override
+            public void visitAnnotationMemberValue(AnnotationMemberValue node) {
+            }
+
+            @Override
+            public void visitArrayMemberValue(ArrayMemberValue node) {
+                final String clazz = node.getType().toString();
+                imports.add(clazz.substring(0, clazz.lastIndexOf(".class")));
+            }
+
+            @Override
+            public void visitBooleanMemberValue(BooleanMemberValue node) {
+            }
+
+            @Override
+            public void visitByteMemberValue(ByteMemberValue node) {
+            }
+
+            @Override
+            public void visitCharMemberValue(CharMemberValue node) {
+            }
+
+            @Override
+            public void visitDoubleMemberValue(DoubleMemberValue node) {
+            }
+
+            @Override
+            public void visitEnumMemberValue(EnumMemberValue node) {
+                imports.add(node.getType());
+            }
+
+            @Override
+            public void visitFloatMemberValue(FloatMemberValue node) {
+            }
+
+            @Override
+            public void visitIntegerMemberValue(IntegerMemberValue node) {
+            }
+
+            @Override
+            public void visitLongMemberValue(LongMemberValue node) {
+            }
+
+            @Override
+            public void visitShortMemberValue(ShortMemberValue node) {
+            }
+
+            @Override
+            public void visitStringMemberValue(StringMemberValue node) {
+            }
+
+            @Override
+            public void visitClassMemberValue(ClassMemberValue node) {
+                imports.add(node.getValue());
+            }
+        });
     }
 
     private void addDependenciesFromConstantPool(CtClass ctClass, Collection<String> imports) {

--- a/strategies/affected/src/test/java/org/arquillian/smart/testing/strategies/affected/ast/AnnotationAtClassLevelWithClassValue.java
+++ b/strategies/affected/src/test/java/org/arquillian/smart/testing/strategies/affected/ast/AnnotationAtClassLevelWithClassValue.java
@@ -1,0 +1,6 @@
+package org.arquillian.smart.testing.strategies.affected.ast;
+
+
+@Import(SimpleImportsClass.class)
+public class AnnotationAtClassLevelWithClassValue {
+}

--- a/strategies/affected/src/test/java/org/arquillian/smart/testing/strategies/affected/ast/Import.java
+++ b/strategies/affected/src/test/java/org/arquillian/smart/testing/strategies/affected/ast/Import.java
@@ -1,0 +1,14 @@
+package org.arquillian.smart.testing.strategies.affected.ast;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Import {
+    Class<?>[] value();
+}

--- a/strategies/affected/src/test/java/org/arquillian/smart/testing/strategies/affected/ast/JavaAssistClassParserTest.java
+++ b/strategies/affected/src/test/java/org/arquillian/smart/testing/strategies/affected/ast/JavaAssistClassParserTest.java
@@ -1,5 +1,6 @@
 package org.arquillian.smart.testing.strategies.affected.ast;
 
+import java.util.Arrays;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,6 +37,20 @@ public class JavaAssistClassParserTest {
             .containsExactlyInAnyOrder("java.nio.file.Files",
                 "org.arquillian.smart.testing.strategies.affected.ast.DuplicateClassNameDifferentPackagesAsField",
                 "java.lang.Object", "org.assertj.core.util.Files", "org.arquillian.smart.testing.FilesCodec");
+    }
+
+    @Test
+    public void should_resolve_classes_inside_annotation() {
+        // given
+        final JavaAssistClassParser javaAssistClassParser = new JavaAssistClassParser();
+
+        // when
+        final JavaClass annotationClass =
+            javaAssistClassParser.getClass(AnnotationAtClassLevelWithClassValue.class.getName());
+
+        assertThat(annotationClass.getImports())
+            .containsExactlyInAnyOrder("org.arquillian.smart.testing.strategies.affected.ast.AnnotationAtClassLevelWithClassValue", "java.lang.Object",
+                "org.arquillian.smart.testing.strategies.affected.ast.SimpleImportsClass", "org.arquillian.smart.testing.strategies.affected.ast.Import");
     }
 
     @Test

--- a/strategies/affected/src/test/java/org/arquillian/smart/testing/strategies/affected/ast/JavaAssistClassParserTest.java
+++ b/strategies/affected/src/test/java/org/arquillian/smart/testing/strategies/affected/ast/JavaAssistClassParserTest.java
@@ -1,6 +1,5 @@
 package org.arquillian.smart.testing.strategies.affected.ast;
 
-import java.util.Arrays;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
#### Short description of what this resolves:

Scans annotation attributes as well searching for classes.

#### Changes proposed in this pull request:

- Adds a member visitor to find classes defined in annotation fields

Fixes #320 
