### PR TITLE
fix(#323): updated resolver to 3.1.3 with fixed concurrency issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,6 @@ before_install:
     fi'
 
 before_script:
-  - mkdir -p /home/travis/.arquillian/mvn
-  - wget https://archive.apache.org/dist/maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.tar.gz -P /home/travis/.arquillian/resolver/maven/download
-  - tar -xf /home/travis/.arquillian/resolver/maven/download/apache-maven-3.5.2-bin.tar.gz -C ~/.arquillian/mvn
   # Cleanup PR doc previews - until we figure out how to have a webhook on closing the PR
   - 'if [ "${BRANCH}" == "master" ] && [ $GENERATE_DOC -eq 0 ]; then
         cd gh-pages;
@@ -60,9 +57,6 @@ before_script:
         cd ..;
       fi
   '
-
-env:
-  - TEST_BED_M2_HOME=/home/travis/.arquillian/mvn/apache-maven-3.5.2
 
 script:
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <version.javassist>3.21.0-GA</version.javassist>
     <version.fast-classpath-scanner>2.9.3</version.fast-classpath-scanner>
     <version.jgrapht>1.1.0</version.jgrapht>
-    <version.shrinkwrap.resolver>3.1.2</version.shrinkwrap.resolver>
+    <version.shrinkwrap.resolver>3.1.3</version.shrinkwrap.resolver>
     <version.snakeyaml>1.19</version.snakeyaml>
     <version.mockito>2.13.0</version.mockito>
     <version.jgit>4.9.1.201712030800-r</version.jgit>


### PR DESCRIPTION
#### Short description of what this resolves:

updated resolver to 3.1.3 with fixed concurrency issue and also dropped Maven download before the travis build. 

The fix for the concurrency issue is here https://github.com/shrinkwrap/resolver/commit/acd2df6af132e77b0c1c79dbaedfde9625859726 - it is introducing a marker file also for the downloading operation - to avoid parallel downloads of the same binary. 
The same issue was possible to reproduce using this test https://github.com/shrinkwrap/resolver/commit/acd2df6af132e77b0c1c79dbaedfde9625859726#diff-1f2230d1084bd1cb53853f951adea62e - so it also verifies that it is fixed now. 
Reproduced & verified also locally so it should work now :-)

Fixes #323 
